### PR TITLE
Fixed the animation for Speech buttons

### DIFF
--- a/src/exercises/exerciseTypes/SpeakButton.js
+++ b/src/exercises/exerciseTypes/SpeakButton.js
@@ -1,11 +1,11 @@
-import {useContext, useState} from "react";
+import { useContext, useEffect, useState } from "react";
 import strings from "../../i18n/definitions";
 
 import Loader from "react-loader-spinner";
 import * as s from "./SpeakButton.sc";
 import SessionStorage from "../../assorted/SessionStorage";
 
-import {SpeechContext} from "../SpeechContext";
+import { SpeechContext } from "../SpeechContext";
 
 const small_style = {
   // Icon properties
@@ -66,20 +66,27 @@ export default function SpeakButton({
   styling,
   handleClick,
   isReadContext,
+  parentIsSpeakingControl,
 }) {
   const speech = useContext(SpeechContext);
   // const [speech] = useState(new ZeeguuSpeech(api, bookmarkToStudy.from_lang));
   const [isSpeaking, setIsSpeaking] = useState(false);
   let style = styles[styling] || small_next_style; // default is next style
 
+  useEffect(() => {
+    setIsSpeaking(parentIsSpeakingControl);
+  }, [parentIsSpeakingControl]);
+
   async function handleSpeak() {
     // If audio is playing don't let other buttons be clicked.
     if (SessionStorage.isAudioBeingPlayed()) return;
     try {
-      if (isReadContext) { await speech.speakOut(bookmarkToStudy.context, setIsSpeaking); }
-      else { await speech.speakOut(bookmarkToStudy.from, setIsSpeaking); }
-    }
-    catch(err){
+      if (isReadContext) {
+        await speech.speakOut(bookmarkToStudy.context, setIsSpeaking);
+      } else {
+        await speech.speakOut(bookmarkToStudy.from, setIsSpeaking);
+      }
+    } catch (err) {
       console.log("There was an error executing the speech: " + err);
       SessionStorage.setAudioBeingPlayed(false);
     }

--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -41,7 +41,6 @@ export default function SpellWhatYouHear({
     await speech.speakOut(bookmarkToStudy.from, setIsButtonSpeaking);
   }
 
-  // Timeout is set so that the page renders before the word is spoken, allowing for the user to gain focus on the page
   useEffect(() => {
     setExerciseType(EXERCISE_TYPE);
     api.getArticleInfo(bookmarksToStudy[0].article_id, (articleInfo) => {
@@ -60,7 +59,11 @@ export default function SpellWhatYouHear({
   }, []);
 
   useEffect(() => {
-    handleSpeak();
+    // Timeout is set so that the page renders before the word is spoken, allowing for the user to gain focus on the page
+    // Changed timeout to be slightly shorter.
+    setTimeout(() => {
+      handleSpeak();
+    }, 300);
   }, [articleInfo]);
 
   function inputKeyPress() {

--- a/src/speech/APIBasedSpeech.js
+++ b/src/speech/APIBasedSpeech.js
@@ -22,13 +22,15 @@ const ZeeguuSpeech = class {
       .fetchLinkToSpeechMp3(word, this.language)
       .then((linkToMp3) => {
         this.pronunciationPlayer.src = linkToMp3;
+        this.pronunciationPlayer.addEventListener("ended", (e) => {
+          // Only terminate the animation after playing the sound.
+          animateSpeechButton(setIsSpeaking, false);
+        });
       })
       .catch(() => {
         // in case anything goes wrong here... we should still deactivate the animation
         animateSpeechButton(setIsSpeaking, false);
       });
-
-    animateSpeechButton(setIsSpeaking, false);
   }
 
   playFullArticle(articleInfo, api, player) {


### PR DESCRIPTION
After adding the new SpeechAPI we are not animating the buttons currently, they change state for a few ms and not accurately animate until the speech ends. It seems that Audio creates an event on "ended" which should be where we revert the status. 

While doing this change, I have also changed the logic on how the spell what you hear works. Instead of calling the timeout at the beginning of useEffect, instead wait until the articleInfo is loaded and then fire a shorter timeout. Now, the button also correctly animates when playing a sound.

+ Added a way to set the animation of a button from the parent. This is to allow us to play the animation in SpellWhatYouHear since we play the sound without any user clicks
+ Formatting using Prettier
