### PR TITLE
Force reseting the CurrentExercise component from Parent (Exercise)

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -403,6 +403,7 @@ export default function Exercises({
       <ProgressBar index={currentIndex} total={exerciseSession.length} />
       <s.ExForm>
         <CurrentExercise
+          key={currentIndex}
           bookmarksToStudy={currentBookmarksToStudy}
           correctAnswer={correctAnswer}
           notifyIncorrectAnswer={incorrectAnswerNotification}

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -431,6 +431,7 @@ export default function OrderWords({
       newUserSolutionWordArray.push(wordSelected);
     }
     else {
+      // In case the user selected the same word twice, we remove it.
       newUserSolutionWordArray = newUserSolutionWordArray.filter((wordElement) => 
         wordElement.id !== wordSelected.id);
     }
@@ -464,7 +465,6 @@ export default function OrderWords({
     setIsCorrect(true);
     setIsCluesRowVisible(false);
     handleAnswer(message, duration);
-    setWordsReferenceStatus([]);
   }
 
   function handleAnswer(message) {
@@ -564,18 +564,19 @@ export default function OrderWords({
       setUserSolutionWordArray(newUserSolutionWordArray);
       let concatMessage = messageToAPI + "C";
       handleAnswer(concatMessage);
-      // Need to reset MasterStatus, so when the new exercise is loaded, there are no words.
-      // This happens when you don't change the exercise.
-      setWordsReferenceStatus([]);
     }
     else {
       // We need to ensure that we don't send the entire sentence,
       // or alignment might align very distant words.
       // We provide only the context up to + 1 what the user has constructed.
       let resizedSolutionText = filterPunctuationSolArray.slice(0, newUserSolutionWordArray.length + 1).join(" ");
-      api.annotateClues(newUserSolutionWordArray, resizedSolutionText, exerciseLang, (updatedUserSolutionWords) => {
-        updateWordsFromAPI(updatedUserSolutionWords, resizedSolutionText, userSolutionSentence);
-      }
+      api.annotateClues(
+        newUserSolutionWordArray, 
+        resizedSolutionText, 
+        exerciseLang, 
+        (updatedUserSolutionWords) => {
+          updateWordsFromAPI(updatedUserSolutionWords, resizedSolutionText, userSolutionSentence);
+        }
       );
     }
   }
@@ -756,7 +757,12 @@ export default function OrderWords({
       {!isCorrect && (<p className="tipText">{strings.orderWordsTipMessage}</p>)}
       {!isCorrect && ENABLE_SHORTER_CONTEXT_BUTTON &&(
         <sOW.ItemRowCompactWrap className="ItemRowCompactWrap">
-          <button onClick={handleReduceContext} className={isHandlingLongSentences ? "owButton reduceContext correct" : "owButton reduceContext disable"}>Toggle Short Context</button>
+          <button 
+            onClick={handleReduceContext} 
+            className={isHandlingLongSentences ? "owButton reduceContext correct" 
+            : "owButton reduceContext disable"}>
+              Toggle Short Context
+          </button>
         </sOW.ItemRowCompactWrap>  
       )
       }

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -53,32 +53,7 @@ export default function OrderWords({
   const [textBeforeTranslatedText, setTextBeforeTranslatedText] = useState("");
   const [textAfterTranslatedText, setTextAfterTranslatedText] = useState("");
   
-
   console.log("Running ORDER WORDS EXERCISE")
-
-  // Util Functions for the Component
-  function _resetReactStates() {
-    setInitialTime(new Date());
-    setResetCounter(0);
-    setHintCounter(0);
-    setTotalErrorCounter(0);
-    setPosSelected("");
-    setWordsReferenceStatus([]);
-    setExerciseContext("");
-    setClueText([]);
-    setTranslatedText("");
-    setIsCluesRowVisible(false);
-    setUserSolutionWordArray([]);
-    setConfuseWords();
-    setWordSelected();
-    setWordSwapStatus("");
-    setWordSwapId(NO_WORD_SELECTED_ID);
-    setSolutionWords([]);
-    setIsResetConfirmVisible(false);
-    setIsSentenceTooLong(false);
-    setTextBeforeTranslatedText("");
-    setTextAfterTranslatedText("");
-  }
 
   function _removeEmptyTokens(tokenList) {
     // In some instance, there will be punctuation in the middle, which
@@ -247,7 +222,6 @@ export default function OrderWords({
   useEffect(() => {
     setExerciseType(EXERCISE_TYPE);
     let exerciseIntializeVariables = _get_exercise_start_variables()
-    _resetReactStates();
     // Handle the case of long sentences, this relies on activating the functionality. 
     prepareContext(
       exerciseIntializeVariables["originalBookmarkContext"],
@@ -260,7 +234,7 @@ export default function OrderWords({
     // to prepare the exercise, as well as the sentenceTooLong.
     setInitialTime(exerciseIntializeVariables["exerciseStartTime"]);
     setIsSentenceTooLong(exerciseIntializeVariables["isLongSentence"]);
-  }, [bookmarksToStudy])
+  },[])
 
   function prepareContext(
     originalContext,
@@ -304,7 +278,7 @@ export default function OrderWords({
       .then((data) => {
         let translatedContext = data["translation"];
         // Line below is used for development with no API key (translatedContext is Null)
-        // if (!translatedContext) { translatedContext = exerciseContext; }
+        if (!translatedContext) { translatedContext = exerciseContext; }
         if (exerciseContext.length < originalContext.length){
           let startPos = originalContext.search(exerciseContext);
           let contextLen = originalContext.length;
@@ -661,7 +635,6 @@ export default function OrderWords({
   function handleReduceContext(){
     let newIsHandleLongSentences = !isHandlingLongSentences;
     let exerciseIntializeVariables = _get_exercise_start_variables()
-    _resetReactStates();
     // Handle the case of long sentences, this relies on activating the functionality. 
     prepareContext(
       exerciseIntializeVariables["originalBookmarkContext"],


### PR DESCRIPTION
Following the recommendations in https://react.dev/learn/preserving-and-resetting-state Option 2.

To do this a **key** was added to the CurrentExercise Component in Exercise.js which reflects the current Index. This ensures that the component re-renders and re-initializes the local state variables.

This allows the Exercise objects to be repeated and ensure they re-initialize all the local states, which was tested with _OrderWords_ and _MultipleChoice_.