### PR TITLE
Word click in interactive text pronounces

### DIFF
--- a/src/articles/SearchField.sc.js
+++ b/src/articles/SearchField.sc.js
@@ -24,15 +24,16 @@ const SearchField = styled.div`
     font-weight: 300;
     font-size: 0.875em;
     height: 1.5em;
+    &:focus {
+      border: 0.17em solid ${almostBlack};
+      font-weight: 500 !important;
+    }
   }
-
   .searchTextfieldInput {
     color: ${almostBlack};
     font-weight: 400;
     font-size: small;
     background: ${zeeguuVeryLightYellow};
-    background: green;
-    border-bottom: 1px solid ${zeeguuLightYellow} !important;
   }
 `;
 

--- a/src/articles/SearchField.sc.js
+++ b/src/articles/SearchField.sc.js
@@ -1,5 +1,10 @@
 import styled from "styled-components";
-import { zeeguuOrange } from "../components/colors";
+import {
+  zeeguuOrange,
+  almostBlack,
+  zeeguuLightYellow,
+  zeeguuVeryLightYellow,
+} from "../components/colors";
 
 const SearchField = styled.div`
   margin-bottom: 1em;
@@ -19,6 +24,15 @@ const SearchField = styled.div`
     font-weight: 300;
     font-size: 0.875em;
     height: 1.5em;
