### PR TITLE
OrderWords loading screen

### DIFF
--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -128,6 +128,7 @@ export default function OrderWords({
   useEffect(() => {
     let orgiinalContext = bookmarksToStudy[0].context;
     resetStatus();
+    setTranslatedText("");
     // Handle the case of long sentences, this relies on activating the functionality. 
     if (orgiinalContext.split(" ").length > 15 && handleLongSentences) {
       api.getArticleInfo(bookmarksToStudy[0].article_id, (articleInfo) => {


### PR DESCRIPTION
Orderwords, needs to reset the translated status once the bookmark changes.

- setTranslatedText to "" when updating the bookmark. This is to avoid showing the exercise while the API is getting a translation.