### PR TITLE
OrderWords adding Placeholder + fixes

### DIFF
--- a/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
+++ b/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
@@ -115,6 +115,10 @@ const ExerciseOW = styled.div`
     :hover{ }
   }
 
+  .placeholder {
+    
+  }
+
   .swapModeBar {
     //background-color: ${darkBlue};
     background-color: #6db9d92b;

--- a/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
+++ b/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
@@ -116,7 +116,8 @@ const ExerciseOW = styled.div`
   }
 
   .placeholder {
-    
+    font-size: x-large;
+    border-radius: 1000px;
   }
 
   .swapModeBar {

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -242,12 +242,22 @@ export default function OrderWords({
       console.log("Selected Choice: " + selectedChoice);
       // Save the previous status.
       setWordSwapStatus(wordSelected.status);
+      let constructorWordWithPlaceholders = []
+      for(let i=0; i < newConstructorWordArray.length; i++){
+        let placeholderId = updatedMasterStatus.length+i
+        constructorWordWithPlaceholders.push({"word":"•", "id":placeholderId, "inUse":true})
+        constructorWordWithPlaceholders.push(newConstructorWordArray[i])
+      }
+      constructorWordWithPlaceholders.push({"word":"•", 
+      "id":updatedMasterStatus.length+constructorWordWithPlaceholders.length,
+      "inUse":true})
 
       wordSelected.status = "toSwap";
-
+      console.log(updatedMasterStatus);
+      console.log(constructorWordWithPlaceholders);
       setWordSwapId(selectedChoice);
       setWordsMasterStatus(updatedMasterStatus);
-      setConstructorWordArray(newConstructorWordArray);
+      setConstructorWordArray(constructorWordWithPlaceholders);
       return;
     }
 
@@ -278,7 +288,10 @@ export default function OrderWords({
           newConstructorWordArray[i] = wordInSwapStatus;
         }
       }
-
+      console.log(newConstructorWordArray);
+      newConstructorWordArray = newConstructorWordArray.filter((wordElement) => 
+      wordElement.id < updatedMasterStatus.length);
+      console.log(newConstructorWordArray);
       // wordsMasterStatus index match the id in words.
       updatedMasterStatus[wordSwapId] = wordInSwapStatus;
 

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -212,26 +212,25 @@ export default function OrderWords({
 
   function notifyChoiceSelection(selectedChoice, inUse) {
     undoResetStatus();
-    if (isCorrect) return // Avoid swapping Words when it is correct.
+    if (isCorrect) { return } // Avoid swapping Words when it is correct.
     // Create objects to update.
-    let updatedMasterStatus = [...wordsMasterStatus]
-    let newConstructorWordArray = [...constructorWordArray]
+    let updatedMasterStatus = [...wordsMasterStatus];
+    let newConstructorWordArray = [...constructorWordArray];
 
-    let wordSelected = getWordById(selectedChoice, updatedMasterStatus)
+    let wordSelected = getWordById(selectedChoice, updatedMasterStatus);
 
     // Handle Case where Word is in ConstructorBox & No word is selected.
     if (inUse && (wordSwapId === -1)) {
       // Select the Word for Swapping. 
       // Set the Color to Blue
-      setWordSwapId(selectedChoice)
-      console.log(selectedChoice);
-      console.log("Selected: " + wordSwapId);
+      console.log("Word Swap Id: " + wordSwapId);
+      console.log("Selected Choice: " + selectedChoice);
+      // Save the previous status.
       setWordSwapStatus(wordSelected.status);
-      let wordInOrder = getWordById(wordSwapId, newConstructorWordArray)
 
-      wordSelected.status = "toSwap"
-      wordInOrder.status = "toSwap"
+      wordSelected.status = "toSwap";
 
+      setWordSwapId(selectedChoice);
       setWordsMasterStatus(updatedMasterStatus);
       setConstructorWordArray(newConstructorWordArray);
       return;
@@ -240,6 +239,8 @@ export default function OrderWords({
     // Handle the case where we swap a selected word.
     if (wordSwapId !== -1 && selectedChoice !== wordSwapId) {
       console.log("Swapping words!")
+      console.log("Word Swap Id: " + wordSwapId);
+      console.log("Selected Choice: " + selectedChoice);
       // Update the Word to have the previous status
       let wordInSwapStatus = getWordById(wordSwapId, newConstructorWordArray)
       wordInSwapStatus = { ...wordInSwapStatus }
@@ -256,15 +257,15 @@ export default function OrderWords({
       for (let i = 0; i < newConstructorWordArray.length; i++) {
         if (newConstructorWordArray[i].id === wordSwapId) {
           if (!wordSelected.inUse) { wordSelected.inUse = true }
-          newConstructorWordArray[i] = wordSelected
+          newConstructorWordArray[i] = wordSelected;
         }
         else if (newConstructorWordArray[i].id === selectedChoice) {
-          newConstructorWordArray[i] = wordInSwapStatus
+          newConstructorWordArray[i] = wordInSwapStatus;
         }
       }
 
       // wordsMasterStatus index match the id in words.
-      updatedMasterStatus[wordSwapId] = wordInSwapStatus
+      updatedMasterStatus[wordSwapId] = wordInSwapStatus;
 
       // Update all the statuses.
       setWordsMasterStatus(updatedMasterStatus);
@@ -275,21 +276,22 @@ export default function OrderWords({
 
     // Add the Word to the Constructor
     if (!wordSelected.inUse) {
-      newConstructorWordArray.push(wordSelected)
+      newConstructorWordArray.push(wordSelected);
     }
     else {
-      newConstructorWordArray = newConstructorWordArray.filter((wordElement) => wordElement.id !== wordSelected.id)
+      newConstructorWordArray = newConstructorWordArray.filter((wordElement) => 
+        wordElement.id !== wordSelected.id);
     }
-    wordSelected.inUse = !wordSelected.inUse
+    wordSelected.inUse = !wordSelected.inUse;
+    
     // If there was a selected word, we return it to the previous state.
-    console.log("COMPARING STATUS: " + wordSelected.status)
     if (wordSelected.status === "toSwap") {
       wordSelected.status = wordSwapStatus;
       setWordSwapStatus("");
     }
-    console.log("AFTER COMPARING STATUS: " + wordSelected.status)
-    setWordSwapId(-1)
-    setWordsMasterStatus(updatedMasterStatus)
+
+    setWordSwapId(-1);
+    setWordsMasterStatus(updatedMasterStatus);
     setConstructorWordArray(newConstructorWordArray);
   }
 
@@ -377,7 +379,7 @@ export default function OrderWords({
     // Aligns all the status to be the same.
     let updatedWords = [...wordsMasterStatus];
     let inUseIds = [...constructorWordArray].map(word => word.id);
-    console.log(inUseIds)
+    console.log(inUseIds);
     for (let i = 0; i < updatedWords.length; i++) {
       if (inUseIds.includes(updatedWords[i].id)) {
         updatedWords[i].status = status;
@@ -439,7 +441,7 @@ export default function OrderWords({
     setConstructorWordArray(updatedWordStatus);
     setWordsMasterStatus(newWordMasterStatus);
     setTotalErrorCounter(updatedErrorCounter);
-    updateClueText(cluesTextList, errorCount)
+    updateClueText(cluesTextList, errorCount);
     logUserActivityCheck(constructedSentence,
       resizeSol, errorCount, cluesTextList, errorTypesList, updatedErrorCounter);
     
@@ -506,9 +508,9 @@ export default function OrderWords({
 
       // We need to ensure that we don't send the entire sentence,
       // or alignment might align very distant words.
-      let resizeSol = "" + filterPunctuationSolText
-      resizeSol = resizeSol.split(" ")
-      resizeSol = resizeSol.slice(0, constructorWordArray.length + 1).join(" ")
+      let resizeSol = "" + filterPunctuationSolText;
+      resizeSol = resizeSol.split(" ");
+      resizeSol = resizeSol.slice(0, constructorWordArray.length + 1).join(" ");
       api.annotateClues(constructorWordArray, resizeSol, exerciseLang, (updatedConstructedWords) => {
         updateWordsFromAPI(updatedConstructedWords, resizeSol, constructedSentence);
       }

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -458,9 +458,9 @@ export default function OrderWords({
     setConstructorWordArray(updatedWordStatus);
     setWordsMasterStatus(newWordMasterStatus);
     setTotalErrorCounter(updatedErrorCounter);
-    updateClueText(cluesTextList, errorCount);
+    let finalClueText = updateClueText(cluesTextList, errorCount);
     logUserActivityCheck(constructedSentence,
-      resizeSol, errorCount, cluesTextList, errorTypesList, updatedErrorCounter);
+      resizeSol, errorCount, finalClueText, errorTypesList, updatedErrorCounter);
     
   }
   function updateClueText(cluesTextList, errorCount) {

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -24,7 +24,7 @@ export default function OrderWords({
   reload,
   setReload,
 }) {
-  const [initialTime] = useState(new Date());
+  const [initialTime, setInitialTime] = useState(new Date());
   //const [buttonOptions, setButtonOptions] = useState(null);
   const [resetCounter, setResetCounter] = useState(0);
   const [hintCounter, setHintCounter] = useState(0);
@@ -49,7 +49,8 @@ export default function OrderWords({
 
   console.log("Running ORDER WORDS EXERCISE")
 
-  function resetReactStates(){
+  function resetReactStates() {
+    setInitialTime(new Date());
     setResetCounter(0);
     setHintCounter(0);
     setTotalErrorCounter(0);
@@ -69,7 +70,7 @@ export default function OrderWords({
     setSentenceWasTooLong(false);
   }
 
-  function removeEmptyTokens(tokenList){
+  function removeEmptyTokens(tokenList) {
     // In some instance, there will be punctuation in the middle, which
     // results in trailing spaces. The loop below ensures those get removed.
     return tokenList.filter((token) => token !== "")
@@ -133,8 +134,6 @@ export default function OrderWords({
       )
     });
   }
-
-
 
   function prepareExercise(contextToUse) {
     console.log("CONTEXT: '" + contextToUse + "'");

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -97,6 +97,17 @@ export default function OrderWords({
     return arrayWords
   }
 
+  function orderWordsLogUserActivity(eventType, jsonData){
+    console.log("LOG EVENT, type: " + eventType);
+    console.log(jsonData);
+    api.logUserActivity(
+      eventType,
+      "",
+      bookmarksToStudy[0].id,
+      JSON.stringify(jsonData)
+    );
+  }
+
   function createConfusionWords(contextToUse, translatedContext, sentenceTooLong) {
     const initialWords = getWordsInArticle(contextToUse);
     setSolutionWords(setWordAttributes([...initialWords]));
@@ -115,7 +126,7 @@ export default function OrderWords({
       setConfuseWords(apiConfuseWords);
       setPosSelected(jsonCWords["pos_picked"]);
       setWordForConfuson(jsonCWords["word_used"]);
-      let confExerciseStart = {
+      let jsonDataExerciseStart = {
         "sentence_was_too_long": sentenceTooLong,
         "translation": translatedContext,
         "context": contextToUse,
@@ -126,13 +137,7 @@ export default function OrderWords({
         "bookmark": bookmarksToStudy[0].from,
         "exercise_start": initialTime,
       }
-      console.log(confExerciseStart)
-      api.logUserActivity(
-        "WO_START",
-        "",
-        bookmarksToStudy[0].id,
-        JSON.stringify(confExerciseStart)
-      )
+      orderWordsLogUserActivity("WO_START", jsonDataExerciseStart);
     });
   }
 
@@ -323,7 +328,7 @@ export default function OrderWords({
       bookmarksToStudy[0].id
     );
 
-    let confExerciseEnd = {
+    let jsonDataExerciseEnd = {
       "sentence_was_too_long": sentenceWasTooLong,
       "outcome": message,
       "total_time": duration,
@@ -338,15 +343,7 @@ export default function OrderWords({
       "word_for_confusion": wordForConfusion,
       "exercise_start": initialTime,
     };
-
-
-    console.log(confExerciseEnd);
-    api.logUserActivity(
-      "WO_END",
-      "",
-      bookmarksToStudy[0].id,
-      JSON.stringify(confExerciseEnd)
-    );
+    orderWordsLogUserActivity("WO_END", jsonDataExerciseEnd);
   }
 
   function resetStatus() {
@@ -445,6 +442,7 @@ export default function OrderWords({
     updateClueText(cluesTextList, errorCount)
     logUserActivityCheck(constructedSentence,
       resizeSol, errorCount, cluesTextList, errorTypesList, updatedErrorCounter);
+    
   }
   function updateClueText(cluesTextList, errorCount) {
     console.log(cluesTextList);
@@ -463,7 +461,7 @@ export default function OrderWords({
 
   function logUserActivityCheck(constructedSentence,
     resizeSol, errorCount, finalClueText, errorTypesList, updatedErrorCounter) {
-    let activityLog = {
+    let jsonDataExerciseCheck = {
       "constructed_sent": constructedSentence,
       "solution_sent": resizeSol,
       "n_errors": errorCount,
@@ -472,13 +470,7 @@ export default function OrderWords({
       "total_errors": updatedErrorCounter,
       "exercise_start": initialTime
     };
-    console.log(activityLog);
-    api.logUserActivity(
-      "WO_CHECK",
-      "",
-      bookmarksToStudy[0].id,
-      JSON.stringify(activityLog)
-    );
+    orderWordsLogUserActivity("WO_CHECK", jsonDataExerciseCheck);
   }
 
   function handleCheck() {
@@ -577,8 +569,14 @@ export default function OrderWords({
 
       {!isCorrect && (
         <sOW.ItemRowCompactWrap className="ItemRowCompactWrap">
-          <button onClick={handleReset} className={constructorWordArray.length > 0 ? "owButton undo" : "owButton disable"}>↻ {strings.reset}</button>
-          <button onClick={handleCheck} className={constructorWordArray.length > 0 ? "owButton check" : "owButton disable"}>{solutionWords.length === constructorWordArray.length ? strings.check : strings.hint} ✔</button>
+          <button onClick={handleReset} 
+            className={constructorWordArray.length > 0 ? "owButton undo" : "owButton disable"}>
+              ↻ {strings.reset}
+          </button>
+          <button onClick={handleCheck} 
+          className={constructorWordArray.length > 0 ? "owButton check" : "owButton disable"}>
+            {solutionWords.length === constructorWordArray.length ? strings.check : strings.hint} ✔
+          </button>
         </sOW.ItemRowCompactWrap>
       )}
       {(wordSwapId !== -1) && (!resetConfirmDiv) && (

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -69,8 +69,15 @@ export default function OrderWords({
     setSentenceWasTooLong(false);
   }
 
+  function removeEmptyTokens(tokenList){
+    // In some instance, there will be punctuation in the middle, which
+    // results in trailing spaces. The loop below ensures those get removed.
+    return tokenList.filter((token) => token !== "")
+  }
+
   function getWordsInArticle(sentence) {
-    return removePunctuation(sentence).split(" ")
+    let wordsForExercise = removePunctuation(sentence).split(" ")
+    return removeEmptyTokens(wordsForExercise)
   }
 
   function setWordAttributes(word_list) {

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -334,7 +334,7 @@ let strings = new LocalizedStrings(
       chooseTheWordFittingContextHeadline:
         "Choose the alternative that fits the context",
       orderTheWordsToMakeTheFollowingSentence:
-        "Order the words to make the following sentence",
+        "Order the words to make the following sentence. You don't need to use all the words.",
       matchWordWithTranslation: "Match each word with its translation",
       audioExerciseHeadline:
         "Write the word your hear. Click to have it repeated!",
@@ -385,6 +385,7 @@ let strings = new LocalizedStrings(
       improveTranslation: "Improve Translation",
       corfirmReset: "Are you sure? This will reset all words.",
       swapInfo: "Click a word to swap, or click again to remove.",
+      swapInfoPlaceholderToken: "This is a placeholder, click a word to swap.",
 
       //ButtonFeedback
       speak: "Speak",


### PR DESCRIPTION
- FIxed empty tokens by doing a pass to remove any empty strings in the array.
- Added the **placeholder token**. This is when there is a feedback of a missing word. The token can be interacted with to swap with any other token. It can't be removed like the word tokens, and instead needs to be swapped or disappears when the user adds a new word.
- With the above change, a property was added "hasPlaceholders" to avoid adding placeholder tokens when they are already present. The placeholder tokens will take negative ids below starting from -2, -3 ..., as -1 is reserved for no word selected.
- The Exercise time wasn't correctly updated in between updates.
- Added the "isInSentence" property which is true whenever a token is in the original sentence. This helps guide the user's feedback from the API. 
- The user_activity_log is now handled by a method. 
- Updated the top message to tell users they don't need to use all the words. 
- Variable name updates to make them match the zeeguu naming conventions. 
- Hint/Check button now says Check if the sentence has reached the length or above. 