### PR TITLE
Update _WordsRouter.js

### DIFF
--- a/src/words/_WordsRouter.js
+++ b/src/words/_WordsRouter.js
@@ -77,6 +77,7 @@ export default function WordsRouter({ api }) {
           api={api}
           component={Productive}
         />
+        <PrivateRoute exact path="/words/top" api={api} component={Top} />
         <PrivateRoute
           exact
           path="/render/words/productive"


### PR DESCRIPTION
+ Top words path was not rendering

The cause for this is probably because this used to be the default path, so there was no route for when it's used as a secondary tab like the other. This is an issue now since the default tab is Receptive Words after the new exercises implementation. 