### PR TITLE
FIxed the text not being able to copy with spaces

### DIFF
--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -10,9 +10,10 @@ import {
 
 const TranslatableText = styled.div`
   z-tag {
-    padding-right: 0.3em;
+    white-space: break-spaces;
     cursor: pointer;
-    /* margin-right: 1em; */
+    /* margin-right: 1em; 
+    padding-right: 0.3em;*/
     display: inline-block;
     margin: 0;
     line-height: 29px;

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -67,7 +67,7 @@ export default function TranslatableWord({
   if (!word.translation) {
     return (
       <>
-        <z-tag onClick={(e) => clickOnWord(e, word)}>{word.word}</z-tag>
+        <z-tag onClick={(e) => clickOnWord(e, word)}>{word.word + " "}</z-tag>
       </>
     );
   }


### PR DESCRIPTION
Fixed the fact that the text could not be Copy + Pasted with the Spaces from the text.

## Current behaviour:

![image](https://github.com/zeeguu/web/assets/17390076/bcaa2a07-b0b8-4b41-8f27-6c094de9a324)

```
SoldatenMichelBlödornlåfastspændtpåskafottetenjuni-eftermiddagi1739.
Hanskullehenrettesformord. 
```

## Changed to:

![image](https://github.com/zeeguu/web/assets/17390076/c199a1ab-7fb7-45ca-92ec-f133b0691312)
```
Soldaten Michel Blödorn lå fastspændt på skafottet en juni-eftermiddag i 1739.
Han skulle henrettes for mord. 
```