+  }
+
+  .searchTextfieldInput {
+    color: ${almostBlack};
+    font-weight: 400;
+    font-size: small;
+    background: ${zeeguuVeryLightYellow};
+    background: green;
+    border-bottom: 1px solid ${zeeguuLightYellow} !important;
   }
 `;
 

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -8,12 +8,13 @@ export default function AlterMenu({
   clickedOutsideAlterMenu,
   selectAlternative,
   hideTranslation,
+  clickedOutsideTranslation,
 }) {
   const [refToAlterMenu, hasClickedOutside] = useClickOutside();
   const [inputValue, setInputValue] = useState("");
 
   useEffect(() => {
-    if (hasClickedOutside) {
+    if (hasClickedOutside && clickedOutsideTranslation) {
       clickedOutsideAlterMenu();
     }
   }, [hasClickedOutside, clickedOutsideAlterMenu]);
@@ -60,7 +61,7 @@ export default function AlterMenu({
       ))}
 
       <input
-        className=".ownTranslationInput matchWidth"
+        className="ownTranslationInput matchWidth"
         type="text"
         id="#userAlternative"
         value={inputValue}

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useClickOutside } from "react-click-outside-hook";
 import { zeeguuDarkOrange } from "../components/colors";
+import { AlterMenuSC } from "./AlterMenu.sc";
 
 export default function AlterMenu({
   word,
   clickedOutsideAlterMenu,
   selectAlternative,
+  hideTranslation,
 }) {
   const [refToAlterMenu, hasClickedOutside] = useClickOutside();
   const [inputValue, setInputValue] = useState("");
@@ -41,29 +43,35 @@ export default function AlterMenu({
   }
 
   return (
-    <div ref={refToAlterMenu} className="altermenu">
+    <AlterMenuSC ref={refToAlterMenu}>
       {word.alternatives.map((each) => (
         <div
           key={each.translation}
-          onClick={(e) => selectAlternative(each.translation, shortenSource(each))}
+          onClick={(e) =>
+            selectAlternative(each.translation, shortenSource(each))
+          }
           className="additionalTrans"
         >
           {each.translation}
-          <div style={{ fontSize: 9, color: zeeguuDarkOrange}}>
+          <div style={{ fontSize: 9, color: zeeguuDarkOrange }}>
             {shortenSource(each)}
           </div>
         </div>
       ))}
 
       <input
-        className="searchTextfieldInput matchWidth"
+        className=".ownTranslationInput matchWidth"
         type="text"
         id="#userAlternative"
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={(e) => handleKeyDown(e)}
-        placeholder="Own translation..."
+        placeholder="add translation..."
       />
-    </div>
+
+      <div className="alterMenuLink" onClick={(e) => hideTranslation(e, word)}>
+        Remove
+      </div>
+    </AlterMenuSC>
   );
 }

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -5,19 +5,19 @@ import { AlterMenuSC } from "./AlterMenu.sc";
 
 export default function AlterMenu({
   word,
-  clickedOutsideAlterMenu,
+  hideAlterMenu,
   selectAlternative,
   hideTranslation,
   clickedOutsideTranslation,
 }) {
-  const [refToAlterMenu, hasClickedOutside] = useClickOutside();
+  const [refToAlterMenu, clickedOutsideAlterMenu] = useClickOutside();
   const [inputValue, setInputValue] = useState("");
 
   useEffect(() => {
-    if (hasClickedOutside && clickedOutsideTranslation) {
-      clickedOutsideAlterMenu();
+    if (clickedOutsideAlterMenu && clickedOutsideTranslation) {
+      hideAlterMenu();
     }
-  }, [hasClickedOutside, clickedOutsideAlterMenu]);
+  }, [clickedOutsideAlterMenu]);
 
   function handleKeyDown(e) {
     if (e.code === "Enter") {
@@ -67,11 +67,11 @@ export default function AlterMenu({
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={(e) => handleKeyDown(e)}
-        placeholder="add translation..."
+        placeholder="add own translation..."
       />
 
       <div className="alterMenuLink" onClick={(e) => hideTranslation(e, word)}>
-        Remove
+        Hide Translation
       </div>
     </AlterMenuSC>
   );

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -27,12 +27,24 @@ const AlterMenuSC = styled.div`
   }
 
   .ownTranslationInput {
+    all: unset;
+    border: 0.17em solid ${zeeguuLightYellow};
+    border-radius: 0.9375em;
+    padding: 0.125em;
+    padding-left: 0.5em;
+    padding-right: 5px;
+    height: 2em;
+    width: 100%;
+    box-sizing: border-box;
+    background: white;
     color: ${almostBlack};
+    border-radius: 1em;
     font-weight: 400;
     font-size: small;
-    background: ${zeeguuVeryLightYellow};
-    background: green;
-    border-bottom: 1px solid ${zeeguuLightYellow} !important;
+    &:focus {
+      border: 0.17em solid ${almostBlack};
+      font-weight: 500;
+    }
   }
 
   .alterMenuLink {

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+
+import {
+  almostBlack,
+  zeeguuLightYellow,
+  zeeguuVeryLightYellow,
+} from "../components/colors";
+
+const AlterMenuSC = styled.div`
+  font-size: medium;
+
+  position: absolute;
+  max-width: 30em;
+  background-color: ${zeeguuVeryLightYellow};
+  border-radius: 0.3em;
+  margin-top: 0.5em;
+  padding: 0.3em;
+
+  .additionalTrans {
+    height: 100%;
+    text-transform: lowercase;
+    white-space: normal;
+    border-bottom: 1px solid ${zeeguuLightYellow} !important;
+    color: ${almostBlack};
+    line-height: 1em;
+    cursor: pointer;
+  }
+
+  .ownTranslationInput {
+    color: ${almostBlack};
+    font-weight: 400;
+    font-size: small;
+    background: ${zeeguuVeryLightYellow};
+    background: green;
+    border-bottom: 1px solid ${zeeguuLightYellow} !important;
+  }
+
+  .alterMenuLink {
+    text-decoration: underline;
+    color: orange;
+  }
+`;
+
+export { AlterMenuSC };

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -43,6 +43,7 @@ const AlterMenuSC = styled.div`
     border-radius: 1em;
     font-weight: 400;
     font-size: small;
+
     &:focus {
       border: 0.17em solid ${almostBlack};
       font-weight: 500;
@@ -50,7 +51,9 @@ const AlterMenuSC = styled.div`
   }
 
   .alterMenuLink {
-    text-decoration: underline;
+    //text-decoration: underline;
+    margin-top: 0.2em;
+    border-top: 1px solid ${zeeguuLightYellow} !important;
     color: orange;
   }
 `;

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -2,7 +2,9 @@ import styled from "styled-components";
 
 import {
   almostBlack,
+  zeeguuDarkOrange,
   zeeguuLightYellow,
+  zeeguuOrange,
   zeeguuVeryLightYellow,
 } from "../components/colors";
 
@@ -12,7 +14,8 @@ const AlterMenuSC = styled.div`
   position: absolute;
   max-width: 30em;
   background-color: ${zeeguuVeryLightYellow};
