### PR TITLE
Extension message minor UI fix

### DIFF
--- a/src/components/ExtensionMessage.js
+++ b/src/components/ExtensionMessage.js
@@ -49,7 +49,7 @@ export default function ExtensionMessage({
               browser extension.
             </p>
             <img
-              className="fullDivWidthImage"
+              className="full-width-img"
               src={"../static/images/find-extension.png"}
               //TODO: Add new alt description
               alt="Zeeguu browser extension"


### PR DESCRIPTION
Due to an outdated class name `fullDivWidthImage,` the image in the Extension Message modal did not scale properly and was too big. To solve it - I have updated its className with the currently used after the most recent modal refactor: `full-width-img`. 

**Before fix:**
<kbd><img width="800" alt="modal_before" src="https://github.com/zeeguu/web/assets/115182912/2b6bf5d5-b0fd-4031-815a-997bb19cd05b"></kbd>


**After fix:**
 <kbd><img width="800" alt="modal_after" src="https://github.com/zeeguu/web/assets/115182912/5ff6c30d-346e-4e3e-957a-880a6d1576f3"> </kbd>