### PR TITLE
Redirection Notification Modal - "Don't show this message" checkbox

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -13,7 +13,7 @@ export default function ArticleOverview({
   dontShowImage,
   hasExtension,
   api,
-  selectedDoNotShowRedirectionModal,
+  selectedDoNotShowRedirectionModal_Checkbox,
   setSelectedDoNotShowRedirectionModal,
   openedExternallyWithoutModal,
   setOpenedExternallyWithoutModal,
@@ -50,7 +50,9 @@ export default function ArticleOverview({
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
-          selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
+          selectedDoNotShowRedirectionModal_Checkbox={
+            selectedDoNotShowRedirectionModal_Checkbox
+          }
           setSelectedDoNotShowRedirectionModal={
             setSelectedDoNotShowRedirectionModal
           }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -24,7 +24,7 @@ export default function ArticleOverview({
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
 
-  function handleClose() {
+  function handleCloseRedirectionModal() {
     setIsRedirectionModaOpen(false);
   }
 
@@ -47,7 +47,7 @@ export default function ArticleOverview({
           api={api}
           article={article}
           open={isRedirectionModalOpen}
-          handleClose={handleClose}
+          handleCloseRedirectionModal={handleCloseRedirectionModal}
           setDoNotShowRedirectionModal_UserPreference={
             setDoNotShowRedirectionModal_UserPreference
           }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -79,7 +79,7 @@ export default function ArticleOverview({
     // else, we only open in zeegu if it's a personal copy or the article
     // has an uploader, thus it's uploaded from our own platform
     // either by the user themselves or by a teacher maybe
-    if (article.has_personal_copy || article.has_uploader) {
+    if (article.has_personal_copy || article.has_uploader || isSaved === true) {
       return open_in_zeeguu;
     } else if (openedExternallyWithoutModal === false) {
       return open_externally_with_modal;

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -7,13 +7,12 @@ import Feature from "../features/Feature";
 import { extractVideoIDFromURL } from "../utils/misc/youtube";
 import SmallSaveArticleButton from "./SmallSaveArticleButton";
 
-
 export default function ArticleOverview({
   article,
   dontShowPublishingTime,
   dontShowImage,
   hasExtension,
-    api
+  api,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
 
@@ -32,7 +31,7 @@ export default function ArticleOverview({
     let open_in_zeeguu = (
       <Link to={`/read/article?id=${article.id}`}>{article.title}</Link>
     );
-    let open_externally = (
+    let open_externally_with_modal = (
       //The RedirectionNotificationModal is displayed when the user clicks
       //the article's title from the recommendation list.
       //The modal informs the user that they are about to be redirected
@@ -48,6 +47,13 @@ export default function ArticleOverview({
           {article.title}
         </s.InvisibleTitleButton>
       </>
+    );
+    //If the user selects the "do not show again" checkbox on the RedirectionNotificationModal,
+    //clicking the article's title will send them directly to the original article's site.
+    let open_externally_without_modal = (
+      <a target="_blank" rel="noreferrer" href={article.url}>
+        {article.title}
+      </a>
     );
 
     if (article.video) {
@@ -65,14 +71,15 @@ export default function ArticleOverview({
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
     } else {
-      return open_externally;
+      return open_externally_with_modal;
     }
   }
 
   return (
     <s.ArticlePreview>
-      <s.Title>{titleLink(article)}
-          <SmallSaveArticleButton api={api} article={article} />
+      <s.Title>
+        {titleLink(article)}
+        <SmallSaveArticleButton api={api} article={article} />
       </s.Title>
       <s.Difficulty>{difficulty}</s.Difficulty>
       <s.WordCount>{article.metrics.word_count}</s.WordCount>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -19,6 +19,7 @@ export default function ArticleOverview({
   setOpenedExternallyWithoutModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
+  const [isSaved, setIsSaved] = useState(article.has_personal_copy);
 
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
@@ -52,6 +53,8 @@ export default function ArticleOverview({
             setSelectedDoNotShowRedirectionModal
           }
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
+          isSaved={isSaved}
+          setIsSaved={setIsSaved}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>
           {article.title}
@@ -87,7 +90,12 @@ export default function ArticleOverview({
     <s.ArticlePreview>
       <s.Title>
         {titleLink(article)}
-        <SmallSaveArticleButton api={api} article={article} />
+        <SmallSaveArticleButton
+          api={api}
+          article={article}
+          isSaved={isSaved}
+          setIsSaved={setIsSaved}
+        />
       </s.Title>
       <s.Difficulty>{difficulty}</s.Difficulty>
       <s.WordCount>{article.metrics.word_count}</s.WordCount>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -19,7 +19,9 @@ export default function ArticleOverview({
   setOpenedExternallyWithoutModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
-  const [isSaved, setIsSaved] = useState(article.has_personal_copy);
+  const [isArticleSaved, setIsArticleSaved] = useState(
+    article.has_personal_copy
+  );
 
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
@@ -53,8 +55,7 @@ export default function ArticleOverview({
             setSelectedDoNotShowRedirectionModal
           }
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
-          isSaved={isSaved}
-          setIsSaved={setIsSaved}
+          setIsArticleSaved={setIsArticleSaved}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>
           {article.title}
@@ -79,7 +80,11 @@ export default function ArticleOverview({
     // else, we only open in zeegu if it's a personal copy or the article
     // has an uploader, thus it's uploaded from our own platform
     // either by the user themselves or by a teacher maybe
-    if (article.has_personal_copy || article.has_uploader || isSaved === true) {
+    if (
+      article.has_personal_copy ||
+      article.has_uploader ||
+      isArticleSaved === true
+    ) {
       return open_in_zeeguu;
     } else if (openedExternallyWithoutModal === false) {
       return open_externally_with_modal;
@@ -93,8 +98,8 @@ export default function ArticleOverview({
         <SmallSaveArticleButton
           api={api}
           article={article}
-          isSaved={isSaved}
-          setIsSaved={setIsSaved}
+          isArticleSaved={isArticleSaved}
+          setIsArticleSaved={setIsArticleSaved}
         />
       </s.Title>
       <s.Difficulty>{difficulty}</s.Difficulty>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,7 +15,7 @@ export default function ArticleOverview({
   api,
   selectedDoNotShowRedirectionModal_Checkbox,
   setSelectedDoNotShowRedirectionModal_Checkbox,
-  openedExternallyWithoutModal,
+  redirectionModalVisibilityUserPreference,
   setOpenedExternallyWithoutModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
@@ -88,7 +88,7 @@ export default function ArticleOverview({
       isArticleSaved === true
     ) {
       return open_in_zeeguu;
-    } else if (openedExternallyWithoutModal === false) {
+    } else if (redirectionModalVisibilityUserPreference === false) {
       return open_externally_with_modal;
     } else return open_externally_without_modal;
   }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -13,8 +13,6 @@ export default function ArticleOverview({
   dontShowImage,
   hasExtension,
   api,
-  selectedDoNotShowRedirectionModal_Checkbox,
-  setSelectedDoNotShowRedirectionModal_Checkbox,
   doNotShowRedirectionModal_UserPreference,
   setDoNotShowRedirectionModal_UserPreference,
 }) {
@@ -50,12 +48,6 @@ export default function ArticleOverview({
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
-          selectedDoNotShowRedirectionModal_Checkbox={
-            selectedDoNotShowRedirectionModal_Checkbox
-          }
-          setSelectedDoNotShowRedirectionModal_Checkbox={
-            setSelectedDoNotShowRedirectionModal_Checkbox
-          }
           setDoNotShowRedirectionModal_UserPreference={
             setDoNotShowRedirectionModal_UserPreference
           }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -84,22 +84,19 @@ export default function ArticleOverview({
       doNotShowRedirectionModal_UserPreference === false;
 
     if (should_open_in_zeeguu) return open_in_zeeguu;
-    else if (should_open_with_modal)
-      return open_externally_with_modal; 
+    else if (should_open_with_modal) return open_externally_with_modal;
     else return open_externally_without_modal;
   }
 
   return (
     <s.ArticlePreview>
-      <s.Title>
-        {titleLink(article)}
-        <SmallSaveArticleButton
-          api={api}
-          article={article}
-          isArticleSaved={isArticleSaved}
-          setIsArticleSaved={setIsArticleSaved}
-        />
-      </s.Title>
+      <SmallSaveArticleButton
+        api={api}
+        article={article}
+        isArticleSaved={isArticleSaved}
+        setIsArticleSaved={setIsArticleSaved}
+      />
+      <s.Title>{titleLink(article)}</s.Title>
       <s.Difficulty>{difficulty}</s.Difficulty>
       <s.WordCount>{article.metrics.word_count}</s.WordCount>
 

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -14,7 +14,7 @@ export default function ArticleOverview({
   hasExtension,
   api,
   selectedDoNotShowRedirectionModal_Checkbox,
-  setSelectedDoNotShowRedirectionModal,
+  setSelectedDoNotShowRedirectionModal_Checkbox,
   openedExternallyWithoutModal,
   setOpenedExternallyWithoutModal,
 }) {
@@ -53,8 +53,8 @@ export default function ArticleOverview({
           selectedDoNotShowRedirectionModal_Checkbox={
             selectedDoNotShowRedirectionModal_Checkbox
           }
-          setSelectedDoNotShowRedirectionModal={
-            setSelectedDoNotShowRedirectionModal
+          setSelectedDoNotShowRedirectionModal_Checkbox={
+            setSelectedDoNotShowRedirectionModal_Checkbox
           }
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
           setIsArticleSaved={setIsArticleSaved}

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,6 +15,13 @@ export default function ArticleOverview({
   api,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
+  const [checkboxChecked, setCheckboxChecked] = useState(false);
+
+  function handleChecked() {
+    setCheckboxChecked(!checkboxChecked);
+  }
+
+  console.log(checkboxChecked);
 
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
@@ -42,6 +49,7 @@ export default function ArticleOverview({
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
+          handleChecked={handleChecked}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>
           {article.title}

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -28,7 +28,7 @@ export default function ArticleOverview({
     setIsRedirectionModaOpen(false);
   }
 
-  function handleOpen() {
+  function handleOpenRedirectionModal() {
     setIsRedirectionModaOpen(true);
   }
 
@@ -53,7 +53,7 @@ export default function ArticleOverview({
           }
           setIsArticleSaved={setIsArticleSaved}
         />
-        <s.InvisibleTitleButton onClick={handleOpen}>
+        <s.InvisibleTitleButton onClick={handleOpenRedirectionModal}>
           {article.title}
         </s.InvisibleTitleButton>
       </>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -13,10 +13,10 @@ export default function ArticleOverview({
   dontShowImage,
   hasExtension,
   api,
-  checkboxChecked,
-  setCheckboxChecked,
-  useModal,
-  setUseModal,
+  selectedDoNotShowRedirectionModal,
+  setSelectedDoNotShowRedirectionModal,
+  openedExternallyWithoutModal,
+  setOpenedExternallyWithoutModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
 
@@ -43,10 +43,12 @@ export default function ArticleOverview({
       //should be taken to start reading the said article with The Zeeguu Reader extension
       <>
         <RedirectionNotificationModal
-          checkboxChecked={checkboxChecked}
-          setCheckboxChecked={setCheckboxChecked}
-          useModal={useModal}
-          setUseModal={setUseModal}
+          selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
+          setSelectedDoNotShowRedirectionModal={
+            setSelectedDoNotShowRedirectionModal
+          }
+          // openedExternallyWithoutModal={openedExternallyWithoutModal}
+          setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
@@ -78,15 +80,8 @@ export default function ArticleOverview({
     // either by the user themselves or by a teacher maybe
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
-    } else if (useModal === false) {
+    } else if (openedExternallyWithoutModal === false) {
       return open_externally_with_modal;
-      //TODO: Currently right after "do not show" checkbox is checked
-      //the condition checkboxChecked === false and "open_externally_with_modal" no longer holds and the
-      //modal disappears which results in not letting the user proceed to the article
-      //by clicking the modal's "Go to article button" which results in a confusing flow.
-      // To solve this I am considering to add an additional value
-      //to the Logal storage that would be changed when  "Go to article button" is clicked
-      // not right after the checkbox has been cheched
     } else return open_externally_without_modal;
   }
 

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,10 +15,10 @@ export default function ArticleOverview({
   api,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
-  const [checkboxChecked, setCheckboxChecked] = useState(false);
+  const [checkboxChecked, setCheckboxChecked] = useState(null);
 
-  function handleChecked() {
-    setCheckboxChecked(!checkboxChecked);
+  function handleChecked(event) {
+    setCheckboxChecked(event.target.checked);
   }
 
   console.log(checkboxChecked);

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -48,7 +48,7 @@ export default function ArticleOverview({
         </s.InvisibleTitleButton>
       </>
     );
-    //If the user selects the "do not show again" checkbox on the RedirectionNotificationModal,
+    //Todo: If the user selects the "do not show again" checkbox on the RedirectionNotificationModal,
     //clicking the article's title will send them directly to the original article's site.
     let open_externally_without_modal = (
       <a target="_blank" rel="noreferrer" href={article.url}>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -43,6 +43,7 @@ export default function ArticleOverview({
       //list and can be deactivated when they select "Do not show again" and proceed.
       <>
         <RedirectionNotificationModal
+          api={api}
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,6 +15,8 @@ export default function ArticleOverview({
   api,
   checkboxChecked,
   setCheckboxChecked,
+  useModal,
+  setUseModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
 
@@ -43,6 +45,8 @@ export default function ArticleOverview({
         <RedirectionNotificationModal
           checkboxChecked={checkboxChecked}
           setCheckboxChecked={setCheckboxChecked}
+          useModal={useModal}
+          setUseModal={setUseModal}
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
@@ -74,7 +78,7 @@ export default function ArticleOverview({
     // either by the user themselves or by a teacher maybe
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
-    } else if (checkboxChecked === false) {
+    } else if (useModal === false) {
       return open_externally_with_modal;
       //TODO: Currently right after "do not show" checkbox is checked
       //the condition checkboxChecked === false and "open_externally_with_modal" no longer holds and the

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,7 +15,7 @@ export default function ArticleOverview({
   api,
   selectedDoNotShowRedirectionModal_Checkbox,
   setSelectedDoNotShowRedirectionModal_Checkbox,
-  redirectionModalVisibilityUserPreference,
+  doNotShowRedirectionModalUserPreference,
   setOpenedExternallyWithoutModal,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
@@ -88,7 +88,7 @@ export default function ArticleOverview({
       isArticleSaved === true
     ) {
       return open_in_zeeguu;
-    } else if (redirectionModalVisibilityUserPreference === false) {
+    } else if (doNotShowRedirectionModalUserPreference === false) {
       return open_externally_with_modal;
     } else return open_externally_without_modal;
   }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -36,7 +36,8 @@ export default function ArticleOverview({
     let open_in_zeeguu = (
       <Link to={`/read/article?id=${article.id}`}>{article.title}</Link>
     );
-    let open_externally_with_modal = (
+
+    let open_with_modal = (
       //The RedirectionNotificationModal modal informs the user that they are about
       //to be redirected to the original article's website and guides them on what steps
       //should be taken to start reading the said article with The Zeeguu Reader extension
@@ -58,33 +59,27 @@ export default function ArticleOverview({
         </s.InvisibleTitleButton>
       </>
     );
+
     let open_externally_without_modal = (
       <a target="_blank" rel="noreferrer" href={article.url}>
         {article.title}
       </a>
     );
 
-    if (article.video) {
-      return open_in_zeeguu;
-    }
-
-    if (!Feature.extension_experiment1() && !hasExtension) {
-      // if the feature is not enabled and if they don't have the extension we always open in zeeguu
-      return open_in_zeeguu;
-    }
-
-    // else, we only open in zeegu if it's a personal copy or the article
-    // has an uploader, thus it's uploaded from our own platform
-    // either by the user themselves or by a teacher maybe
-    if (
+    let should_open_in_zeeguu =
+      article.video ||
+      (!Feature.extension_experiment1() && !hasExtension) ||
       article.has_personal_copy ||
       article.has_uploader ||
-      isArticleSaved === true
-    ) {
-      return open_in_zeeguu;
-    } else if (doNotShowRedirectionModal_UserPreference === false) {
-      return open_externally_with_modal;
-    } else return open_externally_without_modal;
+      isArticleSaved === true;
+
+    let should_open_with_modal =
+      doNotShowRedirectionModal_UserPreference === false;
+
+    if (should_open_in_zeeguu) return open_in_zeeguu;
+    else if (should_open_with_modal)
+      return open_with_modal; //opens internally for mobile, externally for desktop
+    else return open_externally_without_modal;
   }
 
   return (

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import moment from "moment";
+import { isMobile } from "../utils/misc/browserDetection";
 import * as s from "./ArticlePreview.sc";
 import RedirectionNotificationModal from "../components/RedirectionNotificationModal";
 import Feature from "../features/Feature";
@@ -61,7 +62,13 @@ export default function ArticleOverview({
     );
 
     let open_externally_without_modal = (
-      <a target="_blank" rel="noreferrer" href={article.url}>
+      //allow target _self on mobile to easily go back to Zeeguu
+      //using mobile browser navigation
+      <a
+        target={isMobile ? "_self" : "_blank"}
+        rel="noreferrer"
+        href={article.url}
+      >
         {article.title}
       </a>
     );

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -38,7 +38,7 @@ export default function ArticleOverview({
       <Link to={`/read/article?id=${article.id}`}>{article.title}</Link>
     );
 
-    let open_with_modal = (
+    let open_externally_with_modal = (
       //The RedirectionNotificationModal modal informs the user that they are about
       //to be redirected to the original article's website and guides them on what steps
       //should be taken to start reading the said article with The Zeeguu Reader extension
@@ -85,7 +85,7 @@ export default function ArticleOverview({
 
     if (should_open_in_zeeguu) return open_in_zeeguu;
     else if (should_open_with_modal)
-      return open_with_modal; //opens internally for mobile, externally for desktop
+      return open_externally_with_modal; 
     else return open_externally_without_modal;
   }
 

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,7 +15,7 @@ export default function ArticleOverview({
   api,
   selectedDoNotShowRedirectionModal_Checkbox,
   setSelectedDoNotShowRedirectionModal_Checkbox,
-  doNotShowRedirectionModalUserPreference,
+  doNotShowRedirectionModal_UserPreference,
   setDoNotShowRedirectionModal_UserPreference,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
@@ -90,7 +90,7 @@ export default function ArticleOverview({
       isArticleSaved === true
     ) {
       return open_in_zeeguu;
-    } else if (doNotShowRedirectionModalUserPreference === false) {
+    } else if (doNotShowRedirectionModal_UserPreference === false) {
       return open_externally_with_modal;
     } else return open_externally_without_modal;
   }

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -13,6 +13,8 @@ export default function ArticleOverview({
   dontShowImage,
   hasExtension,
   api,
+  checkboxChecked,
+  setCheckboxChecked,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
 
@@ -39,6 +41,8 @@ export default function ArticleOverview({
       //should be taken to start reading the said article with The Zeeguu Reader extension
       <>
         <RedirectionNotificationModal
+          checkboxChecked={checkboxChecked}
+          setCheckboxChecked={setCheckboxChecked}
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -74,9 +74,16 @@ export default function ArticleOverview({
     // either by the user themselves or by a teacher maybe
     if (article.has_personal_copy || article.has_uploader) {
       return open_in_zeeguu;
-    } else {
+    } else if (checkboxChecked === false) {
       return open_externally_with_modal;
-    }
+      //TODO: Currently right after "do not show" checkbox is checked
+      //the condition checkboxChecked === false and "open_externally_with_modal" no longer holds and the
+      //modal disappears which results in not letting the user proceed to the article
+      //by clicking the modal's "Go to article button" which results in a confusing flow.
+      // To solve this I am considering to add an additional value
+      //to the Logal storage that would be changed when  "Go to article button" is clicked
+      // not right after the checkbox has been cheched
+    } else return open_externally_without_modal;
   }
 
   return (

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -16,7 +16,7 @@ export default function ArticleOverview({
   selectedDoNotShowRedirectionModal_Checkbox,
   setSelectedDoNotShowRedirectionModal_Checkbox,
   doNotShowRedirectionModalUserPreference,
-  setOpenedExternallyWithoutModal,
+  setDoNotShowRedirectionModal_UserPreference,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
   const [isArticleSaved, setIsArticleSaved] = useState(
@@ -56,7 +56,9 @@ export default function ArticleOverview({
           setSelectedDoNotShowRedirectionModal_Checkbox={
             setSelectedDoNotShowRedirectionModal_Checkbox
           }
-          setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
+          setDoNotShowRedirectionModal_UserPreference={
+            setDoNotShowRedirectionModal_UserPreference
+          }
           setIsArticleSaved={setIsArticleSaved}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -15,13 +15,6 @@ export default function ArticleOverview({
   api,
 }) {
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
-  const [checkboxChecked, setCheckboxChecked] = useState(null);
-
-  function handleChecked(event) {
-    setCheckboxChecked(event.target.checked);
-  }
-
-  console.log(checkboxChecked);
 
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
@@ -49,7 +42,6 @@ export default function ArticleOverview({
           article={article}
           open={isRedirectionModalOpen}
           handleClose={handleClose}
-          handleChecked={handleChecked}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>
           {article.title}

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -36,30 +36,27 @@ export default function ArticleOverview({
       <Link to={`/read/article?id=${article.id}`}>{article.title}</Link>
     );
     let open_externally_with_modal = (
-      //The RedirectionNotificationModal is displayed when the user clicks
-      //the article's title from the recommendation list.
-      //The modal informs the user that they are about to be redirected
-      //to the original article's website and guides them on what steps
+      //The RedirectionNotificationModal modal informs the user that they are about
+      //to be redirected to the original article's website and guides them on what steps
       //should be taken to start reading the said article with The Zeeguu Reader extension
+      //The modal is displayed when the user clicks the article's title from the recommendation
+      //list and can be deactivated when they select "Do not show again" and proceed.
       <>
         <RedirectionNotificationModal
+          article={article}
+          open={isRedirectionModalOpen}
+          handleClose={handleClose}
           selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
           setSelectedDoNotShowRedirectionModal={
             setSelectedDoNotShowRedirectionModal
           }
-          // openedExternallyWithoutModal={openedExternallyWithoutModal}
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
-          article={article}
-          open={isRedirectionModalOpen}
-          handleClose={handleClose}
         />
         <s.InvisibleTitleButton onClick={handleOpen}>
           {article.title}
         </s.InvisibleTitleButton>
       </>
     );
-    //Todo: If the user selects the "do not show again" checkbox on the RedirectionNotificationModal,
-    //clicking the article's title will send them directly to the original article's site.
     let open_externally_without_modal = (
       <a target="_blank" rel="noreferrer" href={article.url}>
         {article.title}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -37,27 +37,35 @@ export default function NewArticles({ api }) {
   //in bool values changing on its own on refresh without any other external trigger.
   // A '=== "true"' clause has been added to the getDoNotShowRedirectionNotificationModal() getter
   //to achieve predictable and desired bool values
-  const checked =
+  const isDoNotShowRedirectionNotificationModaSelected =
     LocalStorage.getDoNotShowRedirectionNotificationModal() === "true"
       ? true
       : false;
 
-  const [checkboxChecked, setCheckboxChecked] = useState(checked);
-
-  useEffect(() => {
-    LocalStorage.setDoNotShowRedirectionNotificationModal(checkboxChecked);
-  }, [checkboxChecked]);
-
-  const openArticleWithoutModal =
+  const isArticleOpenedExternallyWithoutModal =
     LocalStorage.getOpenArticleExternallyWithoutModal() === "true"
       ? true
       : false;
 
-  const [useModal, setUseModal] = useState(openArticleWithoutModal);
+  const [
+    selectedDoNotShowRedirectionModal,
+    setSelectedDoNotShowRedirectionModal,
+  ] = useState(isDoNotShowRedirectionNotificationModaSelected);
+
+  const [openedExternallyWithoutModal, setOpenedExternallyWithoutModal] =
+    useState(isArticleOpenedExternallyWithoutModal);
 
   useEffect(() => {
-    LocalStorage.setOpenArticleExternallyWithoutModal(useModal);
-  }, [useModal]);
+    LocalStorage.setDoNotShowRedirectionNotificationModal(
+      selectedDoNotShowRedirectionModal
+    );
+  }, [selectedDoNotShowRedirectionModal]);
+
+  useEffect(() => {
+    LocalStorage.setOpenArticleExternallyWithoutModal(
+      openedExternallyWithoutModal
+    );
+  }, [openedExternallyWithoutModal]);
 
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
@@ -131,10 +139,12 @@ export default function NewArticles({ api }) {
       <Reminder hasExtension={hasExtension}></Reminder>
       {articleList.map((each) => (
         <ArticlePreview
-          useModal={useModal}
-          setUseModal={setUseModal}
-          checkboxChecked={checkboxChecked}
-          setCheckboxChecked={setCheckboxChecked}
+          openedExternallyWithoutModal={openedExternallyWithoutModal}
+          setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
+          selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
+          setSelectedDoNotShowRedirectionModal={
+            setSelectedDoNotShowRedirectionModal
+          }
           key={each.id}
           article={each}
           api={api}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -56,7 +56,7 @@ export default function NewArticles({ api }) {
   //States controlling whether external articles should be opened with or without
   //the RedirectionNotificationModal
   const [
-    redirectionModalVisibilityUserPreference,
+    doNotShowRedirectionModalUserPreference,
     setOpenedExternallyWithoutModal,
   ] = useState(isArticleOpenedExternallyWithoutModal);
 
@@ -68,9 +68,9 @@ export default function NewArticles({ api }) {
 
   useEffect(() => {
     LocalStorage.setOpenArticleExternallyWithoutModal(
-      redirectionModalVisibilityUserPreference
+      doNotShowRedirectionModalUserPreference
     );
-  }, [redirectionModalVisibilityUserPreference]);
+  }, [doNotShowRedirectionModalUserPreference]);
 
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
@@ -148,8 +148,8 @@ export default function NewArticles({ api }) {
           article={each}
           api={api}
           hasExtension={hasExtension}
-          redirectionModalVisibilityUserPreference={
-            redirectionModalVisibilityUserPreference
+          doNotShowRedirectionModalUserPreference={
+            doNotShowRedirectionModalUserPreference
           }
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
           selectedDoNotShowRedirectionModal_Checkbox={

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -56,7 +56,7 @@ export default function NewArticles({ api }) {
   //States controlling whether external articles should be opened with or without
   //the RedirectionNotificationModal
   const [
-    doNotShowRedirectionModalUserPreference,
+    doNotShowRedirectionModal_UserPreference,
     setDoNotShowRedirectionModal_UserPreference,
   ] = useState(isArticleOpenedExternallyWithoutModal);
 
@@ -68,9 +68,9 @@ export default function NewArticles({ api }) {
 
   useEffect(() => {
     LocalStorage.setOpenArticleExternallyWithoutModal(
-      doNotShowRedirectionModalUserPreference
+      doNotShowRedirectionModal_UserPreference
     );
-  }, [doNotShowRedirectionModalUserPreference]);
+  }, [doNotShowRedirectionModal_UserPreference]);
 
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
@@ -148,8 +148,8 @@ export default function NewArticles({ api }) {
           article={each}
           api={api}
           hasExtension={hasExtension}
-          doNotShowRedirectionModalUserPreference={
-            doNotShowRedirectionModalUserPreference
+          doNotShowRedirectionModal_UserPreference={
+            doNotShowRedirectionModal_UserPreference
           }
           setDoNotShowRedirectionModal_UserPreference={
             setDoNotShowRedirectionModal_UserPreference

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -50,7 +50,7 @@ export default function NewArticles({ api }) {
   const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
   //States linked with the "Do not show" checkbox selection on the RedirectionNotificationModal
   const [
-    selectedDoNotShowRedirectionModal,
+    selectedDoNotShowRedirectionModal_Checkbox,
     setSelectedDoNotShowRedirectionModal,
   ] = useState(isDoNotShowRedirectionNotificationModaSelected);
   //States controlling whether external articles should be opened with or without
@@ -60,9 +60,9 @@ export default function NewArticles({ api }) {
 
   useEffect(() => {
     LocalStorage.setDoNotShowRedirectionNotificationModal(
-      selectedDoNotShowRedirectionModal
+      selectedDoNotShowRedirectionModal_Checkbox
     );
-  }, [selectedDoNotShowRedirectionModal]);
+  }, [selectedDoNotShowRedirectionModal_Checkbox]);
 
   useEffect(() => {
     LocalStorage.setOpenArticleExternallyWithoutModal(
@@ -148,7 +148,9 @@ export default function NewArticles({ api }) {
           hasExtension={hasExtension}
           openedExternallyWithoutModal={openedExternallyWithoutModal}
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
-          selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
+          selectedDoNotShowRedirectionModal_Checkbox={
+            selectedDoNotShowRedirectionModal_Checkbox
+          }
           setSelectedDoNotShowRedirectionModal={
             setSelectedDoNotShowRedirectionModal
           }

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -32,14 +32,14 @@ export default function NewArticles({ api }) {
   const [hasExtension, setHasExtension] = useState(true);
   const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
   const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
-  const checked = LocalStorage.getShowRedirectionNotificationModal() ? true : false;
+  const checked = LocalStorage.getDoNotShowRedirectionNotificationModal() ? true : false;
   const [checkboxChecked, setCheckboxChecked] = useState(
     checked
     // LocalStorage.getShowRedirectionNotificationModal()
   );
 
     useEffect(() => {
-    LocalStorage.setShowRedirectionNotificationModal(checkboxChecked);
+    LocalStorage.setDoNotShowRedirectionNotificationModal(checkboxChecked);
   }, [checkboxChecked]);
 
   useEffect(() => {

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -35,6 +35,7 @@ export default function NewArticles({ api }) {
   const checked = LocalStorage.getShowRedirectionNotificationModal() ? true : false;
   const [checkboxChecked, setCheckboxChecked] = useState(
     checked
+    // LocalStorage.getShowRedirectionNotificationModal()
   );
 
     useEffect(() => {

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -48,6 +48,17 @@ export default function NewArticles({ api }) {
     LocalStorage.setDoNotShowRedirectionNotificationModal(checkboxChecked);
   }, [checkboxChecked]);
 
+  const openArticleWithoutModal =
+    LocalStorage.getOpenArticleExternallyWithoutModal() === "true"
+      ? true
+      : false;
+
+  const [useModal, setUseModal] = useState(openArticleWithoutModal);
+
+  useEffect(() => {
+    LocalStorage.setOpenArticleExternallyWithoutModal(useModal);
+  }, [useModal]);
+
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
     console.log(
@@ -120,6 +131,8 @@ export default function NewArticles({ api }) {
       <Reminder hasExtension={hasExtension}></Reminder>
       {articleList.map((each) => (
         <ArticlePreview
+          useModal={useModal}
+          setUseModal={setUseModal}
           checkboxChecked={checkboxChecked}
           setCheckboxChecked={setCheckboxChecked}
           key={each.id}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -32,6 +32,14 @@ export default function NewArticles({ api }) {
   const [hasExtension, setHasExtension] = useState(true);
   const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
   const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
+  const checked = LocalStorage.getShowRedirectionNotificationModal() ? true : false;
+  const [checkboxChecked, setCheckboxChecked] = useState(
+    checked
+  );
+
+    useEffect(() => {
+    LocalStorage.setShowRedirectionNotificationModal(checkboxChecked);
+  }, [checkboxChecked]);
 
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
@@ -105,6 +113,8 @@ export default function NewArticles({ api }) {
       <Reminder hasExtension={hasExtension}></Reminder>
       {articleList.map((each) => (
         <ArticlePreview
+          checkboxChecked={checkboxChecked}
+          setCheckboxChecked={setCheckboxChecked}
           key={each.id}
           article={each}
           api={api}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -51,7 +51,7 @@ export default function NewArticles({ api }) {
   //States linked with the "Do not show" checkbox selection on the RedirectionNotificationModal
   const [
     selectedDoNotShowRedirectionModal_Checkbox,
-    setSelectedDoNotShowRedirectionModal,
+    setSelectedDoNotShowRedirectionModal_Checkbox,
   ] = useState(isDoNotShowRedirectionNotificationModaSelected);
   //States controlling whether external articles should be opened with or without
   //the RedirectionNotificationModal
@@ -151,8 +151,8 @@ export default function NewArticles({ api }) {
           selectedDoNotShowRedirectionModal_Checkbox={
             selectedDoNotShowRedirectionModal_Checkbox
           }
-          setSelectedDoNotShowRedirectionModal={
-            setSelectedDoNotShowRedirectionModal
+          setSelectedDoNotShowRedirectionModal_Checkbox={
+            setSelectedDoNotShowRedirectionModal_Checkbox
           }
         />
       ))}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -33,10 +33,6 @@ export default function NewArticles({ api }) {
   //Additionally, the conditional statement needed to be tightened up due to JS's unstable behavior, which resulted
   //in bool values changing on its own on refresh without any other external trigger or preferences change.
   // A '=== "true"' clause has been added to the getters to achieve predictable and desired bool values.
-  const isDoNotShowRedirectionNotificationModaSelected_Checkbox =
-    LocalStorage.getDoNotShowRedirectionNotificationModal_Checkbox() === "true"
-      ? true
-      : false;
 
   const isArticleOpenedExternallyWithoutModal =
     LocalStorage.getOpenArticleExternallyWithoutModal() === "true"
@@ -48,23 +44,10 @@ export default function NewArticles({ api }) {
   const [hasExtension, setHasExtension] = useState(true);
   const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
   const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
-  //States linked with the "Do not show" checkbox selection on the RedirectionNotificationModal
-  const [
-    selectedDoNotShowRedirectionModal_Checkbox,
-    setSelectedDoNotShowRedirectionModal_Checkbox,
-  ] = useState(isDoNotShowRedirectionNotificationModaSelected_Checkbox);
-  //States controlling whether external articles should be opened with or without
-  //the RedirectionNotificationModal
   const [
     doNotShowRedirectionModal_UserPreference,
     setDoNotShowRedirectionModal_UserPreference,
   ] = useState(isArticleOpenedExternallyWithoutModal);
-
-  useEffect(() => {
-    LocalStorage.setDoNotShowRedirectionNotificationModal_Checkbox(
-      selectedDoNotShowRedirectionModal_Checkbox
-    );
-  }, [selectedDoNotShowRedirectionModal_Checkbox]);
 
   useEffect(() => {
     LocalStorage.setOpenArticleExternallyWithoutModal(
@@ -153,12 +136,6 @@ export default function NewArticles({ api }) {
           }
           setDoNotShowRedirectionModal_UserPreference={
             setDoNotShowRedirectionModal_UserPreference
-          }
-          selectedDoNotShowRedirectionModal_Checkbox={
-            selectedDoNotShowRedirectionModal_Checkbox
-          }
-          setSelectedDoNotShowRedirectionModal_Checkbox={
-            setSelectedDoNotShowRedirectionModal_Checkbox
           }
         />
       ))}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -33,8 +33,8 @@ export default function NewArticles({ api }) {
   //Additionally, the conditional statement needed to be tightened up due to JS's unstable behavior, which resulted
   //in bool values changing on its own on refresh without any other external trigger or preferences change.
   // A '=== "true"' clause has been added to the getters to achieve predictable and desired bool values.
-  const isDoNotShowRedirectionNotificationModaSelected =
-    LocalStorage.getDoNotShowRedirectionNotificationModal() === "true"
+  const isDoNotShowRedirectionNotificationModaSelected_Checkbox =
+    LocalStorage.getDoNotShowRedirectionNotificationModal_Checkbox() === "true"
       ? true
       : false;
 
@@ -52,14 +52,14 @@ export default function NewArticles({ api }) {
   const [
     selectedDoNotShowRedirectionModal_Checkbox,
     setSelectedDoNotShowRedirectionModal_Checkbox,
-  ] = useState(isDoNotShowRedirectionNotificationModaSelected);
+  ] = useState(isDoNotShowRedirectionNotificationModaSelected_Checkbox);
   //States controlling whether external articles should be opened with or without
   //the RedirectionNotificationModal
   const [openedExternallyWithoutModal, setOpenedExternallyWithoutModal] =
     useState(isArticleOpenedExternallyWithoutModal);
 
   useEffect(() => {
-    LocalStorage.setDoNotShowRedirectionNotificationModal(
+    LocalStorage.setDoNotShowRedirectionNotificationModal_Checkbox(
       selectedDoNotShowRedirectionModal_Checkbox
     );
   }, [selectedDoNotShowRedirectionModal_Checkbox]);

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -32,13 +32,19 @@ export default function NewArticles({ api }) {
   const [hasExtension, setHasExtension] = useState(true);
   const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
   const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
-  const checked = LocalStorage.getDoNotShowRedirectionNotificationModal() ? true : false;
-  const [checkboxChecked, setCheckboxChecked] = useState(
-    checked
-    // LocalStorage.getShowRedirectionNotificationModal()
-  );
 
-    useEffect(() => {
+  //This ternary operator needed to be tightened up due to JS unstable behaviour that resulted
+  //in bool values changing on its own on refresh without any other external trigger.
+  // A '=== "true"' clause has been added to the getDoNotShowRedirectionNotificationModal() getter
+  //to achieve predictable and desired bool values
+  const checked =
+    LocalStorage.getDoNotShowRedirectionNotificationModal() === "true"
+      ? true
+      : false;
+
+  const [checkboxChecked, setCheckboxChecked] = useState(checked);
+
+  useEffect(() => {
     LocalStorage.setDoNotShowRedirectionNotificationModal(checkboxChecked);
   }, [checkboxChecked]);
 

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -27,16 +27,12 @@ function useQuery() {
 export default function NewArticles({ api }) {
   const searchQuery = useQuery().get("search");
 
-  const [articleList, setArticleList] = useState(null);
-  const [originalList, setOriginalList] = useState(null);
-  const [hasExtension, setHasExtension] = useState(true);
-  const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
-  const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
-
-  //This ternary operator needed to be tightened up due to JS unstable behaviour that resulted
-  //in bool values changing on its own on refresh without any other external trigger.
-  // A '=== "true"' clause has been added to the getDoNotShowRedirectionNotificationModal() getter
-  //to achieve predictable and desired bool values
+  //The ternary operators below fix the problem with the getDoNotShowRedirectionNotificationModal()
+  //and getOpenArticleExternallyWithoutModal() getters getters that were outputting undefined string
+  //values when they should be false. This occurs before the user selects their own preferences.
+  //Additionally, the conditional statement needed to be tightened up due to JS's unstable behavior, which resulted
+  //in bool values changing on its own on refresh without any other external trigger or preferences change.
+  // A '=== "true"' clause has been added to the getters to achieve predictable and desired bool values.
   const isDoNotShowRedirectionNotificationModaSelected =
     LocalStorage.getDoNotShowRedirectionNotificationModal() === "true"
       ? true
@@ -47,11 +43,18 @@ export default function NewArticles({ api }) {
       ? true
       : false;
 
+  const [articleList, setArticleList] = useState(null);
+  const [originalList, setOriginalList] = useState(null);
+  const [hasExtension, setHasExtension] = useState(true);
+  const [extensionMessageOpen, setExtensionMessageOpen] = useState(false);
+  const [displayedExtensionPopup, setDisplayedExtensionPopup] = useState(false);
+  //States linked with the "Do not show" checkbox selection on the RedirectionNotificationModal
   const [
     selectedDoNotShowRedirectionModal,
     setSelectedDoNotShowRedirectionModal,
   ] = useState(isDoNotShowRedirectionNotificationModaSelected);
-
+  //States controlling whether external articles should be opened with or without
+  //the RedirectionNotificationModal
   const [openedExternallyWithoutModal, setOpenedExternallyWithoutModal] =
     useState(isArticleOpenedExternallyWithoutModal);
 
@@ -139,16 +142,16 @@ export default function NewArticles({ api }) {
       <Reminder hasExtension={hasExtension}></Reminder>
       {articleList.map((each) => (
         <ArticlePreview
+          key={each.id}
+          article={each}
+          api={api}
+          hasExtension={hasExtension}
           openedExternallyWithoutModal={openedExternallyWithoutModal}
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
           selectedDoNotShowRedirectionModal={selectedDoNotShowRedirectionModal}
           setSelectedDoNotShowRedirectionModal={
             setSelectedDoNotShowRedirectionModal
           }
-          key={each.id}
-          article={each}
-          api={api}
-          hasExtension={hasExtension}
         />
       ))}
 

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -57,7 +57,7 @@ export default function NewArticles({ api }) {
   //the RedirectionNotificationModal
   const [
     doNotShowRedirectionModalUserPreference,
-    setOpenedExternallyWithoutModal,
+    setDoNotShowRedirectionModal_UserPreference,
   ] = useState(isArticleOpenedExternallyWithoutModal);
 
   useEffect(() => {
@@ -151,7 +151,9 @@ export default function NewArticles({ api }) {
           doNotShowRedirectionModalUserPreference={
             doNotShowRedirectionModalUserPreference
           }
-          setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
+          setDoNotShowRedirectionModal_UserPreference={
+            setDoNotShowRedirectionModal_UserPreference
+          }
           selectedDoNotShowRedirectionModal_Checkbox={
             selectedDoNotShowRedirectionModal_Checkbox
           }

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -55,8 +55,10 @@ export default function NewArticles({ api }) {
   ] = useState(isDoNotShowRedirectionNotificationModaSelected_Checkbox);
   //States controlling whether external articles should be opened with or without
   //the RedirectionNotificationModal
-  const [openedExternallyWithoutModal, setOpenedExternallyWithoutModal] =
-    useState(isArticleOpenedExternallyWithoutModal);
+  const [
+    redirectionModalVisibilityUserPreference,
+    setOpenedExternallyWithoutModal,
+  ] = useState(isArticleOpenedExternallyWithoutModal);
 
   useEffect(() => {
     LocalStorage.setDoNotShowRedirectionNotificationModal_Checkbox(
@@ -66,9 +68,9 @@ export default function NewArticles({ api }) {
 
   useEffect(() => {
     LocalStorage.setOpenArticleExternallyWithoutModal(
-      openedExternallyWithoutModal
+      redirectionModalVisibilityUserPreference
     );
-  }, [openedExternallyWithoutModal]);
+  }, [redirectionModalVisibilityUserPreference]);
 
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
@@ -146,7 +148,9 @@ export default function NewArticles({ api }) {
           article={each}
           api={api}
           hasExtension={hasExtension}
-          openedExternallyWithoutModal={openedExternallyWithoutModal}
+          redirectionModalVisibilityUserPreference={
+            redirectionModalVisibilityUserPreference
+          }
           setOpenedExternallyWithoutModal={setOpenedExternallyWithoutModal}
           selectedDoNotShowRedirectionModal_Checkbox={
             selectedDoNotShowRedirectionModal_Checkbox

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -27,17 +27,14 @@ function useQuery() {
 export default function NewArticles({ api }) {
   const searchQuery = useQuery().get("search");
 
-  //The ternary operators below fix the problem with the getDoNotShowRedirectionNotificationModal()
-  //and getOpenArticleExternallyWithoutModal() getters getters that were outputting undefined string
-  //values when they should be false. This occurs before the user selects their own preferences.
+  //The ternary operator below fix the problem with the getOpenArticleExternallyWithoutModal()
+  //getter that was outputting undefined string values when they should be false.
+  //This occurs before the user selects their own preferences.
   //Additionally, the conditional statement needed to be tightened up due to JS's unstable behavior, which resulted
   //in bool values changing on its own on refresh without any other external trigger or preferences change.
   // A '=== "true"' clause has been added to the getters to achieve predictable and desired bool values.
-
-  const isArticleOpenedExternallyWithoutModal =
-    LocalStorage.getOpenArticleExternallyWithoutModal() === "true"
-      ? true
-      : false;
+  const doNotShowRedirectionModal_LocalStorage =
+    LocalStorage.getDoNotShowRedirectionModal() === "true" ? true : false;
 
   const [articleList, setArticleList] = useState(null);
   const [originalList, setOriginalList] = useState(null);
@@ -47,10 +44,10 @@ export default function NewArticles({ api }) {
   const [
     doNotShowRedirectionModal_UserPreference,
     setDoNotShowRedirectionModal_UserPreference,
-  ] = useState(isArticleOpenedExternallyWithoutModal);
+  ] = useState(doNotShowRedirectionModal_LocalStorage);
 
   useEffect(() => {
-    LocalStorage.setOpenArticleExternallyWithoutModal(
+    LocalStorage.setDoNotShowRedirectionModal(
       doNotShowRedirectionModal_UserPreference
     );
   }, [doNotShowRedirectionModal_UserPreference]);

--- a/src/articles/SmallSaveArticleButton.js
+++ b/src/articles/SmallSaveArticleButton.js
@@ -25,7 +25,6 @@ export default function SmallSaveArticleButton({
         <s.SavedLabel>
           {" "}
           <BookmarkIcon fontSize="small" />
-          {/* <img src="/static/images/zeeguuLogo.svg" width="11" alt={""} />  */}
           Saved
         </s.SavedLabel>
       ) : (

--- a/src/articles/SmallSaveArticleButton.js
+++ b/src/articles/SmallSaveArticleButton.js
@@ -1,41 +1,51 @@
 import * as s from "./SmallSaveArticleButton.sc.js";
-import {toast, ToastContainer} from "react-toastify";
-import {useState} from "react";
-import 'react-toastify/dist/ReactToastify.css';
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
+export default function SmallSaveArticleButton({
+  article,
+  api,
+  isSaved,
+  setIsSaved,
+}) {
+  function saveArticle() {
+    api.makePersonalCopy(article.id, (data) => {
+      if (data === "OK") {
+        setIsSaved(true);
+        toast("Article added to your Saves!");
+      }
+    });
+  }
 
-export default function SmallSaveArticleButton ({article, api}) {
+  return (
+    <>
+      {isSaved ? (
+        <s.SavedLabel>
+          {" "}
+          Saved <img
+            src="/static/images/zeeguuLogo.svg"
+            width="11"
+            alt={""}
+          />{" "}
+        </s.SavedLabel>
+      ) : (
+        <div>
+          <s.SaveButton onClick={saveArticle}>Save</s.SaveButton>
+        </div>
+      )}
 
-    const [isSaved, setIsSaved] = useState(article.has_personal_copy);
-
-    function saveArticle() {
-        api.makePersonalCopy(article.id, (data)=> {
-            if (data === "OK") {
-                setIsSaved(true);
-                toast('Article added to your Saves!');
-            }
-        })
-    }
-
-    return <>
-
-        {isSaved?
-            <s.SavedLabel> Saved <img src="/static/images/zeeguuLogo.svg" width="11" alt={""}/> </s.SavedLabel> :
-            <div><s.SaveButton onClick={saveArticle}>Save</s.SaveButton></div>}
-
-        <ToastContainer
-            position="bottom-right"
-            autoClose={2000}
-            hideProgressBar={true}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnFocusLoss
-            draggable
-            pauseOnHover
-            theme="light"
-        />
-        </>
-
-
+      <ToastContainer
+        position="bottom-right"
+        autoClose={2000}
+        hideProgressBar={true}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+      />
+    </>
+  );
 }

--- a/src/articles/SmallSaveArticleButton.js
+++ b/src/articles/SmallSaveArticleButton.js
@@ -1,6 +1,8 @@
 import * as s from "./SmallSaveArticleButton.sc.js";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
+import BookmarkIcon from "@mui/icons-material/Bookmark";
 
 export default function SmallSaveArticleButton({
   article,
@@ -22,15 +24,16 @@ export default function SmallSaveArticleButton({
       {isArticleSaved ? (
         <s.SavedLabel>
           {" "}
-          Saved <img
-            src="/static/images/zeeguuLogo.svg"
-            width="11"
-            alt={""}
-          />{" "}
+          <BookmarkIcon fontSize="small" />
+          {/* <img src="/static/images/zeeguuLogo.svg" width="11" alt={""} />  */}
+          Saved
         </s.SavedLabel>
       ) : (
         <div>
-          <s.SaveButton onClick={saveArticle}>Save</s.SaveButton>
+          <s.SaveButton onClick={saveArticle}>
+            <BookmarkBorderIcon fontSize="small" />
+            Add to Saves
+          </s.SaveButton>
         </div>
       )}
 

--- a/src/articles/SmallSaveArticleButton.js
+++ b/src/articles/SmallSaveArticleButton.js
@@ -5,13 +5,13 @@ import "react-toastify/dist/ReactToastify.css";
 export default function SmallSaveArticleButton({
   article,
   api,
-  isSaved,
-  setIsSaved,
+  isArticleSaved,
+  setIsArticleSaved,
 }) {
   function saveArticle() {
     api.makePersonalCopy(article.id, (data) => {
       if (data === "OK") {
-        setIsSaved(true);
+        setIsArticleSaved(true);
         toast("Article added to your Saves!");
       }
     });
@@ -19,7 +19,7 @@ export default function SmallSaveArticleButton({
 
   return (
     <>
-      {isSaved ? (
+      {isArticleSaved ? (
         <s.SavedLabel>
           {" "}
           Saved <img

--- a/src/articles/SmallSaveArticleButton.sc.js
+++ b/src/articles/SmallSaveArticleButton.sc.js
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { lightGrey } from "../components/colors";
+import { zeeguuOrange } from "../components/colors";
 
 let SaveButton = styled.button`
   font-size: small;
@@ -9,16 +11,17 @@ let SaveButton = styled.button`
   gap: 0.2rem;
   border: inherit;
   background-color: inherit;
-  /* margin: 1rem 0; */
   padding: 0.25rem 0;
   cursor: pointer;
+  &:hover {
+    color: ${zeeguuOrange};
+  }
 `;
 
 let SavedLabel = styled.div`
   font-size: small;
   font-weight: bold;
-  color: brown;
-  /* margin: 0.6em; */
+  color: ${lightGrey};
   display: flex;
   align-items: center;
   gap: 0.2rem;

--- a/src/articles/SmallSaveArticleButton.sc.js
+++ b/src/articles/SmallSaveArticleButton.sc.js
@@ -2,17 +2,25 @@ import styled from "styled-components";
 
 let SaveButton = styled.button`
   font-size: small;
+  color: orange;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  border: inherit;
+  background-color: inherit;
+  /* margin: 1rem 0; */
+  padding: 0.25rem 0;
 `;
 
 let SavedLabel = styled.div`
   font-size: small;
   font-weight: bold;
   color: brown;
-  margin: 0.6em;
-`
+  /* margin: 0.6em; */
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+`;
 
-
-export {
-    SaveButton,
-    SavedLabel
-};
+export { SaveButton, SavedLabel };

--- a/src/articles/SmallSaveArticleButton.sc.js
+++ b/src/articles/SmallSaveArticleButton.sc.js
@@ -2,8 +2,8 @@ import styled from "styled-components";
 
 let SaveButton = styled.button`
   font-size: small;
-  color: orange;
   font-weight: bold;
+  color: orange;
   display: flex;
   align-items: center;
   gap: 0.2rem;
@@ -11,6 +11,7 @@ let SaveButton = styled.button`
   background-color: inherit;
   /* margin: 1rem 0; */
   padding: 0.25rem 0;
+  cursor: pointer;
 `;
 
 let SavedLabel = styled.div`
@@ -21,6 +22,7 @@ let SavedLabel = styled.div`
   display: flex;
   align-items: center;
   gap: 0.2rem;
+  padding: 0.25rem 0;
 `;
 
 export { SaveButton, SavedLabel };

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -24,8 +24,6 @@ const LocalStorage = {
       "audio_experiment_displayed_questionnaire",
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
-    DoNotShowRedirectionNotificationModal_Checkbox:
-      "do_not_show_redirection_notification_modal_checkbox_selected",
     OpenArticleExternallyWithoutModal: "open_article_externally_without_modal",
   },
 
@@ -61,19 +59,6 @@ const LocalStorage = {
   ) {
     localStorage[this.Keys.OpenArticleExternallyWithoutModal] =
       openArticleExternallyWithoutModal;
-  },
-
-  getDoNotShowRedirectionNotificationModal_Checkbox: function () {
-    return localStorage[
-      this.Keys.DoNotShowRedirectionNotificationModal_Checkbox
-    ];
-  },
-
-  setDoNotShowRedirectionNotificationModal_Checkbox: function (
-    doNotShowRedirectionNotificationModal_Checkbox
-  ) {
-    localStorage[this.Keys.DoNotShowRedirectionNotificationModal_Checkbox] =
-      doNotShowRedirectionNotificationModal_Checkbox;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -24,7 +24,8 @@ const LocalStorage = {
       "audio_experiment_displayed_questionnaire",
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
-    ShowRedirectionNotificationModal: "show_redirection_notification_modal",
+    DoNotShowRedirectionNotificationModal:
+      "do_not_show_redirection_notification_modal",
   },
 
   userInfo: function () {
@@ -51,14 +52,14 @@ const LocalStorage = {
   },
 
   getShowRedirectionNotificationModal: function () {
-    return localStorage[this.Keys.ShowRedirectionNotificationModal];
+    return localStorage[this.Keys.DoNotShowRedirectionNotificationModal];
   },
 
   setShowRedirectionNotificationModal: function (
-    showRedirectionNotificationModal
+    doNotShowRedirectionNotificationModal
   ) {
-    localStorage[this.Keys.ShowRedirectionNotificationModal] =
-      showRedirectionNotificationModal;
+    localStorage[this.Keys.DoNotShowRedirectionNotificationModal] =
+      doNotShowRedirectionNotificationModal;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -24,6 +24,7 @@ const LocalStorage = {
       "audio_experiment_displayed_questionnaire",
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
+    ShowRedirectionNotificationModal: "show_redirection_notification_modal",
   },
 
   userInfo: function () {
@@ -47,6 +48,14 @@ const LocalStorage = {
 
   displayedExtensionPopup: function () {
     return localStorage[this.Keys.DisplayedExtensionPopup];
+  },
+
+  getShowRedirectionNotificationModal: function () {
+    return localStorage[this.Keys.ShowRedirectionNotificationModal];
+  },
+
+  setShowRedirectionNotificationModal: function (showRedirectionNotificationModal) {
+    localStorage[this.Keys.ShowRedirectionNotificationModal] = showRedirectionNotificationModal;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -24,8 +24,8 @@ const LocalStorage = {
       "audio_experiment_displayed_questionnaire",
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
-    DoNotShowRedirectionNotificationModal:
-      "do_not_show_redirection_notification_modal_selected",
+    DoNotShowRedirectionNotificationModal_Checkbox:
+      "do_not_show_redirection_notification_modal_checkbox_selected",
     OpenArticleExternallyWithoutModal: "open_article_externally_without_modal",
   },
 
@@ -63,15 +63,17 @@ const LocalStorage = {
       openArticleExternallyWithoutModal;
   },
 
-  getDoNotShowRedirectionNotificationModal: function () {
-    return localStorage[this.Keys.DoNotShowRedirectionNotificationModal];
+  getDoNotShowRedirectionNotificationModal_Checkbox: function () {
+    return localStorage[
+      this.Keys.DoNotShowRedirectionNotificationModal_Checkbox
+    ];
   },
 
-  setDoNotShowRedirectionNotificationModal: function (
-    doNotShowRedirectionNotificationModal
+  setDoNotShowRedirectionNotificationModal_Checkbox: function (
+    doNotShowRedirectionNotificationModal_Checkbox
   ) {
-    localStorage[this.Keys.DoNotShowRedirectionNotificationModal] =
-      doNotShowRedirectionNotificationModal;
+    localStorage[this.Keys.DoNotShowRedirectionNotificationModal_Checkbox] =
+      doNotShowRedirectionNotificationModal_Checkbox;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -24,7 +24,7 @@ const LocalStorage = {
       "audio_experiment_displayed_questionnaire",
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
-    OpenArticleExternallyWithoutModal: "open_article_externally_without_modal",
+    DoNotShowRedirectionModal: "do_not_show_redirection_modal",
   },
 
   userInfo: function () {
@@ -50,15 +50,13 @@ const LocalStorage = {
     return localStorage[this.Keys.DisplayedExtensionPopup];
   },
 
-  getOpenArticleExternallyWithoutModal: function () {
-    return localStorage[this.Keys.OpenArticleExternallyWithoutModal];
+  getDoNotShowRedirectionModal: function () {
+    return localStorage[this.Keys.DoNotShowRedirectionModal];
   },
 
-  setOpenArticleExternallyWithoutModal: function (
-    openArticleExternallyWithoutModal
-  ) {
-    localStorage[this.Keys.OpenArticleExternallyWithoutModal] =
-      openArticleExternallyWithoutModal;
+  setDoNotShowRedirectionModal: function (doNotShowRedirectionModal) {
+    localStorage[this.Keys.DoNotShowRedirectionModal] =
+      doNotShowRedirectionModal;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -26,6 +26,7 @@ const LocalStorage = {
     clickedVideoLink: "clicked_video_link",
     DoNotShowRedirectionNotificationModal:
       "do_not_show_redirection_notification_modal",
+    OpenArticleExternallyWithoutModal: "open_article_externally_without_modal"
   },
 
   userInfo: function () {
@@ -49,6 +50,14 @@ const LocalStorage = {
 
   displayedExtensionPopup: function () {
     return localStorage[this.Keys.DisplayedExtensionPopup];
+  },
+
+  getOpenArticleExternallyWithoutModal: function (){
+    return localStorage[this.Keys.OpenArticleExternallyWithoutModal];
+  },
+
+  setOpenArticleExternallyWithoutModal: function(openArticleExternallyWithoutModal){
+    localStorage[this.Keys.OpenArticleExternallyWithoutModal] = openArticleExternallyWithoutModal;
   },
 
   getDoNotShowRedirectionNotificationModal: function () {

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -51,11 +51,11 @@ const LocalStorage = {
     return localStorage[this.Keys.DisplayedExtensionPopup];
   },
 
-  getShowRedirectionNotificationModal: function () {
+  getDoNotShowRedirectionNotificationModal: function () {
     return localStorage[this.Keys.DoNotShowRedirectionNotificationModal];
   },
 
-  setShowRedirectionNotificationModal: function (
+  setDoNotShowRedirectionNotificationModal: function (
     doNotShowRedirectionNotificationModal
   ) {
     localStorage[this.Keys.DoNotShowRedirectionNotificationModal] =

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -54,8 +54,11 @@ const LocalStorage = {
     return localStorage[this.Keys.ShowRedirectionNotificationModal];
   },
 
-  setShowRedirectionNotificationModal: function (showRedirectionNotificationModal) {
-    localStorage[this.Keys.ShowRedirectionNotificationModal] = showRedirectionNotificationModal;
+  setShowRedirectionNotificationModal: function (
+    showRedirectionNotificationModal
+  ) {
+    localStorage[this.Keys.ShowRedirectionNotificationModal] =
+      showRedirectionNotificationModal;
   },
 
   // Setting info

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -25,8 +25,8 @@ const LocalStorage = {
     TargetNoOfAudioSessions: "audio_target_no_of_sessions",
     clickedVideoLink: "clicked_video_link",
     DoNotShowRedirectionNotificationModal:
-      "do_not_show_redirection_notification_modal",
-    OpenArticleExternallyWithoutModal: "open_article_externally_without_modal"
+      "do_not_show_redirection_notification_modal_selected",
+    OpenArticleExternallyWithoutModal: "open_article_externally_without_modal",
   },
 
   userInfo: function () {
@@ -52,12 +52,15 @@ const LocalStorage = {
     return localStorage[this.Keys.DisplayedExtensionPopup];
   },
 
-  getOpenArticleExternallyWithoutModal: function (){
+  getOpenArticleExternallyWithoutModal: function () {
     return localStorage[this.Keys.OpenArticleExternallyWithoutModal];
   },
 
-  setOpenArticleExternallyWithoutModal: function(openArticleExternallyWithoutModal){
-    localStorage[this.Keys.OpenArticleExternallyWithoutModal] = openArticleExternallyWithoutModal;
+  setOpenArticleExternallyWithoutModal: function (
+    openArticleExternallyWithoutModal
+  ) {
+    localStorage[this.Keys.OpenArticleExternallyWithoutModal] =
+      openArticleExternallyWithoutModal;
   },
 
   getDoNotShowRedirectionNotificationModal: function () {

--- a/src/components/ModalGlobalStyling.sc.js
+++ b/src/components/ModalGlobalStyling.sc.js
@@ -31,7 +31,7 @@ const ModalWrapperGlobal = styled(ModalWrapper)`
 const ModalHeaderGlobal = styled.div`
   margin: 1em 0;
   @media (max-width: 576px) {
-    margin: 0.7em 0;
+    margin: 0.8em 0;
   }
 `;
 
@@ -53,7 +53,7 @@ const ModalBodyGlobal = styled.div`
     object-fit: contain;
   }
   @media (max-width: 576px) {
-    margin: 0.7em 0;
+    margin: 0.8em 0;
   }
 `;
 
@@ -70,7 +70,7 @@ const ModalFooterGlobal = styled.div`
     text-decoration: underline;
   }
   @media (max-width: 576px) {
-    margin: 0.7em 0;
+    margin: 0.8em 0;
   }
 `;
 
@@ -94,5 +94,5 @@ export {
   ModalHeaderGlobal,
   ModalBodyGlobal,
   ModalFooterGlobal,
-  ModalStrongTextWrapperGlobal
+  ModalStrongTextWrapperGlobal,
 };

--- a/src/components/ModalGlobalStyling.sc.js
+++ b/src/components/ModalGlobalStyling.sc.js
@@ -65,6 +65,10 @@ const CloseButtonGlobal = styled.div`
   float: right;
   right: 16px;
   margin-top: -16px;
+  @media (max-width: 576px) {
+    right: 16px;
+    margin-top: -8px;
+  }
 `;
 
 export {

--- a/src/components/ModalGlobalStyling.sc.js
+++ b/src/components/ModalGlobalStyling.sc.js
@@ -8,9 +8,11 @@ const ModalWrapperGlobal = styled(ModalWrapper)`
     font-size: 1.3em;
     line-height: 150%;
     text-align: center;
+    font-weight: 700;
     margin: 0;
     @media (max-width: 576px) {
       text-align: left;
+      font-size: 1.2em;
     }
   }
 
@@ -28,6 +30,15 @@ const ModalWrapperGlobal = styled(ModalWrapper)`
 
 const ModalHeaderGlobal = styled.div`
   margin: 1em 0;
+  @media (max-width: 576px) {
+    margin: 0.7em 0;
+  }
+`;
+
+const ModalStrongTextWrapperGlobal = styled.div`
+  margin: 0;
+  display: inline;
+  font-weight: 700;
 `;
 
 const ModalBodyGlobal = styled.div`
@@ -40,6 +51,9 @@ const ModalBodyGlobal = styled.div`
     height: 100%;
     width: 100%;
     object-fit: contain;
+  }
+  @media (max-width: 576px) {
+    margin: 0.7em 0;
   }
 `;
 
@@ -54,6 +68,9 @@ const ModalFooterGlobal = styled.div`
   }
   a:hover {
     text-decoration: underline;
+  }
+  @media (max-width: 576px) {
+    margin: 0.7em 0;
   }
 `;
 
@@ -77,4 +94,5 @@ export {
   ModalHeaderGlobal,
   ModalBodyGlobal,
   ModalFooterGlobal,
+  ModalStrongTextWrapperGlobal
 };

--- a/src/components/ModalGlobalStyling.sc.js
+++ b/src/components/ModalGlobalStyling.sc.js
@@ -35,7 +35,7 @@ const ModalHeaderGlobal = styled.div`
   }
 `;
 
-const ModalStrongTextWrapperGlobal = styled.div`
+const ModalStrongTextWrapperGlobal = styled.span`
   margin: 0;
   display: inline;
   font-weight: 700;

--- a/src/components/ModalWrapper.sc.js
+++ b/src/components/ModalWrapper.sc.js
@@ -26,7 +26,7 @@ const ModalWrapper = styled(Box)`
   }
 
   @media (max-width: 576px) {
-    padding: 32px 24px;
+    padding: 24px 24px;
     width: 80%;
   }
 `;

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -1,0 +1,9 @@
+import * as s from "./RedirectionNotificationModal.sc";
+
+export default function RedirectionNotificationForDesktop(props) {
+  return (
+    <s.ModalWrapper>
+      <div>Hello from Redirection Notification For Desktop</div>
+    </s.ModalWrapper>
+  );
+}

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -1,24 +1,40 @@
+import { useState } from "react";
 import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop({
-  toggleRedirectionCheckboxSelection,
-  selectedDoNotShowRedirectionModal_Checkbox,
-  setSelectedDoNotShowRedirectionModal_Checkbox,
   article,
   handleModalVisibilityPreferences,
   handleCloseRedirectionModal,
+  setDoNotShowRedirectionModal_UserPreference,
 }) {
-  function handleCloseAndSavePreferences() {
+  const [
+    selectedDoNotShowRedirectionModal_Checkbox,
+    setSelectedDoNotShowRedirectionModal_Checkbox,
+  ] = useState(false);
+
+  function toggleRedirectionCheckboxSelection() {
+    setSelectedDoNotShowRedirectionModal_Checkbox(
+      !selectedDoNotShowRedirectionModal_Checkbox
+    );
+  }
+
+  //saves modal visibility preferences to the Local Storage
+  function handleModalVisibilityPreferences() {
+    selectedDoNotShowRedirectionModal_Checkbox === true
+      ? setDoNotShowRedirectionModal_UserPreference(true)
+      : setDoNotShowRedirectionModal_UserPreference(false);
+  }
+
+  function handleCloseAndSaveVisibilityPreferences() {
     handleModalVisibilityPreferences();
     handleCloseRedirectionModal();
   }
 
-  //reset checkbox state if the user closes modal without saving their preferences
-  //so that they don't reenter to to pre-checked checkbox
+  //when user exits modal by clicking "X" without saving anything
   function handleCloseWithoutSavingVisibilityPreferences() {
     handleCloseRedirectionModal();
-    setSelectedDoNotShowRedirectionModal_Checkbox(false);
+    setSelectedDoNotShowRedirectionModal_Checkbox(false); //to avoid prechecked checkboxes
   }
 
   return (
@@ -77,7 +93,7 @@ export default function RedirectionNotificationForDesktop({
                 to the article, saves visibility preferences of the modal and closes it */}
           <s.GoToArticleButton
             role="button"
-            onClick={handleCloseAndSavePreferences}
+            onClick={handleCloseAndSaveVisibilityPreferences}
           >
             Enter the article's website
           </s.GoToArticleButton>

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -6,11 +6,11 @@ export default function RedirectionNotificationForDesktop({
   selectedDoNotShowRedirectionModal_Checkbox,
   article,
   handleModalVisibilityPreferences,
-  handleClose,
+  handleCloseRedirectionModal,
 }) {
   function handleCloseAndSavePreferences() {
     handleModalVisibilityPreferences();
-    handleClose();
+    handleCloseRedirectionModal();
   }
 
   return (
@@ -75,7 +75,7 @@ export default function RedirectionNotificationForDesktop({
           </s.GoToArticleButton>
         </a>
       </s.Footer>
-      <s.CloseButton role="button" onClick={handleClose}>
+      <s.CloseButton role="button" onClick={handleCloseRedirectionModal}>
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
     </>

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -2,7 +2,7 @@ import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop({
-  handleVisibilityCheckboxSelection,
+  toggleRedirectionCheckboxSelection,
   selectedDoNotShowRedirectionModal,
   article,
   handleModalUse,
@@ -55,7 +55,7 @@ export default function RedirectionNotificationForDesktop({
       <s.Footer>
         <s.CheckboxWrapper>
           <input
-            onChange={handleVisibilityCheckboxSelection}
+            onChange={toggleRedirectionCheckboxSelection}
             checked={selectedDoNotShowRedirectionModal}
             type="checkbox"
             id="checkbox"

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -1,41 +1,13 @@
-import { useState } from "react";
 import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop({
   article,
-  handleCloseRedirectionModal,
-  setDoNotShowRedirectionModal_UserPreference,
+  toggleRedirectionCheckboxSelection,
+  selectedDoNotShowRedirectionModal_Checkbox,
+  handleCloseAndSaveVisibilityPreferences,
+  handleCloseWithoutSavingVisibilityPreferences,
 }) {
-  const [
-    selectedDoNotShowRedirectionModal_Checkbox,
-    setSelectedDoNotShowRedirectionModal_Checkbox,
-  ] = useState(false);
-
-  function toggleRedirectionCheckboxSelection() {
-    setSelectedDoNotShowRedirectionModal_Checkbox(
-      !selectedDoNotShowRedirectionModal_Checkbox
-    );
-  }
-
-  //saves modal visibility preferences to the Local Storage
-  function handleModalVisibilityPreferences() {
-    selectedDoNotShowRedirectionModal_Checkbox === true
-      ? setDoNotShowRedirectionModal_UserPreference(true)
-      : setDoNotShowRedirectionModal_UserPreference(false);
-  }
-
-  function handleCloseAndSaveVisibilityPreferences() {
-    handleModalVisibilityPreferences();
-    handleCloseRedirectionModal();
-  }
-
-  //when user exits modal by clicking "X"
-  function handleCloseWithoutSavingVisibilityPreferences() {
-    handleCloseRedirectionModal();
-    setSelectedDoNotShowRedirectionModal_Checkbox(false); //to avoid prechecked checkboxes
-  }
-
   return (
     <>
       <s.Header>

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -4,7 +4,6 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop({
   article,
-  handleModalVisibilityPreferences,
   handleCloseRedirectionModal,
   setDoNotShowRedirectionModal_UserPreference,
 }) {
@@ -31,7 +30,7 @@ export default function RedirectionNotificationForDesktop({
     handleCloseRedirectionModal();
   }
 
-  //when user exits modal by clicking "X" without saving anything
+  //when user exits modal by clicking "X"
   function handleCloseWithoutSavingVisibilityPreferences() {
     handleCloseRedirectionModal();
     setSelectedDoNotShowRedirectionModal_Checkbox(false); //to avoid prechecked checkboxes

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -4,6 +4,7 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 export default function RedirectionNotificationForDesktop({
   toggleRedirectionCheckboxSelection,
   selectedDoNotShowRedirectionModal_Checkbox,
+  setSelectedDoNotShowRedirectionModal_Checkbox,
   article,
   handleModalVisibilityPreferences,
   handleCloseRedirectionModal,
@@ -11,6 +12,13 @@ export default function RedirectionNotificationForDesktop({
   function handleCloseAndSavePreferences() {
     handleModalVisibilityPreferences();
     handleCloseRedirectionModal();
+  }
+
+  //reset checkbox state if the user closes modal without saving their preferences
+  //so that they don't reenter to to pre-checked checkbox
+  function handleCloseWithoutSavingVisibilityPreferences() {
+    handleCloseRedirectionModal();
+    setSelectedDoNotShowRedirectionModal_Checkbox(false);
   }
 
   return (
@@ -75,7 +83,10 @@ export default function RedirectionNotificationForDesktop({
           </s.GoToArticleButton>
         </a>
       </s.Footer>
-      <s.CloseButton role="button" onClick={handleCloseRedirectionModal}>
+      <s.CloseButton
+        role="button"
+        onClick={handleCloseWithoutSavingVisibilityPreferences}
+      >
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
     </>

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -5,11 +5,11 @@ export default function RedirectionNotificationForDesktop({
   toggleRedirectionCheckboxSelection,
   selectedDoNotShowRedirectionModal_Checkbox,
   article,
-  handleModalUse,
+  handleModalVisibilityPreferences,
   handleClose,
 }) {
   function handleCloseAndSavePreferences() {
-    handleModalUse();
+    handleModalVisibilityPreferences();
     handleClose();
   }
 

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -46,8 +46,9 @@ export default function RedirectionNotificationForDesktop({
       </s.Header>
       <s.Body>
         <p>
-          <strong>Once there</strong>, find and{" "}
-          <strong>
+          <s.ModalStrongTextWrapper>Once there</s.ModalStrongTextWrapper>, find
+          and{" "}
+          <s.ModalStrongTextWrapper>
             click The Zeeguu Reader{" "}
             <s.Icon>
               <img
@@ -57,7 +58,7 @@ export default function RedirectionNotificationForDesktop({
               ></img>
             </s.Icon>{" "}
             icon
-          </strong>{" "}
+          </s.ModalStrongTextWrapper>{" "}
           in the top right corner of&nbsp;your browser's toolbar
           or&nbsp;on&nbsp;the&nbsp;list of your installed extensions{" "}
           <s.Icon>
@@ -67,7 +68,11 @@ export default function RedirectionNotificationForDesktop({
               src="../static/images/puzzle.svg"
             ></img>
           </s.Icon>
-          . <strong>Then&nbsp;select Read Article</strong>.
+          .{" "}
+          <s.ModalStrongTextWrapper>
+            Then&nbsp;select Read Article
+          </s.ModalStrongTextWrapper>
+          .
         </p>
         <img
           className="fullDivWidthImage"

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -3,7 +3,7 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop({
   toggleRedirectionCheckboxSelection,
-  selectedDoNotShowRedirectionModal,
+  selectedDoNotShowRedirectionModal_Checkbox,
   article,
   handleModalUse,
   handleClose,
@@ -56,7 +56,7 @@ export default function RedirectionNotificationForDesktop({
         <s.CheckboxWrapper>
           <input
             onChange={toggleRedirectionCheckboxSelection}
-            checked={selectedDoNotShowRedirectionModal}
+            checked={selectedDoNotShowRedirectionModal_Checkbox}
             type="checkbox"
             id="checkbox"
             name=""

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -1,7 +1,18 @@
 import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
-export default function RedirectionNotificationForDesktop(props) {
+export default function RedirectionNotificationForDesktop({
+  handleVisibilityCheckboxSelection,
+  selectedDoNotShowRedirectionModal,
+  article,
+  handleModalUse,
+  handleClose,
+}) {
+  function handleCloseAndSavePreferences() {
+    handleModalUse();
+    handleClose();
+  }
+
   return (
     <>
       <s.Header>
@@ -44,8 +55,8 @@ export default function RedirectionNotificationForDesktop(props) {
       <s.Footer>
         <s.CheckboxWrapper>
           <input
-            onChange={props.handleVisibilityCheckboxSelection}
-            checked={props.selectedDoNotShowRedirectionModal}
+            onChange={handleVisibilityCheckboxSelection}
+            checked={selectedDoNotShowRedirectionModal}
             type="checkbox"
             id="checkbox"
             name=""
@@ -53,18 +64,18 @@ export default function RedirectionNotificationForDesktop(props) {
           ></input>{" "}
           <label htmlFor="checkbox">Don't show this message</label>
         </s.CheckboxWrapper>
-        <a target="_blank" rel="noreferrer" href={props.article.url}>
+        <a target="_blank" rel="noreferrer" href={article.url}>
           {/* Clicking the GoToArticleButton button sends the reader
                 to the article, saves visibility preferences of the modal and closes it */}
           <s.GoToArticleButton
             role="button"
-            onClick={props.handleCloseAndSavePreferences}
+            onClick={handleCloseAndSavePreferences}
           >
             Enter the article's website
           </s.GoToArticleButton>
         </a>
       </s.Footer>
-      <s.CloseButton role="button" onClick={props.handleClose}>
+      <s.CloseButton role="button" onClick={handleClose}>
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
     </>

--- a/src/components/RedirectionNotificationForDesktop.js
+++ b/src/components/RedirectionNotificationForDesktop.js
@@ -1,9 +1,72 @@
 import * as s from "./RedirectionNotificationModal.sc";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export default function RedirectionNotificationForDesktop(props) {
   return (
-    <s.ModalWrapper>
-      <div>Hello from Redirection Notification For Desktop</div>
-    </s.ModalWrapper>
+    <>
+      <s.Header>
+        <h1>
+          You are ready to&nbsp;continue<br></br>
+          to the original article's website
+        </h1>
+      </s.Header>
+      <s.Body>
+        <p>
+          <strong>Once there</strong>, find and{" "}
+          <strong>
+            click The Zeeguu Reader{" "}
+            <s.Icon>
+              <img
+                className="fullDivWidthImage"
+                alt=""
+                src="../static/images/zeeguuLogo.svg"
+              ></img>
+            </s.Icon>{" "}
+            icon
+          </strong>{" "}
+          in the top right corner of&nbsp;your browser's toolbar
+          or&nbsp;on&nbsp;the&nbsp;list of your installed extensions{" "}
+          <s.Icon>
+            <img
+              className="fullDivWidthImage"
+              alt=""
+              src="../static/images/puzzle.svg"
+            ></img>
+          </s.Icon>
+          . <strong>Then&nbsp;select Read Article</strong>.
+        </p>
+        <img
+          className="fullDivWidthImage"
+          src={"../static/images/find-extension.png"}
+          alt="Zeeguu browser extension"
+        />
+      </s.Body>
+      <s.Footer>
+        <s.CheckboxWrapper>
+          <input
+            onChange={props.handleVisibilityCheckboxSelection}
+            checked={props.selectedDoNotShowRedirectionModal}
+            type="checkbox"
+            id="checkbox"
+            name=""
+            value=""
+          ></input>{" "}
+          <label htmlFor="checkbox">Don't show this message</label>
+        </s.CheckboxWrapper>
+        <a target="_blank" rel="noreferrer" href={props.article.url}>
+          {/* Clicking the GoToArticleButton button sends the reader
+                to the article, saves visibility preferences of the modal and closes it */}
+          <s.GoToArticleButton
+            role="button"
+            onClick={props.handleCloseAndSavePreferences}
+          >
+            Enter the article's website
+          </s.GoToArticleButton>
+        </a>
+      </s.Footer>
+      <s.CloseButton role="button" onClick={props.handleClose}>
+        <CloseRoundedIcon fontSize="medium" />
+      </s.CloseButton>
+    </>
   );
 }

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -36,14 +36,13 @@ export default function RedirectionNotificationForMobile({
       <s.Body>
         <p>
           If you want to read articles on your mobile device using Zeeguu, just
-          tap on the
+          tap on&nbsp;the
           <s.ModalStrongTextWrapper> Save </s.ModalStrongTextWrapper> button
-          below the article's title or click
+          below the article's title or&nbsp;click
           <s.ModalStrongTextWrapper>
             {" "}
-            Save to Zeeguu
+            Add to Saves.
           </s.ModalStrongTextWrapper>{" "}
-          to add it to your Saves.
         </p>
       </s.Body>
       <s.CloseButton
@@ -64,21 +63,23 @@ export default function RedirectionNotificationForMobile({
           ></input>{" "}
           <label htmlFor="checkbox">Don't show this message</label>
         </s.CheckboxWrapper>
-        <a target="_self" rel="noreferrer" href={article.url}>
-          <s.GoToArticleButton
+        <s.ButtonContainer>
+          <a target="_self" rel="noreferrer" href={article.url}>
+            <s.GoToArticleButton
+              role="button"
+              onClick={handleGoToArticleAndCloseModal}
+            >
+              Enter the article's website
+            </s.GoToArticleButton>
+          </a>
+          <s.SaveArticleButton
             role="button"
-            onClick={handleGoToArticleAndCloseModal}
+            onClick={handleSaveArticleAndCloseModal}
           >
-            Enter the article's website
-          </s.GoToArticleButton>
-        </a>
-        <s.SaveArticleButton
-          role="button"
-          onClick={handleSaveArticleAndCloseModal}
-        >
-          <BookmarkBorderIcon fontSize="small" />
-          Save to Zeeguu
-        </s.SaveArticleButton>
+            <BookmarkBorderIcon fontSize="small" />
+            Add to Saves
+          </s.SaveArticleButton>
+        </s.ButtonContainer>
       </s.Footer>
     </>
   );

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -2,7 +2,26 @@ import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import { Link } from "react-router-dom/cjs/react-router-dom";
 
-export default function RedirectionNotificationForMobile(props) {
+export default function RedirectionNotificationForMobile({
+  api,
+  article,
+  handleClose,
+  setIsArticleSaved,
+}) {
+  function handleSaveArticle() {
+    api.makePersonalCopy(article.id, (data) => {
+      if (data === "OK") {
+        setIsArticleSaved(true);
+      }
+    });
+  }
+
+  function handleSaveAndOpenArticle() {
+    handleSaveArticle();
+    // handleModalUse(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
+    handleClose();
+  }
+
   return (
     <>
       <s.Header>
@@ -16,7 +35,7 @@ export default function RedirectionNotificationForMobile(props) {
           <strong> Save and view the article</strong> to add it to your Saves.
         </p>
       </s.Body>
-      <s.CloseButton role="button" onClick={props.handleClose}>
+      <s.CloseButton role="button" onClick={handleClose}>
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
       <s.Footer>
@@ -26,11 +45,8 @@ export default function RedirectionNotificationForMobile(props) {
               on mobile only when target="_blank". This issue didn't occur
               on the desktop and for regular <a> links. Needs further investigation
               if we want this functionality here  */}
-        <Link to={`/read/article?id=${props.article.id}`}>
-          <s.GoToArticleButton
-            role="button"
-            onClick={props.handleSaveAndOpenArticle}
-          >
+        <Link to={`/read/article?id=${article.id}`}>
+          <s.GoToArticleButton role="button" onClick={handleSaveAndOpenArticle}>
             Save and view the article
           </s.GoToArticleButton>
         </Link>

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -5,8 +5,11 @@ import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 export default function RedirectionNotificationForMobile({
   api,
   article,
-  handleCloseRedirectionModal,
   setIsArticleSaved,
+  toggleRedirectionCheckboxSelection,
+  selectedDoNotShowRedirectionModal_Checkbox,
+  handleCloseAndSaveVisibilityPreferences,
+  handleCloseWithoutSavingVisibilityPreferences,
 }) {
   function handleSaveArticle() {
     api.makePersonalCopy(article.id, (data) => {
@@ -18,7 +21,11 @@ export default function RedirectionNotificationForMobile({
 
   function handleSaveArticleAndCloseModal() {
     handleSaveArticle();
-    handleCloseRedirectionModal();
+    handleCloseAndSaveVisibilityPreferences();
+  }
+
+  function handleGoToArticleAndCloseModal() {
+    handleCloseAndSaveVisibilityPreferences();
   }
 
   return (
@@ -39,14 +46,28 @@ export default function RedirectionNotificationForMobile({
           to add it to your Saves.
         </p>
       </s.Body>
-      <s.CloseButton role="button" onClick={handleCloseRedirectionModal}>
+      <s.CloseButton
+        role="button"
+        onClick={handleCloseWithoutSavingVisibilityPreferences}
+      >
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
       <s.Footer>
+        <s.CheckboxWrapper>
+          <input
+            onChange={toggleRedirectionCheckboxSelection}
+            checked={selectedDoNotShowRedirectionModal_Checkbox}
+            type="checkbox"
+            id="checkbox"
+            name=""
+            value=""
+          ></input>{" "}
+          <label htmlFor="checkbox">Don't show this message</label>
+        </s.CheckboxWrapper>
         <a target="_self" rel="noreferrer" href={article.url}>
           <s.GoToArticleButton
             role="button"
-            onClick={handleCloseRedirectionModal}
+            onClick={handleGoToArticleAndCloseModal}
           >
             Enter the article's website
           </s.GoToArticleButton>

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -30,8 +30,13 @@ export default function RedirectionNotificationForMobile({
         <p>
           If you want to read articles on your mobile device using Zeeguu, just
           tap on the
-          <strong> Save </strong> button below the article's title or click
-          <strong> Save and view the article</strong> to add it to your Saves.
+          <s.ModalStrongTextWrapper> Save </s.ModalStrongTextWrapper> button
+          below the article's title or click
+          <s.ModalStrongTextWrapper>
+            {" "}
+            Save and view the article
+          </s.ModalStrongTextWrapper>{" "}
+          to add it to your Saves.
         </p>
       </s.Body>
       <s.CloseButton role="button" onClick={handleCloseRedirectionModal}>

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -35,14 +35,12 @@ export default function RedirectionNotificationForMobile({
       </s.Header>
       <s.Body>
         <p>
-          If you want to read articles on your mobile device using Zeeguu, just
-          tap on&nbsp;the
-          <s.ModalStrongTextWrapper> Save </s.ModalStrongTextWrapper> button
-          below the article's title or&nbsp;click
+          If you want to read article recommendations on your mobile device
+          using Zeeguu, you need to save them by clicking the&nbsp;
           <s.ModalStrongTextWrapper>
-            {" "}
-            Add to Saves.
+            Add&nbsp;to&nbsp;Saves
           </s.ModalStrongTextWrapper>{" "}
+          button.
         </p>
       </s.Body>
       <s.CloseButton

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -1,6 +1,6 @@
 import * as s from "./RedirectionNotificationModal.sc";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
-import { Link } from "react-router-dom/cjs/react-router-dom";
+import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 
 export default function RedirectionNotificationForMobile({
   api,
@@ -16,7 +16,7 @@ export default function RedirectionNotificationForMobile({
     });
   }
 
-  function handleSaveAndOpenArticle() {
+  function handleSaveArticleAndCloseModal() {
     handleSaveArticle();
     handleCloseRedirectionModal();
   }
@@ -34,7 +34,7 @@ export default function RedirectionNotificationForMobile({
           below the article's title or click
           <s.ModalStrongTextWrapper>
             {" "}
-            Save and view the article
+            Save to Zeeguu
           </s.ModalStrongTextWrapper>{" "}
           to add it to your Saves.
         </p>
@@ -43,11 +43,21 @@ export default function RedirectionNotificationForMobile({
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
       <s.Footer>
-        <Link to={`/read/article?id=${article.id}`}>
-          <s.GoToArticleButton role="button" onClick={handleSaveAndOpenArticle}>
-            Save and view the article
+        <a target="_self" rel="noreferrer" href={article.url}>
+          <s.GoToArticleButton
+            role="button"
+            onClick={handleCloseRedirectionModal}
+          >
+            Enter the article's website
           </s.GoToArticleButton>
-        </Link>
+        </a>
+        <s.SaveArticleButton
+          role="button"
+          onClick={handleSaveArticleAndCloseModal}
+        >
+          <BookmarkBorderIcon fontSize="small" />
+          Save to Zeeguu
+        </s.SaveArticleButton>
       </s.Footer>
     </>
   );

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -1,9 +1,40 @@
 import * as s from "./RedirectionNotificationModal.sc";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { Link } from "react-router-dom/cjs/react-router-dom";
 
 export default function RedirectionNotificationForMobile(props) {
   return (
-    <s.ModalWrapper>
-      <div>Hello from Redirection Notification For Mobile</div>
-    </s.ModalWrapper>
+    <>
+      <s.Header>
+        <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>
+      </s.Header>
+      <s.Body>
+        <p>
+          If you want to read articles on your mobile device using Zeeguu, just
+          tap on the
+          <strong> Save </strong> button below the article's title or click
+          <strong> Save and view the article</strong> to add it to your Saves.
+        </p>
+      </s.Body>
+      <s.CloseButton role="button" onClick={props.handleClose}>
+        <CloseRoundedIcon fontSize="medium" />
+      </s.CloseButton>
+      <s.Footer>
+        {/* "Do not show this message" option temporarily not
+              implemented here as the function handleModalUse() within
+              handleSaveAndOpenArticle() seems to fully work with React Link
+              on mobile only when target="_blank". This issue didn't occur
+              on the desktop and for regular <a> links. Needs further investigation
+              if we want this functionality here  */}
+        <Link to={`/read/article?id=${props.article.id}`}>
+          <s.GoToArticleButton
+            role="button"
+            onClick={props.handleSaveAndOpenArticle}
+          >
+            Save and view the article
+          </s.GoToArticleButton>
+        </Link>
+      </s.Footer>
+    </>
   );
 }

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -18,7 +18,6 @@ export default function RedirectionNotificationForMobile({
 
   function handleSaveAndOpenArticle() {
     handleSaveArticle();
-    // handleModalVisibilityPreferences(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
     handleCloseRedirectionModal();
   }
 
@@ -39,12 +38,6 @@ export default function RedirectionNotificationForMobile({
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
       <s.Footer>
-        {/* "Do not show this message" option temporarily not
-              implemented here as the function handleModalUse() within
-              handleSaveAndOpenArticle() seems to fully work with React Link
-              on mobile only when target="_blank". This issue didn't occur
-              on the desktop and for regular <a> links. Needs further investigation
-              if we want this functionality here  */}
         <Link to={`/read/article?id=${article.id}`}>
           <s.GoToArticleButton role="button" onClick={handleSaveAndOpenArticle}>
             Save and view the article

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -35,9 +35,10 @@ export default function RedirectionNotificationForMobile({
       </s.Header>
       <s.Body>
         <p>
-          If you want to read article recommendations on your mobile device
-          using Zeeguu, you need to save them by clicking the&nbsp;
+          If you want to read articles with the help of Zeeguu on your mobile
+          device, you need to save them first by clicking the
           <s.ModalStrongTextWrapper>
+            {" "}
             Add&nbsp;to&nbsp;Saves
           </s.ModalStrongTextWrapper>{" "}
           button.

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -1,0 +1,9 @@
+import * as s from "./RedirectionNotificationModal.sc";
+
+export default function RedirectionNotificationForMobile(props) {
+  return (
+    <s.ModalWrapper>
+      <div>Hello from Redirection Notification For Mobile</div>
+    </s.ModalWrapper>
+  );
+}

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -18,7 +18,7 @@ export default function RedirectionNotificationForMobile({
 
   function handleSaveAndOpenArticle() {
     handleSaveArticle();
-    // handleModalUse(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
+    // handleModalVisibilityPreferences(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
     handleClose();
   }
 

--- a/src/components/RedirectionNotificationForMobile.js
+++ b/src/components/RedirectionNotificationForMobile.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom/cjs/react-router-dom";
 export default function RedirectionNotificationForMobile({
   api,
   article,
-  handleClose,
+  handleCloseRedirectionModal,
   setIsArticleSaved,
 }) {
   function handleSaveArticle() {
@@ -19,7 +19,7 @@ export default function RedirectionNotificationForMobile({
   function handleSaveAndOpenArticle() {
     handleSaveArticle();
     // handleModalVisibilityPreferences(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
-    handleClose();
+    handleCloseRedirectionModal();
   }
 
   return (
@@ -35,7 +35,7 @@ export default function RedirectionNotificationForMobile({
           <strong> Save and view the article</strong> to add it to your Saves.
         </p>
       </s.Body>
-      <s.CloseButton role="button" onClick={handleClose}>
+      <s.CloseButton role="button" onClick={handleCloseRedirectionModal}>
         <CloseRoundedIcon fontSize="medium" />
       </s.CloseButton>
       <s.Footer>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -28,7 +28,7 @@ export default function RedirectionNotificationModal({
 
   //saves modal visibility preferences to the Local Storage
   //ideally shared by mobile and desktop variant
-  //temporarily not working on mobile
+  //temporarily not working on mobileg
   function handleModalVisibilityPreferences() {
     selectedDoNotShowRedirectionModal_Checkbox === true
       ? setDoNotShowRedirectionModal_UserPreference(true)
@@ -45,6 +45,9 @@ export default function RedirectionNotificationModal({
             }
             selectedDoNotShowRedirectionModal_Checkbox={
               selectedDoNotShowRedirectionModal_Checkbox
+            }
+            setSelectedDoNotShowRedirectionModal_Checkbox={
+              setSelectedDoNotShowRedirectionModal_Checkbox
             }
             article={article}
             handleModalVisibilityPreferences={handleModalVisibilityPreferences}

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -54,6 +54,15 @@ export default function RedirectionNotificationModal({
           />
         </s.Body>
         <s.Footer>
+          <label for="checkbox">
+            <input
+              type="checkbox"
+              id="checkbox"
+              name="noshow"
+              value="Do not show again"
+            ></input>{" "}
+            Don't show this again
+          </label>
           <a target="_blank" rel="noreferrer" href={article.url}>
             {/* Clicking the GoToArticleButton button sends the reader
                 to the article and closes the modal so that when the user

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,5 +1,4 @@
 import Modal from "@mui/material/Modal";
-import { useState } from "react";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
 import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -15,10 +15,22 @@ export default function RedirectionNotificationModal({
   handleClose,
   setCheckboxChecked,
   checkboxChecked,
+  setUseModal,
 }) {
   //toggle checkbox state
   function handleChecked() {
     setCheckboxChecked(!checkboxChecked);
+  }
+
+  function handleUseModal(){
+    if (checkboxChecked === true){
+      setUseModal(true)
+    } else setUseModal(false)
+  }
+
+  function handleClosed(){
+    handleUseModal()
+    handleClose()
   }
   return (
     <Modal open={open} onClose={handleClose}>
@@ -78,7 +90,7 @@ export default function RedirectionNotificationModal({
                 to the article and closes the modal so that when the user
                 returns to the Zeeguu app home page, they can see the recommendation
                 list instead of the modal still being open */}
-            <s.GoToArticleButton role="button" onClick={handleClose}>
+            <s.GoToArticleButton role="button" onClick={handleClosed}>
               Enter the article's website
             </s.GoToArticleButton>
           </a>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -13,24 +13,24 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  setCheckboxChecked,
-  checkboxChecked,
-  setUseModal,
+  setSelectedDoNotShowRedirectionModal,
+  selectedDoNotShowRedirectionModal,
+  setOpenedExternallyWithoutModal,
 }) {
   //toggle checkbox state
-  function handleChecked() {
-    setCheckboxChecked(!checkboxChecked);
+  function handleVisibilitySettings() {
+    setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
 
-  function handleUseModal(){
-    if (checkboxChecked === true){
-      setUseModal(true)
-    } else setUseModal(false)
+  function handleModalUse() {
+    selectedDoNotShowRedirectionModal === true
+      ? setOpenedExternallyWithoutModal(true)
+      : setOpenedExternallyWithoutModal(false);
   }
 
-  function handleClosed(){
-    handleUseModal()
-    handleClose()
+  function handleCloseAndSavePreferences() {
+    handleModalUse();
+    handleClose();
   }
   return (
     <Modal open={open} onClose={handleClose}>
@@ -76,8 +76,8 @@ export default function RedirectionNotificationModal({
         <s.Footer>
           <s.CheckboxWrapper>
             <input
-              onChange={handleChecked}
-              checked={checkboxChecked}
+              onChange={handleVisibilitySettings}
+              checked={selectedDoNotShowRedirectionModal}
               type="checkbox"
               id="checkbox"
               name=""
@@ -90,7 +90,10 @@ export default function RedirectionNotificationModal({
                 to the article and closes the modal so that when the user
                 returns to the Zeeguu app home page, they can see the recommendation
                 list instead of the modal still being open */}
-            <s.GoToArticleButton role="button" onClick={handleClosed}>
+            <s.GoToArticleButton
+              role="button"
+              onClick={handleCloseAndSavePreferences}
+            >
               Enter the article's website
             </s.GoToArticleButton>
           </a>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -14,13 +14,13 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  selectedDoNotShowRedirectionModal_Checkbox, //related to the "Do not show" checkbox selection
-  setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
+  selectedDoNotShowRedirectionModal_Checkbox, 
+  setSelectedDoNotShowRedirectionModal_Checkbox, 
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
   setIsArticleSaved, // related to the article's state
 }) {
   function toggleRedirectionCheckboxSelection() {
-    setSelectedDoNotShowRedirectionModal(
+    setSelectedDoNotShowRedirectionModal_Checkbox(
       !selectedDoNotShowRedirectionModal_Checkbox
     );
   }

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -23,6 +23,7 @@ export default function RedirectionNotificationModal({
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
 
+  //saves modal visibility preferences to the Local Storage
   function handleModalUse() {
     selectedDoNotShowRedirectionModal === true
       ? setOpenedExternallyWithoutModal(true)
@@ -42,14 +43,15 @@ export default function RedirectionNotificationModal({
     });
   }
 
-  function handleCloseMobile() {
+  function handleSaveAndOpenArticle() {
     handleSaveArticle();
+    // handleModalUse(); //Temporarily disabled for this function as it worked only when <Link> had its target set to _blank
     handleClose();
   }
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
-        {isMobile() === false ? (
+        {!isMobile() ? (
           // Displayed to the users who access Zeeguu from desktop browsers
           <>
             <s.Header>
@@ -103,9 +105,7 @@ export default function RedirectionNotificationModal({
               </s.CheckboxWrapper>
               <a target="_blank" rel="noreferrer" href={article.url}>
                 {/* Clicking the GoToArticleButton button sends the reader
-                to the article and closes the modal so that when the user
-                returns to the Zeeguu app home page, they can see the recommendation
-                list instead of the modal still being open */}
+                to the article, saves visibility preferences of the modal and closes it */}
                 <s.GoToArticleButton
                   role="button"
                   onClick={handleCloseAndSavePreferences}
@@ -137,9 +137,17 @@ export default function RedirectionNotificationModal({
               <CloseRoundedIcon fontSize="medium" />
             </s.CloseButton>
             <s.Footer>
-              {/* Saves the article and opens internally */}
+              {/* "Do not show this message" option temporarily not
+              implemented here as the function handleModalUse() within
+              handleSaveAndOpenArticle() seems to fully work with React Link
+              on mobile only when target="_blank". This issue didn't occur
+              on the desktop and for regular <a> links. Needs further investigation
+              if we want this functionality here  */}
               <Link to={`/read/article?id=${article.id}`}>
-                <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
+                <s.GoToArticleButton
+                  role="button"
+                  onClick={handleSaveAndOpenArticle}
+                >
                   Save and view the article
                 </s.GoToArticleButton>
               </Link>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,4 +1,5 @@
 import Modal from "@mui/material/Modal";
+import { useState } from "react";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
 import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";
@@ -14,19 +15,68 @@ export default function RedirectionNotificationModal({
   setDoNotShowRedirectionModal_UserPreference,
   setIsArticleSaved, // related to the article's state
 }) {
+  const [
+    selectedDoNotShowRedirectionModal_Checkbox,
+    setSelectedDoNotShowRedirectionModal_Checkbox,
+  ] = useState(false);
+
+  function toggleRedirectionCheckboxSelection() {
+    setSelectedDoNotShowRedirectionModal_Checkbox(
+      !selectedDoNotShowRedirectionModal_Checkbox
+    );
+  }
+
+  function handleModalVisibilityPreferences() {
+    selectedDoNotShowRedirectionModal_Checkbox === true
+      ? setDoNotShowRedirectionModal_UserPreference(true)
+      : setDoNotShowRedirectionModal_UserPreference(false);
+  }
+
+  function handleCloseAndSaveVisibilityPreferences() {
+    handleModalVisibilityPreferences();
+    handleCloseRedirectionModal();
+  }
+
+  //when user exits modal by clicking "X"
+  function handleCloseWithoutSavingVisibilityPreferences() {
+    handleCloseRedirectionModal();
+    setSelectedDoNotShowRedirectionModal_Checkbox(false); //to avoid prechecked checkboxes
+  }
+
   return (
     <Modal open={open} onClose={handleCloseRedirectionModal}>
       <s.ModalWrapper>
         {!isMobile() ? (
           <RedirectionNotificationForDesktop
-            setDoNotShowRedirectionModal_UserPreference={
-              setDoNotShowRedirectionModal_UserPreference
+            toggleRedirectionCheckboxSelection={
+              toggleRedirectionCheckboxSelection
+            }
+            selectedDoNotShowRedirectionModal_Checkbox={
+              selectedDoNotShowRedirectionModal_Checkbox
+            }
+            handleCloseAndSaveVisibilityPreferences={
+              handleCloseAndSaveVisibilityPreferences
+            }
+            handleCloseWithoutSavingVisibilityPreferences={
+              handleCloseWithoutSavingVisibilityPreferences
             }
             article={article}
-            handleCloseRedirectionModal={handleCloseRedirectionModal}
           />
         ) : (
           <RedirectionNotificationForMobile
+            toggleRedirectionCheckboxSelection={
+              toggleRedirectionCheckboxSelection
+            }
+            selectedDoNotShowRedirectionModal_Checkbox={
+              selectedDoNotShowRedirectionModal_Checkbox
+            }
+            handleModalVisibilityPreferences={handleModalVisibilityPreferences}
+            handleCloseAndSaveVisibilityPreferences={
+              handleCloseAndSaveVisibilityPreferences
+            }
+            handleCloseWithoutSavingVisibilityPreferences={
+              handleCloseWithoutSavingVisibilityPreferences
+            }
             handleCloseRedirectionModal={handleCloseRedirectionModal}
             article={article}
             api={api}

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,4 +1,5 @@
 import Modal from "@mui/material/Modal";
+import { useState } from "react";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
 import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";
@@ -14,11 +15,14 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  selectedDoNotShowRedirectionModal_Checkbox,
-  setSelectedDoNotShowRedirectionModal_Checkbox,
-  setDoNotShowRedirectionModal_UserPreference, // derived from selectedDoNotShowRedirectionModal_Checkbox
+  setDoNotShowRedirectionModal_UserPreference,
   setIsArticleSaved, // related to the article's state
 }) {
+  const [
+    selectedDoNotShowRedirectionModal_Checkbox,
+    setSelectedDoNotShowRedirectionModal_Checkbox,
+  ] = useState(false);
+
   function toggleRedirectionCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal_Checkbox(
       !selectedDoNotShowRedirectionModal_Checkbox
@@ -27,8 +31,8 @@ export default function RedirectionNotificationModal({
 
   //saves modal visibility preferences to the Local Storage
   //ideally shared by mobile and desktop variant
-  //temporarily not working for mobile
-  function handleModalUse() {
+  //temporarily not working on mobile
+  function handleModalVisibilityPreferences() {
     selectedDoNotShowRedirectionModal_Checkbox === true
       ? setDoNotShowRedirectionModal_UserPreference(true)
       : setDoNotShowRedirectionModal_UserPreference(false);
@@ -46,7 +50,7 @@ export default function RedirectionNotificationModal({
               selectedDoNotShowRedirectionModal_Checkbox
             }
             article={article}
-            handleModalUse={handleModalUse}
+            handleModalVisibilityPreferences={handleModalVisibilityPreferences}
             handleClose={handleClose}
           />
         ) : (

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,6 +1,4 @@
 import Modal from "@mui/material/Modal";
-import { Link } from "react-router-dom/cjs/react-router-dom";
-import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
 import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";
@@ -26,30 +24,14 @@ export default function RedirectionNotificationModal({
   }
 
   //saves modal visibility preferences to the Local Storage
+  //ideally shared by mobile and desktop variant
+  //temporarily not working for mobile
   function handleModalUse() {
     selectedDoNotShowRedirectionModal === true
       ? setOpenedExternallyWithoutModal(true)
       : setOpenedExternallyWithoutModal(false);
   }
 
-  function handleCloseAndSavePreferences() {
-    handleModalUse();
-    handleClose();
-  }
-
-  function handleSaveArticle() {
-    api.makePersonalCopy(article.id, (data) => {
-      if (data === "OK") {
-        setIsArticleSaved(true);
-      }
-    });
-  }
-
-  function handleSaveAndOpenArticle() {
-    handleSaveArticle();
-    // handleModalUse(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
-    handleClose();
-  }
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
@@ -62,14 +44,15 @@ export default function RedirectionNotificationModal({
               selectedDoNotShowRedirectionModal
             }
             article={article}
-            handleCloseAndSavePreferences={handleCloseAndSavePreferences}
+            handleModalUse={handleModalUse}
             handleClose={handleClose}
           />
         ) : (
           <RedirectionNotificationForMobile
             handleClose={handleClose}
             article={article}
-            handleSaveAndOpenArticle={handleSaveAndOpenArticle}
+            api={api}
+            setIsArticleSaved={setIsArticleSaved}
           />
         )}
       </s.ModalWrapper>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -17,7 +17,7 @@ export default function RedirectionNotificationModal({
   selectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
-  setIsSaved, // related to the article
+  setIsSaved, // related to the article's state
 }) {
   function handleVisibilityCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
@@ -49,7 +49,7 @@ export default function RedirectionNotificationModal({
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
-        {isMobile() === true ? (
+        {isMobile() === false ? (
           // Displayed to the users who access Zeeguu from desktop browsers
           <>
             <s.Header>
@@ -120,7 +120,6 @@ export default function RedirectionNotificationModal({
           </>
         ) : (
           // Displayed to the users who access Zeeguu from mobile browsers
-          //TODO: separate it and make it a SaveArticleModal
           <>
             <s.Header>
               <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>
@@ -130,7 +129,7 @@ export default function RedirectionNotificationModal({
                 If you want to read articles on your mobile device using Zeeguu,
                 just tap on the
                 <strong> Save </strong> button below the article's title or
-                click<strong> Save and enter the article</strong> to add it to
+                click<strong> Save and view the article</strong> to add it to
                 your Saves.
               </p>
             </s.Body>
@@ -141,7 +140,7 @@ export default function RedirectionNotificationModal({
               {/* Saves the article and opens internally */}
               <Link to={`/read/article?id=${article.id}`}>
                 <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
-                  Save and enter the article
+                  Save and view the article
                 </s.GoToArticleButton>
               </Link>
             </s.Footer>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,3 +1,4 @@
+import React, { useState } from "react";
 import Modal from "@mui/material/Modal";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
@@ -12,6 +13,12 @@ export default function RedirectionNotificationModal({
   open,
   handleClose, //handleClose function defined in the ArticlePreview.js, passed as a prop
 }) {
+  const [checkboxChecked, setCheckboxChecked] = useState(false);
+
+  function handleChecked() {
+    setCheckboxChecked(!checkboxChecked);
+  }
+
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
@@ -56,12 +63,13 @@ export default function RedirectionNotificationModal({
         <s.Footer>
           <s.CheckboxWrapper>
             <input
+              onChange={handleChecked}
               type="checkbox"
               id="checkbox"
               name="noshow"
-              value="Do not show again"
+              value=""
             ></input>{" "}
-            <label for="checkbox">Don't show this message</label>
+            <label htmlFor="checkbox">Don't show this message</label>
           </s.CheckboxWrapper>
           <a target="_blank" rel="noreferrer" href={article.url}>
             {/* Clicking the GoToArticleButton button sends the reader

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -7,14 +7,11 @@ import RedirectionNotificationForMobile from "./RedirectionNotificationForMobile
 
 //This modal is used in the ArticlePreview component
 
-//TODO: Further refactor, e.g after testing and making sure users
-//understand text and wording, turn strings into variables and move to definitions.js
-
 export default function RedirectionNotificationModal({
   api,
   article,
   open,
-  handleClose,
+  handleCloseRedirectionModal,
   setDoNotShowRedirectionModal_UserPreference,
   setIsArticleSaved, // related to the article's state
 }) {
@@ -39,7 +36,7 @@ export default function RedirectionNotificationModal({
   }
 
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleCloseRedirectionModal}>
       <s.ModalWrapper>
         {!isMobile() ? (
           <RedirectionNotificationForDesktop
@@ -51,11 +48,11 @@ export default function RedirectionNotificationModal({
             }
             article={article}
             handleModalVisibilityPreferences={handleModalVisibilityPreferences}
-            handleClose={handleClose}
+            handleCloseRedirectionModal={handleCloseRedirectionModal}
           />
         ) : (
           <RedirectionNotificationForMobile
-            handleClose={handleClose}
+            handleCloseRedirectionModal={handleCloseRedirectionModal}
             article={article}
             api={api}
             setIsArticleSaved={setIsArticleSaved}

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Modal from "@mui/material/Modal";
+import LocalStorage from "../assorted/LocalStorage";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 
@@ -12,16 +13,13 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
+  setCheckboxChecked,
+  checkboxChecked,
 }) {
-  const [checkboxChecked, setCheckboxChecked] = useState(false);
-
   //toggle checkbox state
   function handleChecked() {
     setCheckboxChecked(!checkboxChecked);
   }
-
-  console.log(`Checkbox is checked ${checkboxChecked}`);
-
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,6 +1,4 @@
-import { useState, useEffect } from "react";
 import Modal from "@mui/material/Modal";
-import LocalStorage from "../assorted/LocalStorage";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 
@@ -13,12 +11,11 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  setSelectedDoNotShowRedirectionModal,
-  selectedDoNotShowRedirectionModal,
-  setOpenedExternallyWithoutModal,
+  selectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
+  setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
+  setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
 }) {
-  //toggle checkbox state
-  function handleVisibilitySettings() {
+  function handleVisibilityCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
 
@@ -76,7 +73,7 @@ export default function RedirectionNotificationModal({
         <s.Footer>
           <s.CheckboxWrapper>
             <input
-              onChange={handleVisibilitySettings}
+              onChange={handleVisibilityCheckboxSelection}
               checked={selectedDoNotShowRedirectionModal}
               type="checkbox"
               id="checkbox"

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Modal from "@mui/material/Modal";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
@@ -10,9 +11,17 @@ import * as s from "../components/RedirectionNotificationModal.sc";
 export default function RedirectionNotificationModal({
   article,
   open,
-  handleClose, //handleClose function defined in the ArticlePreview.js, passed as a prop
-  handleChecked
+  handleClose,
 }) {
+  const [checkboxChecked, setCheckboxChecked] = useState(false);
+
+  function handleChecked(event) {
+    if (event.target.checked === false) {
+      setCheckboxChecked(false);
+    } else setCheckboxChecked(true);
+  }
+
+  console.log(checkboxChecked);
 
   return (
     <Modal open={open} onClose={handleClose}>
@@ -58,10 +67,11 @@ export default function RedirectionNotificationModal({
         <s.Footer>
           <s.CheckboxWrapper>
             <input
+              defaultChecked={checkboxChecked === true ?? true | false} // it keeps previous selection visible
               onChange={handleChecked}
               type="checkbox"
               id="checkbox"
-              name="noshow"
+              name=""
               value=""
             ></input>{" "}
             <label htmlFor="checkbox">Don't show this message</label>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -19,7 +19,7 @@ export default function RedirectionNotificationModal({
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
   setIsArticleSaved, // related to the article's state
 }) {
-  function handleVisibilityCheckboxSelection() {
+  function toggleRedirectionCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
 
@@ -37,8 +37,8 @@ export default function RedirectionNotificationModal({
       <s.ModalWrapper>
         {!isMobile() ? (
           <RedirectionNotificationForDesktop
-            handleVisibilityCheckboxSelection={
-              handleVisibilityCheckboxSelection
+          toggleRedirectionCheckboxSelection={
+            toggleRedirectionCheckboxSelection
             }
             selectedDoNotShowRedirectionModal={
               selectedDoNotShowRedirectionModal

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -17,7 +17,7 @@ export default function RedirectionNotificationModal({
   selectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
-  setIsSaved, // related to the article's state
+  setIsArticleSaved, // related to the article's state
 }) {
   function handleVisibilityCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
@@ -35,17 +35,17 @@ export default function RedirectionNotificationModal({
     handleClose();
   }
 
-  async function handleSaveArticle() {
-    await api.makePersonalCopy(article.id, (data) => {
+  function handleSaveArticle() {
+    api.makePersonalCopy(article.id, (data) => {
       if (data === "OK") {
-        setIsSaved(true);
+        setIsArticleSaved(true);
       }
     });
   }
 
   function handleSaveAndOpenArticle() {
     handleSaveArticle();
-    // handleModalUse(); //Temporarily disabled for this function as it worked only when <Link> had its target set to _blank
+    // handleModalUse(); //Temporarily disabled for this function on mobile as it worked only when <Link> had its target set to _blank
     handleClose();
   }
   return (
@@ -120,6 +120,7 @@ export default function RedirectionNotificationModal({
           </>
         ) : (
           // Displayed to the users who access Zeeguu from mobile browsers
+          //Todo: Create modal content components for these separate views
           <>
             <s.Header>
               <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom/cjs/react-router-dom";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
+import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";
 
 //This modal is used in the ArticlePreview component
 
@@ -52,72 +53,17 @@ export default function RedirectionNotificationModal({
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
         {!isMobile() ? (
-          // Displayed to the users who access Zeeguu from desktop browsers
-          <>
-            <s.Header>
-              <h1>
-                You are ready to&nbsp;continue<br></br>
-                to the original article's website
-              </h1>
-            </s.Header>
-            <s.Body>
-              <p>
-                <strong>Once there</strong>, find and{" "}
-                <strong>
-                  click The Zeeguu Reader{" "}
-                  <s.Icon>
-                    <img
-                      className="fullDivWidthImage"
-                      alt=""
-                      src="../static/images/zeeguuLogo.svg"
-                    ></img>
-                  </s.Icon>{" "}
-                  icon
-                </strong>{" "}
-                in the top right corner of&nbsp;your browser's toolbar
-                or&nbsp;on&nbsp;the&nbsp;list of your installed extensions{" "}
-                <s.Icon>
-                  <img
-                    className="fullDivWidthImage"
-                    alt=""
-                    src="../static/images/puzzle.svg"
-                  ></img>
-                </s.Icon>
-                . <strong>Then&nbsp;select Read Article</strong>.
-              </p>
-              <img
-                className="fullDivWidthImage"
-                src={"../static/images/find-extension.png"}
-                alt="Zeeguu browser extension"
-              />
-            </s.Body>
-            <s.Footer>
-              <s.CheckboxWrapper>
-                <input
-                  onChange={handleVisibilityCheckboxSelection}
-                  checked={selectedDoNotShowRedirectionModal}
-                  type="checkbox"
-                  id="checkbox"
-                  name=""
-                  value=""
-                ></input>{" "}
-                <label htmlFor="checkbox">Don't show this message</label>
-              </s.CheckboxWrapper>
-              <a target="_blank" rel="noreferrer" href={article.url}>
-                {/* Clicking the GoToArticleButton button sends the reader
-                to the article, saves visibility preferences of the modal and closes it */}
-                <s.GoToArticleButton
-                  role="button"
-                  onClick={handleCloseAndSavePreferences}
-                >
-                  Enter the article's website
-                </s.GoToArticleButton>
-              </a>
-            </s.Footer>
-            <s.CloseButton role="button" onClick={handleClose}>
-              <CloseRoundedIcon fontSize="medium" />
-            </s.CloseButton>
-          </>
+            <RedirectionNotificationForDesktop
+              handleVisibilityCheckboxSelection={
+                handleVisibilityCheckboxSelection
+              }
+              selectedDoNotShowRedirectionModal={
+                selectedDoNotShowRedirectionModal
+              }
+              article={article}
+              handleCloseAndSavePreferences={handleCloseAndSavePreferences}
+              handleClose={handleClose}
+            />
         ) : (
           // Displayed to the users who access Zeeguu from mobile browsers
           //Todo: Create modal content components for these separate views

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,6 +1,5 @@
 import Modal from "@mui/material/Modal";
 import { Link } from "react-router-dom/cjs/react-router-dom";
-import { useState } from "react";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
@@ -18,9 +17,8 @@ export default function RedirectionNotificationModal({
   selectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
+  setIsSaved, // related to the article
 }) {
-  const [isSaved, setIsSaved] = useState(article.has_personal_copy);
-
   function handleVisibilityCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
@@ -122,6 +120,7 @@ export default function RedirectionNotificationModal({
           </>
         ) : (
           // Displayed to the users who access Zeeguu from mobile browsers
+          //TODO: separate it and make it a SaveArticleModal
           <>
             <s.Header>
               <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>
@@ -141,9 +140,9 @@ export default function RedirectionNotificationModal({
             <s.Footer>
               {/* Saves the article and opens internally */}
               <Link to={`/read/article?id=${article.id}`}>
-                <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
-                  Save and enter the article
-                </s.GoToArticleButton>
+              <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
+                Save and enter the article
+              </s.GoToArticleButton>
               </Link>
             </s.Footer>
           </>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import Modal from "@mui/material/Modal";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
@@ -12,12 +11,8 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose, //handleClose function defined in the ArticlePreview.js, passed as a prop
+  handleChecked
 }) {
-  const [checkboxChecked, setCheckboxChecked] = useState(false);
-
-  function handleChecked() {
-    setCheckboxChecked(!checkboxChecked);
-  }
 
   return (
     <Modal open={open} onClose={handleClose}>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -15,13 +15,12 @@ export default function RedirectionNotificationModal({
 }) {
   const [checkboxChecked, setCheckboxChecked] = useState(false);
 
-  function handleChecked(event) {
-    if (event.target.checked === false) {
-      setCheckboxChecked(false);
-    } else setCheckboxChecked(true);
+  //toggle checkbox state
+  function handleChecked() {
+    setCheckboxChecked(!checkboxChecked);
   }
 
-  console.log(checkboxChecked);
+  console.log(`Checkbox is checked ${checkboxChecked}`);
 
   return (
     <Modal open={open} onClose={handleClose}>
@@ -67,8 +66,8 @@ export default function RedirectionNotificationModal({
         <s.Footer>
           <s.CheckboxWrapper>
             <input
-              defaultChecked={checkboxChecked === true ?? true | false} // it keeps previous selection visible
               onChange={handleChecked}
+              checked={checkboxChecked}
               type="checkbox"
               id="checkbox"
               name=""

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -4,6 +4,7 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
 import RedirectionNotificationForDesktop from "./RedirectionNotificationForDesktop";
+import RedirectionNotificationForMobile from "./RedirectionNotificationForMobile";
 
 //This modal is used in the ArticlePreview component
 
@@ -53,53 +54,23 @@ export default function RedirectionNotificationModal({
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
         {!isMobile() ? (
-            <RedirectionNotificationForDesktop
-              handleVisibilityCheckboxSelection={
-                handleVisibilityCheckboxSelection
-              }
-              selectedDoNotShowRedirectionModal={
-                selectedDoNotShowRedirectionModal
-              }
-              article={article}
-              handleCloseAndSavePreferences={handleCloseAndSavePreferences}
-              handleClose={handleClose}
-            />
+          <RedirectionNotificationForDesktop
+            handleVisibilityCheckboxSelection={
+              handleVisibilityCheckboxSelection
+            }
+            selectedDoNotShowRedirectionModal={
+              selectedDoNotShowRedirectionModal
+            }
+            article={article}
+            handleCloseAndSavePreferences={handleCloseAndSavePreferences}
+            handleClose={handleClose}
+          />
         ) : (
-          // Displayed to the users who access Zeeguu from mobile browsers
-          //Todo: Create modal content components for these separate views
-          <>
-            <s.Header>
-              <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>
-            </s.Header>
-            <s.Body>
-              <p>
-                If you want to read articles on your mobile device using Zeeguu,
-                just tap on the
-                <strong> Save </strong> button below the article's title or
-                click<strong> Save and view the article</strong> to add it to
-                your Saves.
-              </p>
-            </s.Body>
-            <s.CloseButton role="button" onClick={handleClose}>
-              <CloseRoundedIcon fontSize="medium" />
-            </s.CloseButton>
-            <s.Footer>
-              {/* "Do not show this message" option temporarily not
-              implemented here as the function handleModalUse() within
-              handleSaveAndOpenArticle() seems to fully work with React Link
-              on mobile only when target="_blank". This issue didn't occur
-              on the desktop and for regular <a> links. Needs further investigation
-              if we want this functionality here  */}
-              <Link to={`/read/article?id=${article.id}`}>
-                <s.GoToArticleButton
-                  role="button"
-                  onClick={handleSaveAndOpenArticle}
-                >
-                  Save and view the article
-                </s.GoToArticleButton>
-              </Link>
-            </s.Footer>
-          </>
+          <RedirectionNotificationForMobile
+            handleClose={handleClose}
+            article={article}
+            handleSaveAndOpenArticle={handleSaveAndOpenArticle}
+          />
         )}
       </s.ModalWrapper>
     </Modal>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -14,20 +14,22 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  selectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
+  selectedDoNotShowRedirectionModal_Checkbox, //related to the "Do not show" checkbox selection
   setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
   setIsArticleSaved, // related to the article's state
 }) {
   function toggleRedirectionCheckboxSelection() {
-    setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
+    setSelectedDoNotShowRedirectionModal(
+      !selectedDoNotShowRedirectionModal_Checkbox
+    );
   }
 
   //saves modal visibility preferences to the Local Storage
   //ideally shared by mobile and desktop variant
   //temporarily not working for mobile
   function handleModalUse() {
-    selectedDoNotShowRedirectionModal === true
+    selectedDoNotShowRedirectionModal_Checkbox === true
       ? setOpenedExternallyWithoutModal(true)
       : setOpenedExternallyWithoutModal(false);
   }
@@ -37,11 +39,11 @@ export default function RedirectionNotificationModal({
       <s.ModalWrapper>
         {!isMobile() ? (
           <RedirectionNotificationForDesktop
-          toggleRedirectionCheckboxSelection={
-            toggleRedirectionCheckboxSelection
+            toggleRedirectionCheckboxSelection={
+              toggleRedirectionCheckboxSelection
             }
-            selectedDoNotShowRedirectionModal={
-              selectedDoNotShowRedirectionModal
+            selectedDoNotShowRedirectionModal_Checkbox={
+              selectedDoNotShowRedirectionModal_Checkbox
             }
             article={article}
             handleModalUse={handleModalUse}

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -54,15 +54,15 @@ export default function RedirectionNotificationModal({
           />
         </s.Body>
         <s.Footer>
-          <label for="checkbox">
+          <s.Checkbox>
+            <label for="checkbox"> Don't show this again</label>
             <input
               type="checkbox"
               id="checkbox"
               name="noshow"
               value="Do not show again"
             ></input>{" "}
-            Don't show this again
-          </label>
+          </s.Checkbox>
           <a target="_blank" rel="noreferrer" href={article.url}>
             {/* Clicking the GoToArticleButton button sends the reader
                 to the article and closes the modal so that when the user

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -46,7 +46,7 @@ export default function RedirectionNotificationModal({
               <s.Icon>
                 <img
                   className="fullDivWidthImage"
-                  alt="The Zeeguu Reader elephant icon"
+                  alt=""
                   src="../static/images/zeeguuLogo.svg"
                 ></img>
               </s.Icon>{" "}
@@ -57,7 +57,7 @@ export default function RedirectionNotificationModal({
             <s.Icon>
               <img
                 className="fullDivWidthImage"
-                alt="Browser extensions puzzle icon"
+                alt=""
                 src="../static/images/puzzle.svg"
               ></img>
             </s.Icon>
@@ -66,7 +66,6 @@ export default function RedirectionNotificationModal({
           <img
             className="fullDivWidthImage"
             src={"../static/images/find-extension.png"}
-            //TODO: Add new alt description
             alt="Zeeguu browser extension"
           />
         </s.Body>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,6 +1,7 @@
 import Modal from "@mui/material/Modal";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
+import { isMobile } from "../utils/misc/browserDetection";
 
 //This modal is used in the ArticlePreview component
 
@@ -32,71 +33,99 @@ export default function RedirectionNotificationModal({
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
-        <s.Header>
-          <h1>
-            You are ready to&nbsp;continue<br></br>
-            to the original article's website
-          </h1>
-        </s.Header>
-        <s.Body>
-          <p>
-            <strong>Once there</strong>, find and{" "}
-            <strong>
-              click The Zeeguu Reader{" "}
-              <s.Icon>
-                <img
-                  className="fullDivWidthImage"
-                  alt=""
-                  src="../static/images/zeeguuLogo.svg"
-                ></img>
-              </s.Icon>{" "}
-              icon
-            </strong>{" "}
-            in the top right corner of&nbsp;your browser's toolbar
-            or&nbsp;on&nbsp;the&nbsp;list of your installed extensions{" "}
-            <s.Icon>
+        {isMobile() === false ? (
+          // Displayed to the users who access Zeeguu from desktop browsers
+          <>
+            <s.Header>
+              <h1>
+                You are ready to&nbsp;continue<br></br>
+                to the original article's website
+              </h1>
+            </s.Header>
+            <s.Body>
+              <p>
+                <strong>Once there</strong>, find and{" "}
+                <strong>
+                  click The Zeeguu Reader{" "}
+                  <s.Icon>
+                    <img
+                      className="fullDivWidthImage"
+                      alt=""
+                      src="../static/images/zeeguuLogo.svg"
+                    ></img>
+                  </s.Icon>{" "}
+                  icon
+                </strong>{" "}
+                in the top right corner of&nbsp;your browser's toolbar
+                or&nbsp;on&nbsp;the&nbsp;list of your installed extensions{" "}
+                <s.Icon>
+                  <img
+                    className="fullDivWidthImage"
+                    alt=""
+                    src="../static/images/puzzle.svg"
+                  ></img>
+                </s.Icon>
+                . <strong>Then&nbsp;select Read Article</strong>.
+              </p>
               <img
                 className="fullDivWidthImage"
-                alt=""
-                src="../static/images/puzzle.svg"
-              ></img>
-            </s.Icon>
-            . <strong>Then&nbsp;select Read Article</strong>.
-          </p>
-          <img
-            className="fullDivWidthImage"
-            src={"../static/images/find-extension.png"}
-            alt="Zeeguu browser extension"
-          />
-        </s.Body>
-        <s.Footer>
-          <s.CheckboxWrapper>
-            <input
-              onChange={handleVisibilityCheckboxSelection}
-              checked={selectedDoNotShowRedirectionModal}
-              type="checkbox"
-              id="checkbox"
-              name=""
-              value=""
-            ></input>{" "}
-            <label htmlFor="checkbox">Don't show this message</label>
-          </s.CheckboxWrapper>
-          <a target="_blank" rel="noreferrer" href={article.url}>
-            {/* Clicking the GoToArticleButton button sends the reader
+                src={"../static/images/find-extension.png"}
+                alt="Zeeguu browser extension"
+              />
+            </s.Body>
+            <s.Footer>
+              <s.CheckboxWrapper>
+                <input
+                  onChange={handleVisibilityCheckboxSelection}
+                  checked={selectedDoNotShowRedirectionModal}
+                  type="checkbox"
+                  id="checkbox"
+                  name=""
+                  value=""
+                ></input>{" "}
+                <label htmlFor="checkbox">Don't show this message</label>
+              </s.CheckboxWrapper>
+              <a target="_blank" rel="noreferrer" href={article.url}>
+                {/* Clicking the GoToArticleButton button sends the reader
                 to the article and closes the modal so that when the user
                 returns to the Zeeguu app home page, they can see the recommendation
                 list instead of the modal still being open */}
-            <s.GoToArticleButton
-              role="button"
-              onClick={handleCloseAndSavePreferences}
-            >
-              Enter the article's website
-            </s.GoToArticleButton>
-          </a>
-        </s.Footer>
-        <s.CloseButton role="button" onClick={handleClose}>
-          <CloseRoundedIcon fontSize="medium" />
-        </s.CloseButton>
+                <s.GoToArticleButton
+                  role="button"
+                  onClick={handleCloseAndSavePreferences}
+                >
+                  Enter the article's website
+                </s.GoToArticleButton>
+              </a>
+            </s.Footer>
+            <s.CloseButton role="button" onClick={handleClose}>
+              <CloseRoundedIcon fontSize="medium" />
+            </s.CloseButton>
+          </>
+        ) : (
+          // Displayed to the users who access Zeeguu from mobile browsers
+          <>
+            <s.Header>
+              <h1>
+                It seems like you are using&nbsp;a&nbsp;mobile device
+                right&nbsp;now
+              </h1>
+            </s.Header>
+            <s.Body>
+              <p>
+                To read articles on a&nbsp;mobile device, click the{" "}
+                <strong>Save</strong> button below the article's title.{" "}
+                <br></br>
+                <br></br>
+                Once the article is saved, you can access it by visiting the{" "}
+                <strong>Saves</strong> section.
+              </p>
+            </s.Body>
+            <s.CloseButton role="button" onClick={handleClose}>
+              <CloseRoundedIcon fontSize="medium" />
+            </s.CloseButton>
+          </>
+        )}
       </s.ModalWrapper>
     </Modal>
   );

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -54,15 +54,15 @@ export default function RedirectionNotificationModal({
           />
         </s.Body>
         <s.Footer>
-          <s.Checkbox>
-            <label for="checkbox"> Don't show this again</label>
+          <s.CheckboxWrapper>
             <input
               type="checkbox"
               id="checkbox"
               name="noshow"
               value="Do not show again"
             ></input>{" "}
-          </s.Checkbox>
+            <label for="checkbox">Don't show this message</label>
+          </s.CheckboxWrapper>
           <a target="_blank" rel="noreferrer" href={article.url}>
             {/* Clicking the GoToArticleButton button sends the reader
                 to the article and closes the modal so that when the user

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -14,9 +14,9 @@ export default function RedirectionNotificationModal({
   article,
   open,
   handleClose,
-  selectedDoNotShowRedirectionModal_Checkbox, 
-  setSelectedDoNotShowRedirectionModal_Checkbox, 
-  setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
+  selectedDoNotShowRedirectionModal_Checkbox,
+  setSelectedDoNotShowRedirectionModal_Checkbox,
+  setDoNotShowRedirectionModal_UserPreference, // derived from selectedDoNotShowRedirectionModal_Checkbox
   setIsArticleSaved, // related to the article's state
 }) {
   function toggleRedirectionCheckboxSelection() {
@@ -30,8 +30,8 @@ export default function RedirectionNotificationModal({
   //temporarily not working for mobile
   function handleModalUse() {
     selectedDoNotShowRedirectionModal_Checkbox === true
-      ? setOpenedExternallyWithoutModal(true)
-      : setOpenedExternallyWithoutModal(false);
+      ? setDoNotShowRedirectionModal_UserPreference(true)
+      : setDoNotShowRedirectionModal_UserPreference(false);
   }
 
   return (

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -1,4 +1,6 @@
 import Modal from "@mui/material/Modal";
+import { Link } from "react-router-dom/cjs/react-router-dom";
+import { useState } from "react";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import * as s from "../components/RedirectionNotificationModal.sc";
 import { isMobile } from "../utils/misc/browserDetection";
@@ -9,6 +11,7 @@ import { isMobile } from "../utils/misc/browserDetection";
 //understand text and wording, turn strings into variables and move to definitions.js
 
 export default function RedirectionNotificationModal({
+  api,
   article,
   open,
   handleClose,
@@ -16,6 +19,8 @@ export default function RedirectionNotificationModal({
   setSelectedDoNotShowRedirectionModal, //related to the "Do not show" checkbox selection
   setOpenedExternallyWithoutModal, //related to the modal use based on the "Do not show" selection
 }) {
+  const [isSaved, setIsSaved] = useState(article.has_personal_copy);
+
   function handleVisibilityCheckboxSelection() {
     setSelectedDoNotShowRedirectionModal(!selectedDoNotShowRedirectionModal);
   }
@@ -28,6 +33,19 @@ export default function RedirectionNotificationModal({
 
   function handleCloseAndSavePreferences() {
     handleModalUse();
+    handleClose();
+  }
+
+  async function handleSaveArticle() {
+    await api.makePersonalCopy(article.id, (data) => {
+      if (data === "OK") {
+        setIsSaved(true);
+      }
+    });
+  }
+
+  function handleCloseMobile() {
+    handleSaveArticle();
     handleClose();
   }
   return (
@@ -106,24 +124,28 @@ export default function RedirectionNotificationModal({
           // Displayed to the users who access Zeeguu from mobile browsers
           <>
             <s.Header>
-              <h1>
-                It seems like you are using&nbsp;a&nbsp;mobile device
-                right&nbsp;now
-              </h1>
+              <h1>It looks like you are using&nbsp;a&nbsp;mobile device</h1>
             </s.Header>
             <s.Body>
               <p>
-                To read articles on a&nbsp;mobile device, click the{" "}
-                <strong>Save</strong> button below the article's title.{" "}
-                <br></br>
-                <br></br>
-                Once the article is saved, you can access it by visiting the{" "}
-                <strong>Saves</strong> section.
+                If you want to read articles on your mobile device using Zeeguu,
+                just tap on the
+                <strong> Save </strong> button below the article's title or
+                click<strong> Save and enter the article</strong> to add it to
+                your Saves section.
               </p>
             </s.Body>
             <s.CloseButton role="button" onClick={handleClose}>
               <CloseRoundedIcon fontSize="medium" />
             </s.CloseButton>
+            <s.Footer>
+              {/* Saves the article and opens internally */}
+              <Link to={`/read/article?id=${article.id}`}>
+                <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
+                  Save and enter the article
+                </s.GoToArticleButton>
+              </Link>
+            </s.Footer>
           </>
         )}
       </s.ModalWrapper>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -49,7 +49,7 @@ export default function RedirectionNotificationModal({
   return (
     <Modal open={open} onClose={handleClose}>
       <s.ModalWrapper>
-        {isMobile() === false ? (
+        {isMobile() === true ? (
           // Displayed to the users who access Zeeguu from desktop browsers
           <>
             <s.Header>
@@ -131,7 +131,7 @@ export default function RedirectionNotificationModal({
                 just tap on the
                 <strong> Save </strong> button below the article's title or
                 click<strong> Save and enter the article</strong> to add it to
-                your Saves section.
+                your Saves.
               </p>
             </s.Body>
             <s.CloseButton role="button" onClick={handleClose}>
@@ -140,9 +140,9 @@ export default function RedirectionNotificationModal({
             <s.Footer>
               {/* Saves the article and opens internally */}
               <Link to={`/read/article?id=${article.id}`}>
-              <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
-                Save and enter the article
-              </s.GoToArticleButton>
+                <s.GoToArticleButton role="button" onClick={handleCloseMobile}>
+                  Save and enter the article
+                </s.GoToArticleButton>
               </Link>
             </s.Footer>
           </>

--- a/src/components/RedirectionNotificationModal.js
+++ b/src/components/RedirectionNotificationModal.js
@@ -15,42 +15,15 @@ export default function RedirectionNotificationModal({
   setDoNotShowRedirectionModal_UserPreference,
   setIsArticleSaved, // related to the article's state
 }) {
-  const [
-    selectedDoNotShowRedirectionModal_Checkbox,
-    setSelectedDoNotShowRedirectionModal_Checkbox,
-  ] = useState(false);
-
-  function toggleRedirectionCheckboxSelection() {
-    setSelectedDoNotShowRedirectionModal_Checkbox(
-      !selectedDoNotShowRedirectionModal_Checkbox
-    );
-  }
-
-  //saves modal visibility preferences to the Local Storage
-  //ideally shared by mobile and desktop variant
-  //temporarily not working on mobileg
-  function handleModalVisibilityPreferences() {
-    selectedDoNotShowRedirectionModal_Checkbox === true
-      ? setDoNotShowRedirectionModal_UserPreference(true)
-      : setDoNotShowRedirectionModal_UserPreference(false);
-  }
-
   return (
     <Modal open={open} onClose={handleCloseRedirectionModal}>
       <s.ModalWrapper>
         {!isMobile() ? (
           <RedirectionNotificationForDesktop
-            toggleRedirectionCheckboxSelection={
-              toggleRedirectionCheckboxSelection
-            }
-            selectedDoNotShowRedirectionModal_Checkbox={
-              selectedDoNotShowRedirectionModal_Checkbox
-            }
-            setSelectedDoNotShowRedirectionModal_Checkbox={
-              setSelectedDoNotShowRedirectionModal_Checkbox
+            setDoNotShowRedirectionModal_UserPreference={
+              setDoNotShowRedirectionModal_UserPreference
             }
             article={article}
-            handleModalVisibilityPreferences={handleModalVisibilityPreferences}
             handleCloseRedirectionModal={handleCloseRedirectionModal}
           />
         ) : (

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -37,6 +37,9 @@ const CheckboxWrapper = styled.div`
   grid-template-columns: 1em auto;
   align-items: center;
   gap: 0.5em;
+  @media (max-width: 576px) {
+    margin-top: 0em;
+  }
   label {
     font-size: 0.9em;
   }

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -19,7 +19,7 @@ const Footer = styled(ModalFooterGlobal)``;
 
 const CloseButton = styled(CloseButtonGlobal)``;
 
-const Icon = styled.div`
+const Icon = styled.span`
   height: 1em;
   width: 1em;
   margin: 0 0.2em;

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -28,11 +28,11 @@ const Icon = styled.span`
 `;
 
 const CheckboxWrapper = styled.div`
-  margin-top: -0.5em;
+  margin-top: -1em;
   align-self: start;
   display: grid;
   grid-template-columns: 1em auto;
-  align-items: start;
+  align-items: center;
   gap: 0.5em;
   label {
     font-size: 0.9em;
@@ -41,6 +41,10 @@ const CheckboxWrapper = styled.div`
     width: 1.2em;
     height: 1.2em;
     accent-color: ${zeeguuOrange};
+    @media (max-width: 576px) {
+      width: 1.5em;
+      height: 1.5em;
+    }
   }
 `;
 

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -22,6 +22,7 @@ const CloseButton = styled(CloseButtonGlobal)``;
 const Icon = styled.span`
   height: 1em;
   width: 1em;
+  max-width:2em;
   margin: 0 0.2em;
   display: inline-block;
 `;

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -28,7 +28,7 @@ const Icon = styled.span`
 `;
 
 const CheckboxWrapper = styled.div`
-  margin-top: -1em;
+  margin-top: -0.5em;
   align-self: start;
   display: grid;
   grid-template-columns: 1em auto;

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -4,6 +4,7 @@ import {
   ModalHeaderGlobal,
   ModalBodyGlobal,
   ModalFooterGlobal,
+  ModalStrongTextWrapperGlobal,
 } from "./ModalGlobalStyling.sc";
 import { zeeguuDarkOrange, zeeguuOrange } from "./colors";
 import { OrangeRoundButton } from "./allButtons.sc";
@@ -19,6 +20,8 @@ const Footer = styled(ModalFooterGlobal)``;
 
 const CloseButton = styled(CloseButtonGlobal)``;
 
+const ModalStrongTextWrapper = styled(ModalStrongTextWrapperGlobal)``;
+
 const Icon = styled.span`
   height: 1em;
   width: 1em;
@@ -28,7 +31,7 @@ const Icon = styled.span`
 `;
 
 const CheckboxWrapper = styled.div`
-  margin-top: -1em;
+  margin-top: -0.8em;
   align-self: start;
   display: grid;
   grid-template-columns: 1em auto;
@@ -42,8 +45,8 @@ const CheckboxWrapper = styled.div`
     height: 1.2em;
     accent-color: ${zeeguuOrange};
     @media (max-width: 576px) {
-      width: 1.5em;
-      height: 1.5em;
+      width: 1rem;
+      height: 1rem;
     }
   }
 `;
@@ -68,4 +71,5 @@ export {
   Body,
   Footer,
   CheckboxWrapper,
+  ModalStrongTextWrapper,
 };

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -5,7 +5,7 @@ import {
   ModalBodyGlobal,
   ModalFooterGlobal,
 } from "./ModalGlobalStyling.sc";
-import { zeeguuDarkOrange, darkGrey } from "./colors";
+import { zeeguuDarkOrange, zeeguuOrange } from "./colors";
 import { OrangeRoundButton } from "./allButtons.sc";
 import styled from "styled-components";
 
@@ -26,20 +26,20 @@ const Icon = styled.div`
   display: inline-block;
 `;
 
-const Checkbox = styled.div`
+const CheckboxWrapper = styled.div`
   margin-top: -1em;
   align-self: start;
-  display: flex;
-  flex-direction: row-reverse;
+  display: grid;
+  grid-template-columns: 1em auto;
+  align-items: start;
   gap: 0.5em;
   label {
     font-size: 0.9em;
-    color: ${darkGrey}
   }
   input[type="checkbox"] {
     width: 1.2em;
     height: 1.2em;
-    border-radius: 0.25em;
+    accent-color: ${zeeguuOrange};
   }
 `;
 
@@ -62,5 +62,5 @@ export {
   Header,
   Body,
   Footer,
-  Checkbox,
+  CheckboxWrapper,
 };

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -5,17 +5,11 @@ import {
   ModalBodyGlobal,
   ModalFooterGlobal,
 } from "./ModalGlobalStyling.sc";
-import { zeeguuDarkOrange } from "./colors";
+import { zeeguuDarkOrange, darkGrey } from "./colors";
 import { OrangeRoundButton } from "./allButtons.sc";
 import styled from "styled-components";
 
-const ModalWrapper = styled(ModalWrapperGlobal)`
-  label {
-    font-size: 0.9em;
-    align-self: start;
-    margin-top: -1em;
-  }
-`;
+const ModalWrapper = styled(ModalWrapperGlobal)``;
 
 const Header = styled(ModalHeaderGlobal)``;
 
@@ -30,6 +24,23 @@ const Icon = styled.div`
   width: 1em;
   margin: 0 0.2em;
   display: inline-block;
+`;
+
+const Checkbox = styled.div`
+  margin-top: -1em;
+  align-self: start;
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 0.5em;
+  label {
+    font-size: 0.9em;
+    color: ${darkGrey}
+  }
+  input[type="checkbox"] {
+    width: 1.2em;
+    height: 1.2em;
+    border-radius: 0.25em;
+  }
 `;
 
 //redesigned button for a better focal point and improved
@@ -51,4 +62,5 @@ export {
   Header,
   Body,
   Footer,
+  Checkbox,
 };

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -62,10 +62,33 @@ const GoToArticleButton = styled(OrangeRoundButton)`
   border-bottom: solid 0.2em ${zeeguuDarkOrange};
 `;
 
+const SaveArticleButton = styled.button`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  color: ${zeeguuDarkOrange};
+  color: orange;
+
+  background-color: none;
+  font: inherit;
+  /* color: inherit; */
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-weight: 600;
+`;
+
 export {
   ModalWrapper,
   CloseButton,
   GoToArticleButton,
+  SaveArticleButton,
   Icon,
   Header,
   Body,

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -38,7 +38,7 @@ const CheckboxWrapper = styled.div`
   align-items: center;
   gap: 0.5em;
   @media (max-width: 576px) {
-    margin-top: 0em;
+    margin-top: -0.5em;
   }
   label {
     font-size: 0.9em;
@@ -59,6 +59,7 @@ const CheckboxWrapper = styled.div`
 //TODO: After implementing all the onboarding steps,
 //create style quide for all buttons and refactor / factor them out
 const GoToArticleButton = styled(OrangeRoundButton)`
+  flex: 1;
   padding: 0.7em 2em;
   border-radius: 4em;
   font-weight: 600;
@@ -66,18 +67,14 @@ const GoToArticleButton = styled(OrangeRoundButton)`
 `;
 
 const SaveArticleButton = styled.button`
-  width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: 0.25rem;
-  color: ${zeeguuDarkOrange};
   color: orange;
-
   background-color: none;
   font: inherit;
-  /* color: inherit; */
   text-align: left;
   padding: 0;
   margin: 0;
@@ -85,6 +82,25 @@ const SaveArticleButton = styled.button`
   background: none;
   border: none;
   font-weight: 600;
+
+  @media (max-width: 576px) {
+    justify-content: center;
+    flex: 0;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 1.5rem;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+
+  @media (max-width: 576px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 `;
 
 export {
@@ -92,6 +108,7 @@ export {
   CloseButton,
   GoToArticleButton,
   SaveArticleButton,
+  ButtonContainer,
   Icon,
   Header,
   Body,

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -22,7 +22,7 @@ const CloseButton = styled(CloseButtonGlobal)``;
 const Icon = styled.span`
   height: 1em;
   width: 1em;
-  max-width:2em;
+  max-width: 2em;
   margin: 0 0.2em;
   display: inline-block;
 `;

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -85,6 +85,7 @@ const SaveArticleButton = styled.button`
 
   @media (max-width: 576px) {
     justify-content: center;
+    margin-left: -0.5em;
     flex: 0;
   }
 `;

--- a/src/components/RedirectionNotificationModal.sc.js
+++ b/src/components/RedirectionNotificationModal.sc.js
@@ -9,7 +9,13 @@ import { zeeguuDarkOrange } from "./colors";
 import { OrangeRoundButton } from "./allButtons.sc";
 import styled from "styled-components";
 
-const ModalWrapper = styled(ModalWrapperGlobal)``;
+const ModalWrapper = styled(ModalWrapperGlobal)`
+  label {
+    font-size: 0.9em;
+    align-self: start;
+    margin-top: -1em;
+  }
+`;
 
 const Header = styled(ModalHeaderGlobal)``;
 


### PR DESCRIPTION
The feature should probably be merged into an equivalent of its branch, but I can't create it on my end, so I temporarily made a pull request to development.

# What's new

### The visual part of the feature has been implemented, and minor preparations for the future logic part of the implementation have been made.

- The "Don't show this message" checkbox has been added to the Redirection Notification Modal. Its current text is a proposal and can be modified.
<img width="958" alt="checkbox not checked" src="https://github.com/zeeguu/web/assets/115182912/a7d591ac-14e7-4282-bac8-fd946f38bd8e">
<img width="958" alt="checkbox checked" src="https://github.com/zeeguu/web/assets/115182912/2f31273f-b67d-4358-970b-d859e3dafd0c">


- A state management added to the checkbox feature within the RedirectionNotificationModal.js

- The titleLink function within the ArticlePreview.js component has an additional variable added that is not used just yet, but when the feature is finalized, it should open the article directly from the list if the user selects "don't show this message" in the modal:

`    let open_externally_without_modal = (
      <a target="_blank" rel="noreferrer" href={article.url}>
        {article.title}
      </a>
    );`

- A fix added to the warning message related to the RedirectionNotificationModal “`react-dom.development.js:61 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>`”

- Next, my plan is to make this feature fully functional, but before starting to work on the logic part of it, we need to discuss on Monday what would be the best way to do this. 
 