### PR TITLE
Sidebar pages are now clickable outside of the text

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -34,11 +34,9 @@ export default function SideBar(props) {
     const fontWeight = active ? "700" : "500";
 
     return (
-      <div className="navigationLink">
-        <Link to={to} onClick={resetSidebarToDefault}>
-          <small style={{ fontWeight: fontWeight }}>{text}</small>
-        </Link>
-      </div>
+      <Link className="navigationLink" to={to} onClick={resetSidebarToDefault}>
+        <small style={{ fontWeight: fontWeight }}>{text}</small>
+      </Link>
     );
   }
 

--- a/src/components/SideBar.sc.js
+++ b/src/components/SideBar.sc.js
@@ -123,6 +123,7 @@ const navigationVisibleCommon = css`
     color: white;
     margin-bottom: 0.4em;
     background-color: ${(props) => props.dark};
+    padding-left: 0.5em;
 
     a {
       color: white;
@@ -178,6 +179,7 @@ const SideBarToggled = styled.div`
     padding-top: 0.4em;
     padding-bottom: 0.4em;
     font-size: large;
+    padding-left: 0.5em;
   }
 
   @media (min-width: 768px) {

--- a/src/components/StudentSpecificSidebarOptions.js
+++ b/src/components/StudentSpecificSidebarOptions.js
@@ -26,16 +26,15 @@ export default function StudentSpecificSidebarOptions({ SidebarLink, user }) {
 
       <SidebarLink text={strings.settings} to="/account_settings" />
 
-      <div className="navigationLink">
-        <Link
-          to="/"
-          onClick={() => {
-            user.logoutMethod();
-          }}
-        >
-          <small>{strings.logout}</small>
-        </Link>
-      </div>
+      <Link
+        className="navigationLink"
+        to="/"
+        onClick={() => {
+          user.logoutMethod();
+        }}
+      >
+        <small>{strings.logout}</small>
+      </Link>
     </>
   );
 }


### PR DESCRIPTION
Users would sometimes not click the text when trying to access a tab. Now, the entire rectangle is treated as a link. 
![image](https://github.com/zeeguu/web/assets/17390076/998779df-84e8-4bca-b7d5-f51ce43daca1)

Blue displays the previous selectable area and green the new clickable area to navigate. 