### PR TITLE
Changes to support Shorter Contexts in OrderWords Exercise

### DIFF
--- a/src/api/exercises.js
+++ b/src/api/exercises.js
@@ -74,14 +74,3 @@ Zeeguu_API.prototype.getWOsentences = function (articleText, contextBookmark, la
   }
   return this._post(`/get_sentences_for_wo`, qs.stringify(payload), callback)
 };
-
-Zeeguu_API.prototype.getSmallerContext = function (contextBookmark, wordBookmark, lang, contextLen, callback) {
-  
-  let payload = {
-    bookmark_context: contextBookmark,
-    bookmark_word: wordBookmark, 
-    language: lang,
-    max_context_len: contextLen
-  }
-  return this._post(`/get_smaller_context`, qs.stringify(payload), callback)
-};

--- a/src/api/exercises.js
+++ b/src/api/exercises.js
@@ -65,14 +65,14 @@ Zeeguu_API.prototype.annotateClues = function (word_props, og_sent, lang, callba
   return this._post(`/annotate_clues`, qs.stringify(payload), callback)
 };
 
-Zeeguu_API.prototype.getWOsentences = function (articleText, contextBookmark, lang, callback) {
+Zeeguu_API.prototype.getShorterSimilarSentsInArticle = function (articleText, contextBookmark, lang, callback) {
   
   let payload = {
     article_text: articleText,
     bookmark_context: contextBookmark,
     language: lang
   }
-  return this._post(`/get_sentences_for_wo`, qs.stringify(payload), callback)
+  return this._post(`/get_shorter_similar_sents_in_article`, qs.stringify(payload), callback)
 };
 
 Zeeguu_API.prototype.getSmallerContext = function (contextBookmark, wordBookmark, lang, contextLen, callback) {

--- a/src/api/exercises.js
+++ b/src/api/exercises.js
@@ -74,3 +74,14 @@ Zeeguu_API.prototype.getWOsentences = function (articleText, contextBookmark, la
   }
   return this._post(`/get_sentences_for_wo`, qs.stringify(payload), callback)
 };
+
+Zeeguu_API.prototype.getSmallerContext = function (contextBookmark, wordBookmark, lang, contextLen, callback) {
+  
+  let payload = {
+    bookmark_context: contextBookmark,
+    bookmark_word: wordBookmark, 
+    language: lang,
+    max_context_len: contextLen
+  }
+  return this._post(`/get_smaller_context`, qs.stringify(payload), callback)
+};

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -39,7 +39,7 @@ export default function ArticleOverview({
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
     } else {
-      return open_in_zeeguu;
+      return open_externally;
     }
   }
 

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -39,7 +39,7 @@ export default function ArticleOverview({
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
     } else {
-      return open_externally;
+      return open_in_zeeguu;
     }
   }
 

--- a/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
+++ b/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
@@ -83,8 +83,12 @@ const ExerciseOW = styled.div`
   .cluesRow {
     text-align: center;
     display: inline-block;
-    margin-left: 0em;
-    margin-top: -25px;
+    margin-top: -10px;
+    margin-bottom: -5px;
+    border-style: solid;
+    border-width: 2px 0px 0px 0px;
+    border-radius: 10px;
+    border-color: #e5e5e5;
     
     h4 {
       margin-top: 0px;
@@ -180,7 +184,9 @@ const ExerciseOW = styled.div`
     align-items: center;
     justify-content: space-around;
     margin-top: 1em;
-    margin-bottom: -2.5em;
+    margin-left: 1em;
+    margin-right: 1em;
+    margin-bottom: -3em;
 
     @media (max-width: 430px) {
       flex-flow: row wrap;

--- a/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
+++ b/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
@@ -20,13 +20,6 @@ const ExerciseOW = styled.div`
     font-weight: 500;
   }
 
-  .translatedText {
-    font-size: medium;
-    margin-left:8px;
-    margin-right:8px;
-
-  }
-
   .headlineWithMoreSpace {
     font-size: small;
     color: gray;
@@ -34,11 +27,6 @@ const ExerciseOW = styled.div`
     margin-bottom: 2em;
     
     /* font-weight: 600; */
-  }
-
-  .reduceContext {
-    font-size: 10px;
-    width: 80%;
   }
 
   .bottomInput {
@@ -174,18 +162,6 @@ const ExerciseOW = styled.div`
       background-color: ${zeeguuRed};
 
   }
-  .OWBottomRow{
-    display:block
-    padding: 0.5em;
-    align-items: center;
-    justify-content: space-around;
-    margin-top: 1em;
-    margin-bottom: -2.5em;
-
-    @media (max-width: 430px) {
-      flex-flow: row wrap;
-    }
-  } 
 
   .owButton{
     

--- a/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
+++ b/src/exercises/exerciseTypes/orderWords/ExerciseTypeOW.sc.js
@@ -20,6 +20,13 @@ const ExerciseOW = styled.div`
     font-weight: 500;
   }
 
+  .translatedText {
+    font-size: medium;
+    margin-left:8px;
+    margin-right:8px;
+
+  }
+
   .headlineWithMoreSpace {
     font-size: small;
     color: gray;
@@ -27,6 +34,11 @@ const ExerciseOW = styled.div`
     margin-bottom: 2em;
     
     /* font-weight: 600; */
+  }
+
+  .reduceContext {
+    font-size: 10px;
+    width: 80%;
   }
 
   .bottomInput {
@@ -162,6 +174,18 @@ const ExerciseOW = styled.div`
       background-color: ${zeeguuRed};
 
   }
+  .OWBottomRow{
+    display:block
+    padding: 0.5em;
+    align-items: center;
+    justify-content: space-around;
+    margin-top: 1em;
+    margin-bottom: -2.5em;
+
+    @media (max-width: 430px) {
+      flex-flow: row wrap;
+    }
+  } 
 
   .owButton{
     

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -80,6 +80,14 @@ export default function OrderWords({
     return removeEmptyTokens(wordsForExercise)
   }
 
+  function getWordsFromWordProps(wordPropList){
+    let wordList = []
+    for(let i = 0; i < wordPropList.length; i++){
+      wordList.push(wordPropList[i]["word"])
+    }
+    return wordList
+  }
+
   function setWordAttributes(wordList, sentenceWords) {
     // Create an Word Object, that contains the 
     // id, word, status (Correct, Incorrect, Feedback), inUse (true/false)
@@ -552,18 +560,13 @@ export default function OrderWords({
     if (constructorWordArray.length === 0) { return; };
 
     // Check if the solution is already the same
-    let filterPunctuationSolText = removePunctuation(exerciseContext);
+    let filterPunctuationSolText = getWordsFromWordProps(solutionWords).join(" ");
     let newConstructedSentence = filterPlaceholders([...constructorWordArray]);
     console.log("Filtering...")
-    console.log(newConstructedSentence);
-
-    let constructedSentence = []
-    for (let i = 0; i < newConstructedSentence.length; i++) {
-      constructedSentence.push(newConstructedSentence[i].word);
-    }
-
-    // Get the Sentence
-    constructedSentence = constructedSentence.join(" ")
+    console.log(newConstructedSentence)
+    
+    // Get the Constructed Sentence
+    let constructedSentence = getWordsFromWordProps(newConstructedSentence).join(" ");
 
     if (constructedSentence === filterPunctuationSolText) {
       setHasClues(false);

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -286,10 +286,14 @@ export default function OrderWords({
 
   function prepareExercise(exerciseContext, isSentenceTooLong, isHandlingLongSentences, startTime) {
     console.log("CONTEXT: '" + exerciseContext + "'");
-    exerciseContext = exerciseContext.trim()
+    exerciseContext = exerciseContext.trim();
     console.log("CONTEXT AFTER TRIM: '" + exerciseContext + "'");
-    setExerciseContext(exerciseContext);
     console.log("Getting Translation for ->" + exerciseContext);
+    
+    setExerciseContext(exerciseContext);
+    
+    let originalContext = bookmarksToStudy[0].context.trim();
+
     api
       .basicTranlsate(
         exerciseLang,
@@ -298,17 +302,14 @@ export default function OrderWords({
       )
       .then((response) => response.json())
       .then((data) => {
-        console.log(data);
         let translatedContext = data["translation"];
-        console.log(translatedContext)
-        console.log("Before IF: " + translatedContext);
-        if (!translatedContext) { translatedContext = exerciseContext; }
-        if (exerciseContext.length < bookmarksToStudy[0].context.trim().length){
-          console.log("Inside IF");
-          let startPos = bookmarksToStudy[0].context.search(exerciseContext);
-          let contextLen = bookmarksToStudy[0].context.length
-          setTextBeforeTranslatedText(bookmarksToStudy[0].context.slice(0,startPos))
-          setTextAfterTranslatedText(bookmarksToStudy[0].context.slice(startPos+exerciseContext.length,contextLen))
+        // Line below is used for development with no API key (translatedContext is Null)
+        // if (!translatedContext) { translatedContext = exerciseContext; }
+        if (exerciseContext.length < originalContext.length){
+          let startPos = originalContext.search(exerciseContext);
+          let contextLen = originalContext.length;
+          setTextBeforeTranslatedText(originalContext.slice(0,startPos));
+          setTextAfterTranslatedText(originalContext.slice(startPos+exerciseContext.length,contextLen));
           translatedContext = exerciseContext;
         }        
         setTranslatedText(translatedContext);
@@ -525,7 +526,7 @@ export default function OrderWords({
   function handleResetClick() {
     // Don't allow the user to click rest if no words
     // are in the userSolutionArray
-    if (userSolutionWordArray.length == 0) { return }
+    if (userSolutionWordArray.length === 0) { return }
     setIsResetConfirmVisible(true);
   }
 
@@ -694,7 +695,7 @@ export default function OrderWords({
     <sOW.ExerciseOW className="orderWords">
       {translatedText === "" && !isCorrect && <LoadingAnimation />}
       <div className="headlineOrderWords">
-        {strings.orderTheWordsToMakeTheFollowingSentence}
+        {strings.orderTheWordsToMakeTheHighlightedPhrase}
         <p className="translatedText">{textBeforeTranslatedText}<b>{translatedText}</b>{textAfterTranslatedText}</p>
       </div>
       {isCluesRowVisible && (

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -44,7 +44,9 @@ export default function OrderWords({
   const [solutionWords, setSolutionWords] = useState([]);
   const [resetConfirmDiv, setResetConfirmDiv] = useState(false);
   const [sentenceWasTooLong, setSentenceWasTooLong] = useState(false);
-  const handleLongSentences = false;
+  const [beforeTranslatedText, setBeforeTranslatedText] = useState("");
+  const [afterTranslatedText, setAfterTranslatedText] = useState("");
+  const [handleLongSentences, setHandleLongSentences] = useState(false);
 
   console.log("Running ORDER WORDS EXERCISE")
 
@@ -67,6 +69,8 @@ export default function OrderWords({
     setSolutionWords([]);
     setResetConfirmDiv(false);
     setSentenceWasTooLong(false);
+    setBeforeTranslatedText("");
+    setAfterTranslatedText("");
   }
 
   function removeEmptyTokens(tokenList) {
@@ -122,8 +126,9 @@ export default function OrderWords({
   function createConfusionWords(
     contextToUse, 
     translatedContext, 
-    sentenceTooLong, 
-    startTime) 
+    sentenceTooLong,
+    toggleSmallerContext, 
+    exerciseInitialTime) 
   {
     const initialWords = getWordsInArticle(contextToUse);
     setSolutionWords(setWordAttributes([...initialWords], initialWords));
@@ -144,6 +149,7 @@ export default function OrderWords({
       setWordForConfuson(jsonCWords["word_used"]);
       let jsonDataExerciseStart = {
         "sentence_was_too_long": sentenceTooLong,
+        "smaller_context_toggle": toggleSmallerContext,
         "translation": translatedContext,
         "context": contextToUse,
         "confusionWords": apiConfuseWords,
@@ -151,13 +157,13 @@ export default function OrderWords({
         "word_for_confusion": jsonCWords["word_used"],
         "total_words": exerciseWords.length,
         "bookmark": bookmarksToStudy[0].from,
-        "exercise_start": startTime,
+        "exercise_start": exerciseInitialTime,
       }
       orderWordsLogUserActivity("WO_START", jsonDataExerciseStart);
     });
   }
 
-  function prepareExercise(contextToUse, sentenceTooLong, startTime) {
+  function prepareExercise(contextToUse, sentenceTooLong, toggleSmallerContext, startTime ) {
     console.log("CONTEXT: '" + contextToUse + "'");
     contextToUse = contextToUse.trim()
     console.log("CONTEXT AFTER TRIM: '" + contextToUse + "'");
@@ -173,8 +179,20 @@ export default function OrderWords({
       .then((data) => {
         console.log(data);
         let translatedContext = data["translation"];
+        console.log(translatedContext)
+        console.log("Before IF: " + translatedContext);
+        if (!translatedContext) { translatedContext = contextToUse; }
+        if (contextToUse.length < bookmarksToStudy[0].context.trim().length){
+          console.log("Inside IF");
+          let startPos = bookmarksToStudy[0].context.search(contextToUse);
+          let contextLen = bookmarksToStudy[0].context.length
+          setBeforeTranslatedText(bookmarksToStudy[0].context.slice(0,startPos))
+          setAfterTranslatedText(bookmarksToStudy[0].context.slice(startPos+contextToUse.length,contextLen))
+          translatedContext = contextToUse;
+        }        
         setTranslatedText(translatedContext);
-        createConfusionWords(contextToUse, translatedContext, sentenceTooLong, startTime);
+        createConfusionWords(contextToUse, translatedContext, 
+          sentenceTooLong, toggleSmallerContext, startTime);
 
       })
       .catch(() => {
@@ -201,23 +219,33 @@ export default function OrderWords({
       sentenceTooLong = true
     }
     resetReactStates();
+    console.log("Handling long sentences: " + handleLongSentences);
     // Handle the case of long sentences, this relies on activating the functionality. 
-    if (sentenceTooLong > 15 && handleLongSentences) {
+    if (handleLongSentences) {
+      api.getSmallerContext(originalContext, bookmarksToStudy[0].from,
+        exerciseLang, 15, (apiCandidateSubSent) => {
+          let parsedCandidatesent = JSON.parse(apiCandidateSubSent)
+          console.log("SENTENCES THAT ARE GOOD FOR WO")
+          console.log(parsedCandidatesent);
+          prepareExercise(parsedCandidatesent, sentenceWasTooLong, handleLongSentences, newExerciseStartTime);
+        });
+      /*
       api.getArticleInfo(bookmarksToStudy[0].article_id, (articleInfo) => {
         console.log(articleInfo);
         api.getWOsentences(articleInfo["content"], originalContext,
           exerciseLang, (candidateSents) => {
             console.log("SENTENCES THAT ARE GOOD FOR WO")
             console.log(candidateSents);
-            let candidatesSent = JSON.parse(candidateSents)[0][1]
+            let candidatesSent = JSON.parse(candidateSents)
             console.log(candidatesSent);
             prepareExercise(candidatesSent, sentenceTooLong, newExerciseStartTime);
           });
       });
+      */
     }
     else {
       console.log("Using default context.");
-      prepareExercise(bookmarksToStudy[0].context, sentenceTooLong, newExerciseStartTime);
+      prepareExercise(bookmarksToStudy[0].context, sentenceTooLong, handleLongSentences, newExerciseStartTime);
     }
     // Ensure the exercise time is set to the same that was used 
     // to prepare the exercise, as well as the sentenceTooLong.
@@ -594,6 +622,28 @@ export default function OrderWords({
       );
     }
   }
+  function handleReduceContext(){
+    let newHandleLongSentences = !handleLongSentences;
+    let newExerciseStartTime = new Date();
+    let originalContext = bookmarksToStudy[0].context;
+    resetReactStates();
+    console.log(newHandleLongSentences);
+    // Handle the case of long sentences, this relies on activating the functionality. 
+    if (newHandleLongSentences) {
+        api.getSmallerContext(originalContext, bookmarksToStudy[0].from,
+          exerciseLang, 15, (apiCandidateSubSent) => {
+            let parsedCandidatesent = JSON.parse(apiCandidateSubSent)
+            console.log("SENTENCES THAT ARE GOOD FOR WO")
+            console.log(parsedCandidatesent);
+            prepareExercise(parsedCandidatesent, sentenceWasTooLong, newHandleLongSentences, newExerciseStartTime);
+          });
+    }
+    else {
+      console.log("Using default context.");
+      prepareExercise(bookmarksToStudy[0].context, sentenceWasTooLong, newHandleLongSentences, newExerciseStartTime);
+    }
+    setHandleLongSentences(newHandleLongSentences);
+  }
 
   // Handle the Loading screen while getting the test.
   if ((wordsMasterStatus.length === 0 | translatedText === "") && !isCorrect) {
@@ -606,7 +656,7 @@ export default function OrderWords({
       {translatedText === "" && !isCorrect && <LoadingAnimation />}
       <div className="headlineOrderWords">
         {strings.orderTheWordsToMakeTheFollowingSentence}
-        <h2>{translatedText}</h2>
+        <p className="translatedText">{beforeTranslatedText}<b>{translatedText}</b>{afterTranslatedText}</p>
       </div>
       {hasClues && (
         <sOW.ItemRowCompactWrap className="cluesRow">
@@ -629,9 +679,11 @@ export default function OrderWords({
         </div>
       )}
 
-      {isCorrect && <div>
+      {isCorrect && 
+      <div className="OWBottomRow">
         <h4>{strings.orderWordsCorrectMessage}</h4>
-        <p>{exerciseContext}</p>
+        <p>{bookmarksToStudy[0].context}</p>
+        <p>Word you bookmarked: <b>'{bookmarksToStudy[0].from}'</b></p>
       </div>}
       {wordsMasterStatus.length === 0 && !isCorrect && <LoadingAnimation />}
       {!isCorrect && (
@@ -690,6 +742,12 @@ export default function OrderWords({
         isCorrect={isCorrect}
       />
       {!isCorrect && (<p className="tipText">{strings.orderWordsTipMessage}</p>)}
+      {!isCorrect && (
+        <sOW.ItemRowCompactWrap className="ItemRowCompactWrap">
+          <button onClick={handleReduceContext} className={handleLongSentences ? "owButton reduceContext correct" : "owButton reduceContext disable"}>Toggle Short Context</button>
+        </sOW.ItemRowCompactWrap>  
+      )
+      }
     </sOW.ExerciseOW>
   );
 }

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -333,8 +333,8 @@ let strings = new LocalizedStrings(
         "Find the expression in the context below",
       chooseTheWordFittingContextHeadline:
         "Choose the alternative that fits the context",
-      orderTheWordsToMakeTheFollowingSentence:
-        "Order the words to make the following sentence. You don't need to use all the words.",
+      orderTheWordsToMakeTheHighlightedPhrase:
+        "Order the words to make the highlighted phrase. You don't need to use all the words.",
       matchWordWithTranslation: "Match each word with its translation",
       audioExerciseHeadline:
         "Write the word your hear. Click to have it repeated!",


### PR DESCRIPTION
## CSS changes
- This includes all changes from the refactoring session.
- I made the Clues text slightly closer to the construction box and added a small separator line between the sentence and the box for more clarity.
- Added a new class to style the translated text, the formatting is now the same as before, but only for exercise_context, while the rest will be a non-bold face.
## api/exercise.js
- updated the **getWOsentences** -> **getShorterSimilarSentsInArticle** to reflect changes in the API and make the function of the method more clear.
## definitions.js
- updated the instructions to the exercise to make it more clear that it can be a partial sentence.
## OrderExercise
- All changes from the refactoring session are included in this PR.
- Instead of using -1 as the "NO_WORD_SELECTED_ID" (which is now **-100**), I instead define a constant that defines the value used. This is to allow the change where all placeholders are negative IDs, which makes it easier to filter them out. All words will have ids from 0 onwards.
- Renamed variables for more clarity.
- Added a MAX_CONTEXT_LENGTH that is used to determine the maximum length for the exercise. This doesn't mean all exercises will have 15 words, but that the number of words can go up to that amount.
- Added a variable to allow toggling the Swap button, for testing and future inclusion if needed.
- Introduced a method to get the exercise start variables, this was to make it easier when handling the Reduce Context button logic.
- To implement the change of shorter context, the logic has been moved to its own function prepareContext. This means that the exercise now follows the sequence prepareContext -> prepareExercise -> createConfusionWords.
- To distinguish the different contexts, we now have the original "bookmark_context" and the "exercise_context" which can be shorter than the original.
- The Short Context button now only appears if Constant is set to true. By default, the isHandlingLongSentences is ON and the user cannot disable it.
- An example is shown below. The parts of the text which are not translated are left in the original language. If the translation was done, an alignment model would have to be used to select which tokens should be translated. I will experiment a bit with a few more exercises after this change, but from the texts I have seen it seems OK. 

![Skærmbillede 2023-06-01 114047](https://github.com/zeeguu/web/assets/17390076/17bb309a-7831-4392-8fa5-0fe5362a494e)
