### PR TITLE
Reorder info pages so that language selection comes before registration

### DIFF
--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -62,14 +62,21 @@ export default function MainAppRouter({ api, setUser, hasExtension }) {
           <SignIn api={api} handleSuccessfulSignIn={handleSuccessfulSignIn} />
         )}
       />
+
       <Route
         path="/create_account"
         render={() => (
           <CreateAccount
             api={api}
             handleSuccessfulSignIn={handleSuccessfulSignIn}
+            setUser={setUser}
           />
         )}
+      />
+
+      <Route
+        path="/language_preferences"
+        render={() => <LanguagePreferences api={api} />}
       />
 
       <Route path="/" exact render={() => <LandingPage />} />
@@ -84,13 +91,6 @@ export default function MainAppRouter({ api, setUser, hasExtension }) {
       <Route path="/reset_pass" render={() => <ResetPassword api={api} />} />
 
       <Route path="/render" render={() => <NoSidebarRouter api={api} />} />
-
-      <PrivateRoute
-        path="/language_preferences"
-        api={api}
-        setUser={setUser}
-        component={LanguagePreferences}
-      />
 
       <PrivateRoute
         path="/select_interests"

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -11,6 +11,7 @@ const LocalStorage = {
     Name: "name",
     LearnedLanguage: "learned_language",
     NativeLanguage: "native_language",
+    LearnedCefrLevel: "learned_cefr_level",
     UiLanguage: "ui_language",
     IsTeacher: "is_teacher",
     SelectedTimePeriod: "selected_time_period",
@@ -41,6 +42,30 @@ const LocalStorage = {
 
   isStudent: function () {
     return localStorage[this.Keys.IsStudent] !== "false";
+  },
+
+  getLearnedLanguage: function () {
+    return localStorage[this.Keys.LearnedLanguage];
+  },
+
+  setLearnedLanguage: function (learnedLanguage) {
+    localStorage[this.Keys.LearnedLanguage] = learnedLanguage;
+  },
+
+  getLearnedCefrLevel: function () {
+    return localStorage[this.Keys.LearnedCefrLevel];
+  },
+
+  setLearnedCefrLevel: function (learnedCefrLevel) {
+    localStorage[this.Keys.LearnedCefrLevel] = learnedCefrLevel;
+  },
+
+  getNativeLanguage: function () {
+    return localStorage[this.Keys.NativeLanguage];
+  },
+
+  setNativeLanguage: function (nativeLanguage) {
+    localStorage[this.Keys.NativeLanguage] = nativeLanguage;
   },
 
   selectedTimePeriod: function () {

--- a/src/hooks/useFormField.js
+++ b/src/hooks/useFormField.js
@@ -10,7 +10,13 @@ export default function useFormField(initialState) {
   const [currentState, setState] = useState(initialState);
 
   function handleInputChange(e) {
-    setState(e.target.value);
+    switch (e.target.type) {
+      case "checkbox":
+        setState(e.target.checked);
+        break;
+      default:
+        setState(e.target.value);
+    }
   }
 
   function resetInputState() {

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -66,6 +66,7 @@ let strings = new LocalizedStrings(
       //CreateAccount
       nameIsRequired: "Name is required.",
       passwordMustBeMsg: "Password should be at least 4 characters long.",
+      plsAcceptPrivacyPolicy: "You need to agree to our privacy notice.",
       thankYouMsgPrefix:
         "Thanks for being a beta-tester. We really want to hear from you at",
       thankYouMsgSuffix: ". Contact us also if you don't have an invite code.",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -51,6 +51,7 @@ let strings = new LocalizedStrings(
       youCanChangeLater: "You can always change it later",
       yesPlease: "Yes, please",
       noThankYou: "No, thank you",
+      getStarted: "Get Started",
 
       //LoadingAnimation
       loadingMsg: "Loading...",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -29,6 +29,7 @@ let strings = new LocalizedStrings(
       learnedLanguage: "I want to learn",
       learnedLanguagePlaceholder: "Select language",
       plsProvideValidEmail: "Please provide a valid email.",
+      plsAcceptPrivacyNotice: "Please accept Privacy Notice",
       password: "Password",
       passwordPlaceholder: "Enter Password",
       passwordHelperText: "Must contain at least 4 characters",
@@ -81,8 +82,8 @@ let strings = new LocalizedStrings(
       plsSelectBaseLanguage: "Please select a base language.",
 
       //ExcludeWords
-      addUnwantedWordHelperText:"Add one unwanted word / phrase at a time",
-      unwantedWordPlaceholder:"e.g. robbery",
+      addUnwantedWordHelperText: "Add one unwanted word / phrase at a time",
+      unwantedWordPlaceholder: "e.g. robbery",
 
       //PrivacyNotice
       privacyNotice: "Privacy Notice",

--- a/src/landingPage/LandingPage.js
+++ b/src/landingPage/LandingPage.js
@@ -44,8 +44,8 @@ export default function LandingPage() {
           <h1>Zeeguu</h1>
           <h4>{strings.projectDescription_UltraShort}</h4>
           <nav>
-            <s.PrimaryButton onClick={() => redirect("/create_account")}>
-              <span>{strings.createBetaAccount}</span>
+            <s.PrimaryButton onClick={() => redirect("/language_preferences")}>
+              <span>{strings.getStarted}</span>
             </s.PrimaryButton>
             <s.InverseButton onClick={() => redirect("/login")}>
               <span>{strings.login}</span>

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -46,13 +46,20 @@ export default function CreateAccount({
   const [email, handleEmailChange] = useFormField("");
   const [password, handlePasswordChange] = useFormField("");
 
+  const [isPrivacyNoticeAccepted, setIsPrivacyNoticeAccepted] = useState(false);
+
   const [errorMessage, setErrorMessage] = useState("");
 
   let validatorRules = [
     [name === "", strings.nameIsRequired],
     [!EmailValidator.validate(email), strings.plsProvideValidEmail],
     [password.length < 4, strings.passwordMustBeMsg],
+    [isPrivacyNoticeAccepted === false, strings.plsAcceptPrivacyNotice],
   ];
+
+  function togglePrivacyNoticeConsent() {
+    setIsPrivacyNoticeAccepted((prev) => !prev);
+  }
 
   function handleCreate(e) {
     e.preventDefault();
@@ -148,6 +155,8 @@ export default function CreateAccount({
           </FormSection>
           <FormSection>
             <Checkbox
+              checked={isPrivacyNoticeAccepted}
+              onChange={togglePrivacyNoticeConsent}
               label={
                 <>
                   By checking this box you agree to our{" "}

--- a/src/pages/LanguagePreferences.js
+++ b/src/pages/LanguagePreferences.js
@@ -1,7 +1,6 @@
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect } from "react";
 
-import { UserContext } from "../contexts/UserContext";
-import { saveUserInfoIntoCookies } from "../utils/cookies/userInfo";
+import LocalStorage from "../assorted/LocalStorage";
 
 import redirect from "../utils/routing/routing";
 import useFormField from "../hooks/useFormField";
@@ -24,8 +23,7 @@ import LoadingAnimation from "../components/LoadingAnimation";
 
 import { CEFR_LEVELS } from "../assorted/cefrLevels";
 
-export default function LanguagePreferences({ api, setUser }) {
-  const user = useContext(UserContext);
+export default function LanguagePreferences({ api }) {
   const [learned_language, handleLearned_language_change] = useFormField("");
   const [native_language, handleNative_language_change] = useFormField("en");
   const [learned_cefr_level, handleLearned_cefr_level_change] =
@@ -41,6 +39,18 @@ export default function LanguagePreferences({ api, setUser }) {
     });
     // eslint-disable-next-line
   }, []);
+
+  useEffect(() => {
+    LocalStorage.setLearnedLanguage(learned_language);
+  }, [learned_language]);
+
+  useEffect(() => {
+    LocalStorage.setLearnedCefrLevel(learned_cefr_level);
+  }, [learned_cefr_level]);
+
+  useEffect(() => {
+    LocalStorage.setNativeLanguage(native_language);
+  }, [native_language]);
 
   if (!systemLanguages) {
     return <LoadingAnimation />;
@@ -58,30 +68,12 @@ export default function LanguagePreferences({ api, setUser }) {
     ],
   ];
 
-  let userInfo = {
-    ...user,
-    learned_language: learned_language,
-    learned_cefr_level: learned_cefr_level,
-    native_language: native_language,
-  };
-
-  const modifyCEFRlevel = (languageID, cefrLevel) => {
-    api.modifyCEFRlevel(languageID, cefrLevel);
-  };
-
-  function updateUser(e) {
+  function validateAndRedirect(e) {
     e.preventDefault();
-
     if (!validator(validatorRules, setErrorMessage)) {
       return;
     }
-
-    api.saveUserDetails(userInfo, setErrorMessage, () => {
-      modifyCEFRlevel(learned_language, learned_cefr_level);
-      setUser(userInfo);
-      saveUserInfoIntoCookies(userInfo);
-      redirect("/select_interests");
-    });
+    redirect("/create_account");
   }
 
   return (
@@ -92,6 +84,12 @@ export default function LanguagePreferences({ api, setUser }) {
         </Heading>
       </Header>
       <Main>
+        <p>
+          After this step, you will need an{" "}
+          <span className="bold">invite code</span> to continue registration. If
+          you don't have one yet, reach out to us at{" "}
+          <span className="bold">{strings.zeeguuTeamEmail}</span>.
+        </p>
         <Form action={""}>
           {errorMessage && (
             <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>
@@ -132,7 +130,7 @@ export default function LanguagePreferences({ api, setUser }) {
           </FormSection>
           <p>{strings.youCanChangeLater}</p>
           <ButtonContainer className={"padding-medium"}>
-            <Button className={"full-width-btn"} onClick={updateUser}>
+            <Button className={"full-width-btn"} onClick={validateAndRedirect}>
               {strings.next} <ArrowForwardRoundedIcon />
             </Button>
           </ButtonContainer>

--- a/src/pages/LanguagePreferences.js
+++ b/src/pages/LanguagePreferences.js
@@ -134,6 +134,12 @@ export default function LanguagePreferences({ api }) {
               {strings.next} <ArrowForwardRoundedIcon />
             </Button>
           </ButtonContainer>
+          <p>
+            {strings.alreadyHaveAccount + " "}
+            <a className="bold underlined-link" href="/login">
+              {strings.login}
+            </a>
+          </p>
         </Form>
       </Main>
     </InfoPage>

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -83,8 +83,8 @@ export default function SignIn({ api, handleSuccessfulSignIn }) {
       <Footer>
         <p>
           {strings.dontHaveAnAccount + " "}
-          <a className="bold underlined-link" href="create_account">
-            {strings.createAccount}
+          <a className="bold underlined-link" href="/language_preferences">
+            {strings.getStarted}
           </a>
         </p>
       </Footer>


### PR DESCRIPTION
## What's new:

The **Language Preferences** info page comes before the **Create Account** page.

----
### Changes on the Landing Page:
![homepage](https://github.com/zeeguu/web/assets/115182912/544ff854-8b8c-4106-8523-75447f763965)

Given that the call to action button sends the user to the language preferences first, I have replaced its previous text **"Create Beta Account"** with **"Get Started"**.

----
### Changes on the Login page
![login](https://github.com/zeeguu/web/assets/115182912/15b3d735-09f5-4ea3-8b39-f028b96fadce)

The "Don't have an account? Get Started" bottom link redirects the user to the language selection as well, as it is now the first step to register.

---- 
### Changes on the Language Preferences
![registration](https://github.com/zeeguu/web/assets/115182912/06774cb7-6681-4e36-8c7d-08c398d1367a)

The Language Preferences page now informs the user about the invite code in the next step to avoid the frustration of having to request it in the middle of the process.

----
### Changes on the Registration Page
![registration](https://github.com/zeeguu/web/assets/115182912/ef6739ec-678b-4204-ae68-31911ec16360)

As the paragraph mentioning the **invite-code** has been moved to the language selection - it's now removed from here. In case someone missed it in the previous step - the email address for requesting the **invite-code** is now placed as helper text underneath its respective input field.
<br>
Moreover, since we now add all the details of a user, including language preferences, when we create a user, the `addBasicUser` function is no longer used. Now, the old `addUser` that requires languages is incorporated.