### PR TITLE
Initial language preferences fix

### DIFF
--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -9,7 +9,7 @@ const LocalStorage = {
   Keys: {
     Session: "sessionID",
     Name: "name",
-    
+
     // language related keys used in the logged-in user session
     LearnedLanguage: "learned_language",
     NativeLanguage: "native_language",
@@ -76,13 +76,16 @@ const LocalStorage = {
     localStorage[this.Keys.NativeLanguage] = nativeLanguage;
   },
 
-
   getLearnedLanguage_Initial: function () {
     return localStorage[this.Keys.LearnedLanguage_Initial];
   },
 
   setLearnedLanguage_Initial: function (learnedLanguage_Initial) {
     localStorage[this.Keys.LearnedLanguage_Initial] = learnedLanguage_Initial;
+  },
+
+  removeLearnedLanguage_Initial: function () {
+    localStorage.removeItem(this.Keys.LearnedLanguage_Initial);
   },
 
   getLearnedCefrLevel_Initial: function () {
@@ -93,6 +96,10 @@ const LocalStorage = {
     localStorage[this.Keys.LearnedCefrLevel_Initial] = learnedCefrLevel_Initial;
   },
 
+  removeCefrLevel_Initial: function () {
+    localStorage.removeItem(this.Keys.LearnedCefrLevel_Initial);
+  },
+
   getNativeLanguage_Initial: function () {
     return localStorage[this.Keys.NativeLanguage_Initial];
   },
@@ -101,6 +108,9 @@ const LocalStorage = {
     localStorage[this.Keys.NativeLanguage_Initial] = nativeLanguage_Initial;
   },
 
+  removeNativeLanguage_Initial: function () {
+    localStorage.removeItem(this.Keys.NativeLanguage_Initial);
+  },
 
   selectedTimePeriod: function () {
     return localStorage[this.Keys.SelectedTimePeriod]

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -9,9 +9,17 @@ const LocalStorage = {
   Keys: {
     Session: "sessionID",
     Name: "name",
+    
+    // language related keys used in the logged-in user session
     LearnedLanguage: "learned_language",
     NativeLanguage: "native_language",
     LearnedCefrLevel: "learned_cefr_level",
+
+    // language related keys used for initial language set-up during account creation
+    LearnedLanguage_Initial: "learned_language_initial",
+    NativeLanguage_Initial: "native_language_initial",
+    LearnedCefrLevel_Initial: "learned_cefr_level_initial",
+
     UiLanguage: "ui_language",
     IsTeacher: "is_teacher",
     SelectedTimePeriod: "selected_time_period",
@@ -67,6 +75,32 @@ const LocalStorage = {
   setNativeLanguage: function (nativeLanguage) {
     localStorage[this.Keys.NativeLanguage] = nativeLanguage;
   },
+
+
+  getLearnedLanguage_Initial: function () {
+    return localStorage[this.Keys.LearnedLanguage_Initial];
+  },
+
+  setLearnedLanguage_Initial: function (learnedLanguage_Initial) {
+    localStorage[this.Keys.LearnedLanguage_Initial] = learnedLanguage_Initial;
+  },
+
+  getLearnedCefrLevel_Initial: function () {
+    return localStorage[this.Keys.LearnedCefrLevel_Initial];
+  },
+
+  setLearnedCefrLevel_Initial: function (learnedCefrLevel_Initial) {
+    localStorage[this.Keys.LearnedCefrLevel_Initial] = learnedCefrLevel_Initial;
+  },
+
+  getNativeLanguage_Initial: function () {
+    return localStorage[this.Keys.NativeLanguage_Initial];
+  },
+
+  setNativeLanguage_Initial: function (nativeLanguage_Initial) {
+    localStorage[this.Keys.NativeLanguage_Initial] = nativeLanguage_Initial;
+  },
+
 
   selectedTimePeriod: function () {
     return localStorage[this.Keys.SelectedTimePeriod]

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -18,7 +18,6 @@ import InputField from "./info_page_shared/InputField";
 import Footer from "./info_page_shared/Footer";
 import ButtonContainer from "./info_page_shared/ButtonContainer";
 import Button from "./info_page_shared/Button";
-import Checkbox from "../components/modal_shared/Checkbox";
 import Modal from "../components/modal_shared/Modal";
 import validator from "../assorted/validator";
 import strings from "../i18n/definitions";
@@ -33,21 +32,19 @@ export default function CreateAccount({
 }) {
   const user = useContext(UserContext);
 
-  const learnedLanguage = LocalStorage.getLearnedLanguage() || "de";
-  const nativeLanguage = LocalStorage.getNativeLanguage() || "en";
-  const learnedCefrLevel = LocalStorage.getLearnedCefrLevel() || "1";
+  const learnedLanguage_Initial = LocalStorage.getLearnedLanguage_Initial();
+  const nativeLanguage_Initial = LocalStorage.getNativeLanguage_Initial();
+  const learnedCefrLevel_Initial = LocalStorage.getLearnedCefrLevel_Initial();
 
-  const [learned_language] = useState(learnedLanguage);
-  const [native_language] = useState(nativeLanguage);
-  const [learned_cefr_level] = useState(learnedCefrLevel);
+  const [learned_language_initial] = useState(learnedLanguage_Initial);
+  const [native_language_initial] = useState(nativeLanguage_Initial);
+  const [learned_cefr_level_initial] = useState(learnedCefrLevel_Initial);
 
   const [inviteCode, handleInviteCodeChange] = useFormField("");
   const [name, handleNameChange] = useFormField("");
   const [email, handleEmailChange] = useFormField("");
   const [password, handlePasswordChange] = useFormField("");
   const [checkPrivacyNote, handleCheckPrivacyNote] = useFormField(false);
-
-  const [isPrivacyNoticeAccepted, setIsPrivacyNoticeAccepted] = useState(false);
 
   const [errorMessage, setErrorMessage] = useState("");
   const [showPrivacyNotice, setShowPrivacyNotice] = useState(false);
@@ -74,6 +71,13 @@ export default function CreateAccount({
     });
   }, []);
 
+  //Temp data needed only for account creation
+  function clearInitialLanguageSettings() {
+    LocalStorage.removeLearnedLanguage_Initial();
+    LocalStorage.removeCefrLevel_Initial();
+    LocalStorage.removeNativeLanguage_Initial();
+  }
+
   function handleCreate(e) {
     e.preventDefault();
 
@@ -85,9 +89,9 @@ export default function CreateAccount({
       ...user,
       name: name,
       email: email,
-      learned_language: learned_language,
-      learned_cefr_level: learned_cefr_level,
-      native_language: native_language,
+      learned_language: learned_language_initial,
+      learned_cefr_level: learned_cefr_level_initial,
+      native_language: native_language_initial,
     };
 
     api.addUser(
@@ -99,6 +103,7 @@ export default function CreateAccount({
           handleSuccessfulSignIn(user, session);
           setUser(userInfo);
           saveUserInfoIntoCookies(userInfo);
+          clearInitialLanguageSettings()
           redirect("/select_interests");
         });
       },

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -71,8 +71,8 @@ export default function CreateAccount({
     });
   }, []);
 
-  //Temp data needed only for account creation
-  function clearInitialLanguageSettings() {
+  //Temp local storage entries needed only for account creation
+  function clearInitialLanguageEntries() {
     LocalStorage.removeLearnedLanguage_Initial();
     LocalStorage.removeCefrLevel_Initial();
     LocalStorage.removeNativeLanguage_Initial();
@@ -103,7 +103,7 @@ export default function CreateAccount({
           handleSuccessfulSignIn(user, session);
           setUser(userInfo);
           saveUserInfoIntoCookies(userInfo);
-          clearInitialLanguageSettings()
+          clearInitialLanguageEntries()
           redirect("/select_interests");
         });
       },

--- a/src/pages/LanguagePreferences.js
+++ b/src/pages/LanguagePreferences.js
@@ -24,9 +24,11 @@ import LoadingAnimation from "../components/LoadingAnimation";
 import { CEFR_LEVELS } from "../assorted/cefrLevels";
 
 export default function LanguagePreferences({ api }) {
-  const [learned_language, handleLearned_language_change] = useFormField("");
-  const [native_language, handleNative_language_change] = useFormField("en");
-  const [learned_cefr_level, handleLearned_cefr_level_change] =
+  const [learned_language_initial, handleLearned_language_initial_change] =
+    useFormField("");
+  const [native_language_initial, handleNative_language_initial_change] =
+    useFormField("en");
+  const [learned_cefr_level_initial, handleLearned_cefr_level_initial_change] =
     useFormField("");
   const [systemLanguages, setSystemLanguages] = useState();
   const [errorMessage, setErrorMessage] = useState("");
@@ -40,30 +42,35 @@ export default function LanguagePreferences({ api }) {
     // eslint-disable-next-line
   }, []);
 
+  //The useEffect hooks below take care of updating initial language preferences
+  //in real time
   useEffect(() => {
-    LocalStorage.setLearnedLanguage(learned_language);
-  }, [learned_language]);
+    LocalStorage.setLearnedLanguage_Initial(learned_language_initial);
+  }, [learned_language_initial]);
 
   useEffect(() => {
-    LocalStorage.setLearnedCefrLevel(learned_cefr_level);
-  }, [learned_cefr_level]);
+    LocalStorage.setLearnedCefrLevel_Initial(learned_cefr_level_initial);
+  }, [learned_cefr_level_initial]);
 
   useEffect(() => {
-    LocalStorage.setNativeLanguage(native_language);
-  }, [native_language]);
+    LocalStorage.setNativeLanguage_Initial(native_language_initial);
+  }, [native_language_initial]);
 
   if (!systemLanguages) {
     return <LoadingAnimation />;
   }
 
   let validatorRules = [
-    [learned_language === "", "Please select language you want to practice"],
     [
-      learned_cefr_level === "",
+      learned_language_initial === "",
+      "Please select language you want to practice",
+    ],
+    [
+      learned_cefr_level_initial === "",
       "Please select your current level in language you want to practice",
     ],
     [
-      native_language === "",
+      native_language_initial === "",
       "Please select language you want to translations in",
     ],
   ];
@@ -96,36 +103,36 @@ export default function LanguagePreferences({ api }) {
           )}
           <FormSection>
             <SelectOptions
-              value={learned_language}
+              value={learned_language_initial}
               label={strings.learnedLanguage}
               placeholder={strings.learnedLanguagePlaceholder}
               optionLabel={(e) => e.name}
               optionValue={(e) => e.code}
               id={"practiced-languages"}
               options={systemLanguages.learnable_languages}
-              onChangeHandler={handleLearned_language_change}
+              onChangeHandler={handleLearned_language_initial_change}
             />
 
             <SelectOptions
-              value={learned_cefr_level}
+              value={learned_cefr_level_initial}
               label={strings.levelOfLearnedLanguage}
               placeholder={strings.levelOfLearnedLanguagePlaceholder}
               optionLabel={(e) => e.label}
               optionValue={(e) => e.value}
               id={"level-of-practiced-languages"}
               options={CEFR_LEVELS}
-              onChangeHandler={handleLearned_cefr_level_change}
+              onChangeHandler={handleLearned_cefr_level_initial_change}
             />
 
             <SelectOptions
-              value={native_language}
+              value={native_language_initial}
               label={strings.baseLanguage}
               placeholder={strings.baseLanguagePlaceholder}
               optionLabel={(e) => e.name}
               optionValue={(e) => e.code}
               id={"translation-languages"}
               options={systemLanguages.native_languages}
-              onChangeHandler={handleNative_language_change}
+              onChangeHandler={handleNative_language_initial_change}
             />
           </FormSection>
           <p>{strings.youCanChangeLater}</p>

--- a/src/pages/LanguagePreferences.js
+++ b/src/pages/LanguagePreferences.js
@@ -24,11 +24,11 @@ import LoadingAnimation from "../components/LoadingAnimation";
 import { CEFR_LEVELS } from "../assorted/cefrLevels";
 
 export default function LanguagePreferences({ api }) {
-  const [learned_language_initial, handleLearned_language_initial_change] =
+  const [learned_language_initial, handleLearned_language_initial] =
     useFormField("");
-  const [native_language_initial, handleNative_language_initial_change] =
+  const [native_language_initial, handleNative_language_initial] =
     useFormField("en");
-  const [learned_cefr_level_initial, handleLearned_cefr_level_initial_change] =
+  const [learned_cefr_level_initial, handleLearned_cefr_level_initial] =
     useFormField("");
   const [systemLanguages, setSystemLanguages] = useState();
   const [errorMessage, setErrorMessage] = useState("");
@@ -110,7 +110,7 @@ export default function LanguagePreferences({ api }) {
               optionValue={(e) => e.code}
               id={"practiced-languages"}
               options={systemLanguages.learnable_languages}
-              onChangeHandler={handleLearned_language_initial_change}
+              onChangeHandler={handleLearned_language_initial}
             />
 
             <SelectOptions
@@ -121,7 +121,7 @@ export default function LanguagePreferences({ api }) {
               optionValue={(e) => e.value}
               id={"level-of-practiced-languages"}
               options={CEFR_LEVELS}
-              onChangeHandler={handleLearned_cefr_level_initial_change}
+              onChangeHandler={handleLearned_cefr_level_initial}
             />
 
             <SelectOptions
@@ -132,7 +132,7 @@ export default function LanguagePreferences({ api }) {
               optionValue={(e) => e.code}
               id={"translation-languages"}
               options={systemLanguages.native_languages}
-              onChangeHandler={handleNative_language_initial_change}
+              onChangeHandler={handleNative_language_initial}
             />
           </FormSection>
           <p>{strings.youCanChangeLater}</p>


### PR DESCRIPTION
## Initial language preferences fix

### The error:
After the user session handling update, the initial language preferences are saved to local storage on the `/language_preferences`page. When the user goes to the `/create_account` page, the `learned_language` and `native_language` entries are erased from the local storage, which results in new accounts always set to German by default. 


### Possible cause:
The local storage entries (`learned_language`, `learned_cefr_level`, `native_language`) **are already used in the system**. They are associated with the `/account_settings` page and are likely linked to the user session data, which **clashes with the initial language settings data** before creating a user.
 
**This clash can be easily observed in a slightly unnatural flow:** 
If the **existing user's practiced language** is set to French, level 2 is on the `/account_settings` page, and if they go to the `/language_preferences` - no matter what they select in there - it will keep being **overwritten** and updated to French, level 2 **on refresh**. Something similar probably happens during account creation, but in that case, there is no user yet. Therefore, language selection entries are replaced/overwritten with no data. 

### The fix:
Separate temporary language preference entries for account creation have been created **to prevent this clash**. They are used **only in the process of creating a new user** . 

```
    // language related keys used for initial language set-up during account creation
    LearnedLanguage_Initial: "learned_language_initial",
    NativeLanguage_Initial: "native_language_initial",
    LearnedCefrLevel_Initial: "learned_cefr_level_initial",
```

**After a new user is created**, the `/account_settings` page takes care of language preferences data. 