-  border-radius: 0.3em;
+  border: 0.15em solid ${zeeguuDarkOrange};
+  border-radius: 0.5em;
   margin-top: 0.5em;
   padding: 0.3em;
 
@@ -29,7 +32,6 @@ const AlterMenuSC = styled.div`
   .ownTranslationInput {
     all: unset;
     border: 0.17em solid ${zeeguuLightYellow};
-    border-radius: 0.9375em;
     padding: 0.125em;
     padding-left: 0.5em;
     padding-right: 5px;

--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -39,7 +39,7 @@ export function TranslatableText({
         </div>
       )),
     );
-  }, [paragraphs, translationCount, isCorrect]);
+  }, [paragraphs, translationCount, translating, pronouncing, isCorrect]);
 
   useEffect(() => {
     if (setIsRendered) setIsRendered(true);

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -49,13 +49,15 @@ const TranslatableText = styled.div`
   z-tag z-tran {
     margin-top: 0.2em;
     margin-bottom: -0.1em;
+    margin-left: -0.3em;
     padding: 2px;
+    padding-left: 0.3em;
     border-radius: 0.3em 0.3em 0.3em 0.3em;
     background-clip: padding-box;
     background-color: ${zeeguuLightYellow};
     font-size: medium;
     line-height: 1em;
-    max-width: 24em;
+    max-width: 100%;
     font-weight: 600;
     color: ${almostBlack};
     text-transform: lowercase;

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -47,6 +47,8 @@ const TranslatableText = styled.div`
    */
 
   z-tag z-tran {
+    margin-top: 0.2em;
+    margin-bottom: -0.1em;
     padding: 2px;
     border-radius: 0.3em 0.3em 0.3em 0.3em;
     background-clip: padding-box;

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -3,9 +3,7 @@ import {
   almostBlack,
   zeeguuLightYellow,
   zeeguuOrange,
-  zeeguuVeryLightYellow,
-  translationHover,
-  lightOrange,
+  zeeguuTransparentLightOrange,
 } from "../components/colors";
 
 const TranslatableText = styled.div`
@@ -24,6 +22,7 @@ const TranslatableText = styled.div`
     animation: blink 1.5s linear infinite;
     color: ${zeeguuOrange};
   }
+
   @keyframes blink {
     0% {
       opacity: 0.2;
@@ -39,8 +38,7 @@ const TranslatableText = styled.div`
   /*  z-tag tag hover changes color, translated word hover no underline or color*/
 
   z-tag:hover {
-    color: ${translationHover} !important;
-    background-color: ${lightOrange};
+    background-color: ${zeeguuTransparentLightOrange};
   }
 
   /* the translation - above the origin word
@@ -49,9 +47,7 @@ const TranslatableText = styled.div`
    */
 
   z-tag z-tran {
-    display: block;
     margin-top: -9px;
-    margin-bottom: -4px;
     padding: 2px;
     border-radius: 0.3em 0.3em 0.3em 0.3em;
     background-clip: padding-box;
@@ -59,47 +55,30 @@ const TranslatableText = styled.div`
     font-size: medium;
     line-height: 1em;
     max-width: 24em;
-    font-weight: 300;
+    font-weight: 600;
     color: ${almostBlack};
     text-transform: lowercase;
-    text-align: center;
+    text-align: left;
+    display: flex;
   }
 
   z-tag z-tran:hover {
     color: black;
   }
 
-  /*
-    the original word decoration; a simple dashed underline highlights
-    the fact that we are not sure of the translation; underline becomes
-    solid if the user selects an alternative, confirms this one, or
-    uploads a new translation
-*/
   z-tag z-orig {
     border-bottom: 1px dashed ${zeeguuOrange};
     width: 100%;
     color: ${zeeguuOrange};
-  }
-
-  /* when there are multiple translations, we mark this with a little
-green downwards pointing triangle; we used to mark also single alternatives
- but for now there's no marking for them */
-
-  z-tag z-tran moreAlternatives {
-    font-size: 0.5em;
-    float: right;
-    width: 1em;
-    padding-left: 0.5em;
-  }
-
-  z-tag z-tran moreAlternatives {
+    font-weight: 600;
   }
 
   z-tran > .arrow {
-    visibility: hidden;
-    margin: 0;
     padding: 0;
+    margin-left: auto;
+    color: rgba(0, 0, 0, 0.2);
   }
+
   z-tran:hover > .arrow {
     visibility: visible;
   }
@@ -108,21 +87,6 @@ green downwards pointing triangle; we used to mark also single alternatives
     content: attr(chosen);
   }
 
-  z-tag z-tran moreAlternatives:after {
-    content: "▼";
-    color: ${almostBlack};
-  }
-
-  /* once the user has
- - selected an alternative we change
-  the class to handSelected
- - contributed their own alternative
-  by typing (handContributing) we change
-  the class to handContributed
-
-  these classes currently show a mini
-  animation
- */
   .handSelected,
   .handContributed {
     width: 1.5em;
@@ -131,7 +95,7 @@ green downwards pointing triangle; we used to mark also single alternatives
 
   .handSelected:after,
   .handContributed:after {
-    display: hidden;
+    display: none;
     opacity: 0.1;
     transition:
       visibility 0s 2s,
@@ -163,46 +127,6 @@ that made the UI too heavy ... */
 
   .selectedAlternativeOrig,
   .contributedAlternativeOrig {
-  }
-
-  .altermenu {
-    position: absolute;
-    max-width: 30em;
-    background-color: ${zeeguuVeryLightYellow};
-    border-radius: 0.3em;
-    margin-top: 0.5em;
-  }
-
-  .altermenu .additionalTrans {
-    height: 100%;
-    text-transform: lowercase;
-    white-space: normal;
-    border-bottom: 1px solid ${zeeguuLightYellow}!important;
-    color: ${almostBlack};
-    line-height: 1em;
-    padding: 0.3em;
-    border: none;
-    cursor: pointer;
-    font-size: medium;
-  }
-
-  .altermenu * {
-    font-family: Montserrat;
-    font-weight: 400;
-    font-size: 0.9em;
-  }
-
-  .alterMenuContainer {
-    display: none;
-  }
-
-  .searchTextfieldInput {
-    color: ${almostBlack};
-    font-weight: 400;
-    border: none;
-    padding: 0.3em;
-    font-size: x-small;
-    background: ${zeeguuVeryLightYellow};
   }
 `;
 

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -47,7 +47,6 @@ const TranslatableText = styled.div`
    */
 
   z-tag z-tran {
-    margin-top: -9px;
     padding: 2px;
     border-radius: 0.3em 0.3em 0.3em 0.3em;
     background-clip: padding-box;

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useClickOutside } from "react-click-outside-hook";
 import AlterMenu from "./AlterMenu";
 
 export default function TranslatableWord({
@@ -12,14 +13,15 @@ export default function TranslatableWord({
   disableTranslation,
 }) {
   const [showingAlternatives, setShowingAlternatives] = useState(false);
+  const [refToZTran, hasClickedOutside] = useClickOutside();
 
   function clickOnWord(e, word) {
     if (word.translation) {
       interactiveText.pronounce(word);
       return;
     }
-    e.target.className = "loading";
     if (translating) {
+      e.target.className = "loading";
       interactiveText.translate(word, () => {
         wordUpdated();
         e.target.className = null;
@@ -83,6 +85,7 @@ export default function TranslatableWord({
         <z-tran
           chosen={word.translation}
           translation0={word.translation}
+          ref={refToZTran}
           onClick={(e) => toggleAlternatives(e, word)}
         >
           <span className="arrow">▼</span>
@@ -95,6 +98,7 @@ export default function TranslatableWord({
               setShowingAlternatives={setShowingAlternatives}
               selectAlternative={selectAlternative}
               clickedOutsideAlterMenu={clickedOutsideAlterMenu}
+              clickedOutsideTranslation={hasClickedOutside}
               hideTranslation={hideTranslation}
             />
           )}

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -12,8 +12,8 @@ export default function TranslatableWord({
   setTranslatedWords,
   disableTranslation,
 }) {
-  const [showingAlternatives, setShowingAlternatives] = useState(false);
-  const [refToZTran, hasClickedOutside] = useClickOutside();
+  const [showingAlterMenu, setShowingAlterMenu] = useState(false);
+  const [refToTranslation, clickedOutsideTranslation] = useClickOutside();
 
   function clickOnWord(e, word) {
     if (word.translation) {
@@ -37,14 +37,14 @@ export default function TranslatableWord({
     }
   }
 
-  function toggleAlternatives(e, word) {
-    if (showingAlternatives) {
-      setShowingAlternatives(false);
+  function toggleAlterMenu(e, word) {
+    if (showingAlterMenu) {
+      setShowingAlterMenu(false);
       return;
     }
     interactiveText.alternativeTranslations(word, () => {
       wordUpdated(word);
-      setShowingAlternatives(!showingAlternatives);
+      setShowingAlterMenu(!showingAlterMenu);
     });
   }
 
@@ -55,13 +55,13 @@ export default function TranslatableWord({
       preferredSource,
       () => {
         wordUpdated();
-        setShowingAlternatives(false);
+        setShowingAlterMenu(false);
       },
     );
   }
 
-  function clickedOutsideAlterMenu() {
-    setShowingAlternatives(false);
+  function hideAlterMenu() {
+    setShowingAlterMenu(false);
   }
 
   function hideTranslation(e, word) {
@@ -85,20 +85,21 @@ export default function TranslatableWord({
         <z-tran
           chosen={word.translation}
           translation0={word.translation}
-          ref={refToZTran}
-          onClick={(e) => toggleAlternatives(e, word)}
+          ref={refToTranslation}
+          onClick={(e) => toggleAlterMenu(e, word)}
         >
           <span className="arrow">▼</span>
         </z-tran>
+
         <z-orig>
           <span onClick={(e) => clickOnWord(e, word)}>{word.word} </span>
-          {showingAlternatives && (
+          {showingAlterMenu && (
             <AlterMenu
               word={word}
-              setShowingAlternatives={setShowingAlternatives}
+              setShowingAlternatives={setShowingAlterMenu}
               selectAlternative={selectAlternative}
-              clickedOutsideAlterMenu={clickedOutsideAlterMenu}
-              clickedOutsideTranslation={hasClickedOutside}
+              hideAlterMenu={hideAlterMenu}
+              clickedOutsideTranslation={clickedOutsideTranslation}
               hideTranslation={hideTranslation}
             />
           )}

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -14,6 +14,10 @@ export default function TranslatableWord({
   const [showingAlternatives, setShowingAlternatives] = useState(false);
 
   function clickOnWord(e, word) {
+    if (word.translation) {
+      interactiveText.pronounce(word);
+      return;
+    }
     e.target.className = "loading";
     if (translating) {
       interactiveText.translate(word, () => {
@@ -84,13 +88,14 @@ export default function TranslatableWord({
           <span className="arrow">▼</span>
         </z-tran>
         <z-orig>
-          <span onClick={(e) => hideTranslation(e, word)}>{word.word} </span>
+          <span onClick={(e) => clickOnWord(e, word)}>{word.word} </span>
           {showingAlternatives && (
             <AlterMenu
               word={word}
               setShowingAlternatives={setShowingAlternatives}
               selectAlternative={selectAlternative}
               clickedOutsideAlterMenu={clickedOutsideAlterMenu}
+              hideTranslation={hideTranslation}
             />
           )}
         </z-orig>


### PR DESCRIPTION
On clicking a word again the word is pronounced again rather than removed. Remove is now an option in the dropdown menu of the translation: 

<img width="804" alt="image" src="https://github.com/zeeguu/web/assets/464519/b59f3424-1ef4-4056-9319-7e3230fa8599">

Also, small stylistic improvements over the old translation style that increase readability (compare above with below)

<img width="842" alt="image" src="https://github.com/zeeguu/web/assets/464519/a4364e67-ccf6-4c0a-9479-b7dfcd5f85cf">
