### PR TITLE
fix to avoid context appearing several times in the same exercise

### DIFF
--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -10,16 +10,16 @@ import { learningCycleEnum } from "./ExerciseTypeConstants";
  * with the required amount of bookmarks assigned to each exercise and the first set of bookmarks set as
  * currentBookmarksToStudy to begin the exercise session.
  */
-function getExerciseListByType(exerciseList) {
-  let exerciseByType = {};
+function getExerciseListByLearningCycle(exerciseList) {
+  let exerciseByLearningCycle = {};
   for (let i = 0; i < exerciseList.length; i++) {
     let exercise = exerciseList[i];
-    if (!exerciseByType[exercise.learningCycle]) {
-      exerciseByType[exercise.learningCycle] = [];
+    if (!exerciseByLearningCycle[exercise.learningCycle]) {
+      exerciseByLearningCycle[exercise.learningCycle] = [];
     }
-    exerciseByType[exercise.learningCycle].push(exercise);
+    exerciseByLearningCycle[exercise.learningCycle].push(exercise);
   }
-  return exerciseByType;
+  return exerciseByLearningCycle;
 }
 
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
@@ -37,16 +37,17 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
 
   let exerciseSequence = [];
 
-  let exercisesByType = getExerciseListByType(exerciseTypesList);
+  let exercisesByLearningCycle =
+    getExerciseListByLearningCycle(exerciseTypesList);
 
   for (let i = 0; i < bookmarks.length; i++) {
     // Filter the exercises based on the learning_cycle attribute of the bookmark
-    let possibleExercisesTypes =
-      exercisesByType[learningCycleEnum[bookmarks[i].learning_cycle]];
+    let exerciseListForCycle =
+      exercisesByLearningCycle[learningCycleEnum[bookmarks[i].learning_cycle]];
 
     let suitableExerciseFound = false;
     while (!suitableExerciseFound) {
-      let selectedExerciseType = random(possibleExercisesTypes);
+      let selectedExerciseType = random(exerciseListForCycle);
 
       // Check if there are enough bookmarks for the selected exercise
       if (i + selectedExerciseType.requiredBookmarks <= bookmarks.length) {
@@ -70,9 +71,9 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
         }
       }
       if (!suitableExerciseFound) {
-        possibleExercisesTypes = _removeExerciseFromList(
+        exerciseListForCycle = _removeExerciseFromList(
           selectedExerciseType,
-          possibleExercisesTypes,
+          exerciseListForCycle,
         );
       }
     }

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -41,7 +41,8 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
           i + selectedExercise.requiredBookmarks,
         );
         let contexts = potentialBookmarks.map((bookmark) => bookmark.context);
-        if (new Set(contexts).size === contexts.length) {
+        let distinctContexts = new Set(contexts).size;
+        if (distinctContexts === contexts.length) {
           let exercise = {
             type: selectedExercise.type,
             bookmarks: potentialBookmarks,

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -23,42 +23,56 @@ function getExerciseListByType(exerciseList) {
 }
 
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
+  function _removeExerciseFromList(exercise, list) {
+    list.filter((exercise) => exercise !== exercise);
+  }
+
+  function _distinctContexts(potentialBookmarks) {
+    let potentialBookmarkContexts = potentialBookmarks.map(
+      (bookmark) => bookmark.context,
+    );
+    let distinctContextsCount = new Set(potentialBookmarkContexts).size;
+    return distinctContextsCount === potentialBookmarkContexts.length;
+  }
+
   let exerciseSequence = [];
+
   let exercisesByType = getExerciseListByType(exerciseTypesList);
+
   for (let i = 0; i < bookmarks.length; i++) {
     // Filter the exercises based on the learning_cycle attribute of the bookmark
-    let filteredExercises =
+    let possibleExercisesTypes =
       exercisesByType[learningCycleEnum[bookmarks[i].learning_cycle]];
 
     let suitableExerciseFound = false;
     while (!suitableExerciseFound) {
-      let selectedExercise = random(filteredExercises);
+      let selectedExerciseType = random(possibleExercisesTypes);
 
       // Check if there are enough bookmarks for the selected exercise
-      if (i + selectedExercise.requiredBookmarks <= bookmarks.length) {
+      if (i + selectedExerciseType.requiredBookmarks <= bookmarks.length) {
         let potentialBookmarks = bookmarks.slice(
           i,
-          i + selectedExercise.requiredBookmarks,
+          i + selectedExerciseType.requiredBookmarks,
         );
-        let contexts = potentialBookmarks.map((bookmark) => bookmark.context);
-        let distinctContexts = new Set(contexts).size;
-        if (distinctContexts === contexts.length) {
+
+        if (_distinctContexts(potentialBookmarks)) {
           let exercise = {
-            type: selectedExercise.type,
+            type: selectedExerciseType.type,
             bookmarks: potentialBookmarks,
           };
           exerciseSequence.push(exercise);
 
           // Skip the assigned bookmarks
-          i += selectedExercise.requiredBookmarks - 1;
+          i += selectedExerciseType.requiredBookmarks - 1;
           suitableExerciseFound = true;
         } else {
           suitableExerciseFound = false;
         }
       }
       if (!suitableExerciseFound) {
-        filteredExercises = filteredExercises.filter(
-          (exercise) => exercise !== selectedExercise,
+        possibleExercisesTypes = _removeExerciseFromList(
+          selectedExerciseType,
+          possibleExercisesTypes,
         );
       }
     }

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -36,16 +36,26 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
 
       // Check if there are enough bookmarks for the selected exercise
       if (i + selectedExercise.requiredBookmarks <= bookmarks.length) {
-        let exercise = {
-          type: selectedExercise.type,
-          bookmarks: bookmarks.slice(i, i + selectedExercise.requiredBookmarks),
-        };
-        exerciseSequence.push(exercise);
+        let potentialBookmarks = bookmarks.slice(
+          i,
+          i + selectedExercise.requiredBookmarks,
+        );
+        let contexts = potentialBookmarks.map((bookmark) => bookmark.context);
+        if (new Set(contexts).size === contexts.length) {
+          let exercise = {
+            type: selectedExercise.type,
+            bookmarks: potentialBookmarks,
+          };
+          exerciseSequence.push(exercise);
 
-        // Skip the assigned bookmarks
-        i += selectedExercise.requiredBookmarks - 1;
-        suitableExerciseFound = true;
-      } else {
+          // Skip the assigned bookmarks
+          i += selectedExercise.requiredBookmarks - 1;
+          suitableExerciseFound = true;
+        } else {
+          suitableExerciseFound = false;
+        }
+      }
+      if (!suitableExerciseFound) {
         filteredExercises = filteredExercises.filter(
           (exercise) => exercise !== selectedExercise,
         );

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -24,7 +24,7 @@ function getExerciseListByType(exerciseList) {
 
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
   function _removeExerciseFromList(exercise, list) {
-    list.filter((exercise) => exercise !== exercise);
+    list.filter((ex) => ex !== exercise);
   }
 
   function _distinctContexts(potentialBookmarks) {


### PR DESCRIPTION
This pull request contains a fix so a context cannot appear several times in the same exercise to avoid cases like this:

![context](https://github.com/zeeguu/web/assets/147062323/9d8c3c16-c200-4987-a987-b129b859c34f)

In the above example, a new user had bookmarked several words in the same sentence in his first article read on Zeeguu and all bookmarks were tested in the same exercise. 
