### PR TITLE
Activity timer on phone screens fix

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -17,6 +17,8 @@ import {
 
 import { assignBookmarksToExercises } from "./assignBookmarksToExercises";
 
+import { isMobile } from "../utils/misc/browserDetection";
+
 import {
   DEFAULT_SEQUENCE,
   DEFAULT_SEQUENCE_NO_AUDIO,
@@ -376,11 +378,13 @@ export default function Exercises({
           </p>
         )}
       </s.ExercisesColumn>
-      <ActivityTimer
-        message="Total time in this exercise session"
-        activeSessionDuration={activeSessionDuration}
-        clockActive={clockActive}
-      />
+      {!isMobile() && (
+        <ActivityTimer
+          message="Total time in this exercise session"
+          activeSessionDuration={activeSessionDuration}
+          clockActive={clockActive}
+        />
+      )}
     </>
   );
 }

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -142,7 +142,7 @@ let strings = new LocalizedStrings(
         "Our system continuously searches the net for texts based on your personalized interests. We believe that personally relevant texts will motivate you to study more.",
       personalizedRecommandationsEllaboration2:
         'Moreover, we aim to help you to find texts that are at the right difficulty level since you learn best when materials are challenging but not too difficult (this is what is called "studying in the zone of proximal development").',
-      easyTranslations: "Easy Translation & Pronounciation",
+      easyTranslations: "Easy Translation & Pronunciation",
       easyTranslationsEllaboration1:
         "If a text is challenging it will also include words that you don't understand or don't know how to pronounce.",
       easyTranslationsEllaboration2:
@@ -492,7 +492,7 @@ let strings = new LocalizedStrings(
       elementary: "Elementary",
       intermediate: "Intermediate",
       upperIntermediate: "Upper Intermediate",
-      advanced: "Avanced",
+      advanced: "Advanced",
       proficiency: "Proficiency",
 
       //_ActivityInsightsRouter
@@ -547,7 +547,7 @@ let strings = new LocalizedStrings(
       badExample: "bad example",
       dontShowAgain: "don't show again",
       starExplanation:
-        "The asterix next to the word indicates that the student has exercised the word at least once.",
+        "The asterisk next to the word indicates that the student has exercised the word at least once.",
 
       //CohortForm
       editClass: "Edit Class",
@@ -575,7 +575,7 @@ let strings = new LocalizedStrings(
       addTeacherWarningPartOne:
         "This adds the class to your colleague's list of classes.",
       addTeacherWarningPartTwo:
-        "If you later delete this class, you also irriversibly delete the class from your colleague's list of classes.",
+        "If you later delete this class, you also irreversibly delete the class from your colleague's list of classes.",
       youHaveToAddEmail: "You have to add the email of a teacher.",
       errorMsg:
         "Something went wrong. It can be that the email is not matching anyone in the system or a server error. Feel free to contact us if the error persists.",
@@ -776,7 +776,7 @@ let strings = new LocalizedStrings(
 
       //StudentTranslations
       translatedWordsInSentence:
-        "Translated words in the context of their sencences",
+        "Translated words in the context of their sentences",
       translatedWordInText: "The student translated no words in this text.",
 
       //TeacherTextPreview

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -142,7 +142,7 @@ let strings = new LocalizedStrings(
         "Our system continuously searches the net for texts based on your personalized interests. We believe that personally relevant texts will motivate you to study more.",
       personalizedRecommandationsEllaboration2:
         'Moreover, we aim to help you to find texts that are at the right difficulty level since you learn best when materials are challenging but not too difficult (this is what is called "studying in the zone of proximal development").',
-      easyTranslations: "Easy Translation & Pronunciation",
+      easyTranslations: "Easy Translation & Pronounciation",
       easyTranslationsEllaboration1:
         "If a text is challenging it will also include words that you don't understand or don't know how to pronounce.",
       easyTranslationsEllaboration2:
@@ -415,7 +415,7 @@ let strings = new LocalizedStrings(
       multipleChoiceL2toL1Headline:
         "Select the correct translation of the bold word",
       clickWordInContextHeadline:
-        "Find the word in the context and click on it",
+        "Find the translation of the word below in the context and click on it",
       multipleChoiceContextHeadline: "Choose the context that fits the word",
 
       //FeedbackButtons
@@ -492,7 +492,7 @@ let strings = new LocalizedStrings(
       elementary: "Elementary",
       intermediate: "Intermediate",
       upperIntermediate: "Upper Intermediate",
-      advanced: "Advanced",
+      advanced: "Avanced",
       proficiency: "Proficiency",
 
       //_ActivityInsightsRouter
@@ -547,7 +547,7 @@ let strings = new LocalizedStrings(
       badExample: "bad example",
       dontShowAgain: "don't show again",
       starExplanation:
-        "The asterisk next to the word indicates that the student has exercised the word at least once.",
+        "The asterix next to the word indicates that the student has exercised the word at least once.",
 
       //CohortForm
       editClass: "Edit Class",
@@ -575,7 +575,7 @@ let strings = new LocalizedStrings(
       addTeacherWarningPartOne:
         "This adds the class to your colleague's list of classes.",
       addTeacherWarningPartTwo:
-        "If you later delete this class, you also irreversibly delete the class from your colleague's list of classes.",
+        "If you later delete this class, you also irriversibly delete the class from your colleague's list of classes.",
       youHaveToAddEmail: "You have to add the email of a teacher.",
       errorMsg:
         "Something went wrong. It can be that the email is not matching anyone in the system or a server error. Feel free to contact us if the error persists.",
@@ -776,7 +776,7 @@ let strings = new LocalizedStrings(
 
       //StudentTranslations
       translatedWordsInSentence:
-        "Translated words in the context of their sentences",
+        "Translated words in the context of their sencences",
       translatedWordInText: "The student translated no words in this text.",
 
       //TeacherTextPreview


### PR DESCRIPTION
This PR removes the activity timer from phone screens due to overlapping.
On smaller phone screens the activity timer prevented users from clicking on the _show solution_ button, so they essentially were stuck in an exercise, if they didn't know the answer. 

I've decided to remove the activity timer, since the UI of the exercises already is quite busy on small screens, so I thought this was the best solution.

<img width="316" alt="screenshot" src="https://github.com/zeeguu/web/assets/147062323/38a7b6e7-c4b5-4dca-ae7e-f2d9800143b5">

<img width="316" alt="Screenshot 2024-05-16 at 11 34 48" src="https://github.com/zeeguu/web/assets/147062323/9e24e034-64f9-453a-b654-e631ece0fb15">

The PR also includes an updated headline for the _Click Word in Context_ exercise, since I have received feedback that the instructions weren't clear.