### PR TITLE
Fix audio playback control

### DIFF
--- a/src/assorted/SessionStorage.js
+++ b/src/assorted/SessionStorage.js
@@ -26,19 +26,6 @@ const SessionStorage = {
     return sessionStorage[this.Keys.AudioExercisesEnabled] === "true";
   },
   /**
-   * @return {boolean}
-   */
-  isAudioBeingPlayed: function () {
-    return sessionStorage[this.Keys.AudioBeingPlayed] === "true";
-  },
-  /**
-   * @param {boolean} is_playing
-   */
-  setAudioBeingPlayed: function (is_playing) {
-    sessionStorage[this.Keys.AudioBeingPlayed] = is_playing;
-  },
-
-  /**
    * @param {boolean} is_enabled
    */
   setAudioExercisesEnabled: function (is_enabled) {

--- a/src/exercises/exerciseTypes/SpeakButton.js
+++ b/src/exercises/exerciseTypes/SpeakButton.js
@@ -79,7 +79,7 @@ export default function SpeakButton({
 
   async function handleSpeak() {
     // If audio is playing don't let other buttons be clicked.
-    if (SessionStorage.isAudioBeingPlayed()) return;
+    if (speech.isCurrentlySpeaking) return;
     try {
       if (isReadContext) {
         await speech.speakOut(bookmarkToStudy.context, setIsSpeaking);
@@ -88,7 +88,6 @@ export default function SpeakButton({
       }
     } catch (err) {
       console.log("There was an error executing the speech: " + err);
-      SessionStorage.setAudioBeingPlayed(false);
     }
   }
 

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -65,13 +65,9 @@ export default function TranslateWhatYouHear({
   }, []);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    if (SessionStorage.isAudioExercisesEnabled()) {
       handleSpeak();
-    }, 300);
-
-    return () => {
-      clearTimeout(timer);
-    };
+    }
   }, [interactiveText]);
 
   function handleShowSolution(e, message) {

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -76,8 +76,9 @@ export default function Settings({ api, setUser }) {
     });
     api.getUserPreferences((preferences) => {
       setAudioExercises(
-        preferences["audio_exercises"] === undefined ||
-          preferences["audio_exercises"] === "true",
+        (preferences["audio_exercises"] === undefined ||
+          preferences["audio_exercises"] === "true") &&
+          SessionStorage.isAudioExercisesEnabled(),
       );
     });
     api.getSystemLanguages((systemLanguages) => {
@@ -275,7 +276,12 @@ export default function Settings({ api, setUser }) {
                 checked={audioExercises}
                 onChange={handleAudioExercisesChange}
               />
-              <label>Include Audio Exercises</label>
+              <label>
+                Include Audio Exercises{" "}
+                {SessionStorage.isAudioExercisesEnabled()
+                  ? ""
+                  : "(Temporaly Disabled)"}
+              </label>
             </div>
             {Feature.merle_exercises() && (
               <div style={{ display: "flex" }} className="form-group">

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -14,6 +14,7 @@ import { CEFR_LEVELS } from "../assorted/cefrLevels";
 import { saveUserInfoIntoCookies } from "../utils/cookies/userInfo";
 import { PageTitle } from "../components/PageTitle";
 import Feature from "../features/Feature";
+import SessionStorage from "../assorted/SessionStorage";
 
 export default function Settings({ api, setUser }) {
   const [userDetails, setUserDetails] = useState(null);
@@ -122,7 +123,7 @@ export default function Settings({ api, setUser }) {
     modifyCEFRlevel(userDetails.learned_language, cefr);
 
     console.log("saving: productiveExercises: " + productiveExercises);
-
+    SessionStorage.setAudioExercisesEnabled(audioExercises);
     api.saveUserDetails(userDetails, setErrorMessage, () => {
       api.saveUserPreferences(
         {


### PR DESCRIPTION
+ The reason this happens is because autoplay is not allowed in a page the user hasn't interacted with. Instead a promise should be used to check if the audio was played, and based on that we should reset the status of the animation and the flag.

Essentially the timeout we were using could allow users to click on the page and therefor allow the autoplay to take place.

With this change, the user will see the button and have to click it, but the following exercises they should hear the sound without clicking.

More info can be found at: https://developer.chrome.com/blog/autoplay