### PR TITLE
Uncaught Error in Voices

### DIFF
--- a/src/speech/ZeeguuSpeech.js
+++ b/src/speech/ZeeguuSpeech.js
@@ -29,7 +29,7 @@ function voiceForLanguageCode(code, voices) {
     }
 
     let voice = languageVoices[0];
-    console.log(voice.name + voice.lang);
+    if (voice) console.log(voice.name + voice.lang);
 
     return voice;
 }


### PR DESCRIPTION
Fixed the error
"TypeError: Cannot read properties of undefined (reading 'name')" when loading the voices.

Before calling the console.log, check if there is any voice selected, otherwise don't print.