### PR TITLE
Several improvements

### DIFF
--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -81,7 +81,8 @@ const LocalStorage = {
   },
 
   setLearnedLanguage_OnRegister: function (learnedLanguage_OnRegister) {
-    localStorage[this.Keys.LearnedLanguage_OnRegister] = learnedLanguage_OnRegister;
+    localStorage[this.Keys.LearnedLanguage_OnRegister] =
+      learnedLanguage_OnRegister;
   },
 
   removeLearnedLanguage_OnRegister: function () {
@@ -93,7 +94,8 @@ const LocalStorage = {
   },
 
   setLearnedCefrLevel_OnRegister: function (learnedCefrLevel_OnRegister) {
-    localStorage[this.Keys.LearnedCefrLevel_OnRegister] = learnedCefrLevel_OnRegister;
+    localStorage[this.Keys.LearnedCefrLevel_OnRegister] =
+      learnedCefrLevel_OnRegister;
   },
 
   removeCefrLevel_OnRegister: function () {
@@ -105,7 +107,8 @@ const LocalStorage = {
   },
 
   setNativeLanguage_OnRegister: function (nativeLanguage_OnRegister) {
-    localStorage[this.Keys.NativeLanguage_OnRegister] = nativeLanguage_OnRegister;
+    localStorage[this.Keys.NativeLanguage_OnRegister] =
+      nativeLanguage_OnRegister;
   },
 
   removeNativeLanguage_OnRegister: function () {

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -16,9 +16,9 @@ const LocalStorage = {
     LearnedCefrLevel: "learned_cefr_level",
 
     // language related keys used for initial language set-up during account creation
-    LearnedLanguage_Initial: "learned_language_initial",
-    NativeLanguage_Initial: "native_language_initial",
-    LearnedCefrLevel_Initial: "learned_cefr_level_initial",
+    LearnedLanguage_OnRegister: "learned_language_on_register",
+    NativeLanguage_OnRegister: "native_language_on_register",
+    LearnedCefrLevel_OnRegister: "learned_cefr_on_register",
 
     UiLanguage: "ui_language",
     IsTeacher: "is_teacher",
@@ -76,40 +76,40 @@ const LocalStorage = {
     localStorage[this.Keys.NativeLanguage] = nativeLanguage;
   },
 
-  getLearnedLanguage_Initial: function () {
-    return localStorage[this.Keys.LearnedLanguage_Initial];
+  getLearnedLanguage_OnRegister: function () {
+    return localStorage[this.Keys.LearnedLanguage_OnRegister];
   },
 
-  setLearnedLanguage_Initial: function (learnedLanguage_Initial) {
-    localStorage[this.Keys.LearnedLanguage_Initial] = learnedLanguage_Initial;
+  setLearnedLanguage_OnRegister: function (learnedLanguage_OnRegister) {
+    localStorage[this.Keys.LearnedLanguage_OnRegister] = learnedLanguage_OnRegister;
   },
 
-  removeLearnedLanguage_Initial: function () {
-    localStorage.removeItem(this.Keys.LearnedLanguage_Initial);
+  removeLearnedLanguage_OnRegister: function () {
+    localStorage.removeItem(this.Keys.LearnedLanguage_OnRegister);
   },
 
-  getLearnedCefrLevel_Initial: function () {
-    return localStorage[this.Keys.LearnedCefrLevel_Initial];
+  getLearnedCefrLevel_OnRegister: function () {
+    return localStorage[this.Keys.LearnedCefrLevel_OnRegister];
   },
 
-  setLearnedCefrLevel_Initial: function (learnedCefrLevel_Initial) {
-    localStorage[this.Keys.LearnedCefrLevel_Initial] = learnedCefrLevel_Initial;
+  setLearnedCefrLevel_OnRegister: function (learnedCefrLevel_OnRegister) {
+    localStorage[this.Keys.LearnedCefrLevel_OnRegister] = learnedCefrLevel_OnRegister;
   },
 
-  removeCefrLevel_Initial: function () {
-    localStorage.removeItem(this.Keys.LearnedCefrLevel_Initial);
+  removeCefrLevel_OnRegister: function () {
+    localStorage.removeItem(this.Keys.LearnedCefrLevel_OnRegister);
   },
 
-  getNativeLanguage_Initial: function () {
-    return localStorage[this.Keys.NativeLanguage_Initial];
+  getNativeLanguage_OnRegister: function () {
+    return localStorage[this.Keys.NativeLanguage_OnRegister];
   },
 
-  setNativeLanguage_Initial: function (nativeLanguage_Initial) {
-    localStorage[this.Keys.NativeLanguage_Initial] = nativeLanguage_Initial;
+  setNativeLanguage_OnRegister: function (nativeLanguage_OnRegister) {
+    localStorage[this.Keys.NativeLanguage_OnRegister] = nativeLanguage_OnRegister;
   },
 
-  removeNativeLanguage_Initial: function () {
-    localStorage.removeItem(this.Keys.NativeLanguage_Initial);
+  removeNativeLanguage_OnRegister: function () {
+    localStorage.removeItem(this.Keys.NativeLanguage_OnRegister);
   },
 
   selectedTimePeriod: function () {

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -139,7 +139,7 @@ let strings = new LocalizedStrings(
       rememberPassword: "Remember Password?",
 
       //InstallExtension
-      skipInstallation: "Skip installation",
+      iWillInstallLater: "I will install later",
       installTheExtension: "Install the Extension",
 
       //LandingPage

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -139,7 +139,7 @@ let strings = new LocalizedStrings(
       rememberPassword: "Remember Password?",
 
       //InstallExtension
-      iWillInstallLater: "I will install later",
+      iWillInstallLater: "I will install it later",
       installTheExtension: "Install the Extension",
 
       //LandingPage

--- a/src/landingPage/LandingPage.js
+++ b/src/landingPage/LandingPage.js
@@ -48,7 +48,7 @@ export default function LandingPage() {
 
       <s.PageContent>
         <s.HeroColumn>
-          <h1>Learn foreign languages with&nbsp;Zeeguu</h1>
+          <h1>Learn foreign languages while reading what you&nbsp;like</h1>
           <p className="hero-paragraph">
             {strings.projectDescription_UltraShort}
           </p>

--- a/src/landingPage/LandingPage.sc.js
+++ b/src/landingPage/LandingPage.sc.js
@@ -103,7 +103,7 @@ const _mainHeader = css`
 
 const HeroColumn = styled.div`
   height: auto;
-  max-width: 800px;
+  max-width: 52rem;
   padding: 6rem 1rem;
   margin-left: auto;
   margin-right: auto;

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -38,9 +38,11 @@ export default function CreateAccount({
   const learnedCefrLevel_OnRegister =
     LocalStorage.getLearnedCefrLevel_OnRegister();
 
-  const [learned_language_OnRegister] = useState(learnedLanguage_OnRegister);
-  const [native_language_OnRegister] = useState(nativeLanguage_OnRegister);
-  const [learned_cefr_level_OnRegister] = useState(learnedCefrLevel_OnRegister);
+  const [learned_language_on_register] = useState(learnedLanguage_OnRegister);
+  const [native_language_on_register] = useState(nativeLanguage_OnRegister);
+  const [learned_cefr_level_on_register] = useState(
+    learnedCefrLevel_OnRegister,
+  );
 
   const [inviteCode, handleInviteCodeChange] = useFormField("");
   const [name, handleNameChange] = useFormField("");
@@ -73,7 +75,7 @@ export default function CreateAccount({
     });
   }, []);
 
-  //Temp local storage entries needed only for account creation
+  //Clear temp local storage entries needed only for account creation
   function clearOnRegisterLanguageEntries() {
     LocalStorage.removeLearnedLanguage_OnRegister();
     LocalStorage.removeCefrLevel_OnRegister();
@@ -91,9 +93,9 @@ export default function CreateAccount({
       ...user,
       name: name,
       email: email,
-      learned_language: learned_language_OnRegister,
-      learned_cefr_level: learned_cefr_level_OnRegister,
-      native_language: native_language_OnRegister,
+      learned_language: learned_language_on_register,
+      learned_cefr_level: learned_cefr_level_on_register,
+      native_language: native_language_on_register,
     };
 
     api.addUser(

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -32,13 +32,15 @@ export default function CreateAccount({
 }) {
   const user = useContext(UserContext);
 
-  const learnedLanguage_Initial = LocalStorage.getLearnedLanguage_Initial();
-  const nativeLanguage_Initial = LocalStorage.getNativeLanguage_Initial();
-  const learnedCefrLevel_Initial = LocalStorage.getLearnedCefrLevel_Initial();
+  const learnedLanguage_OnRegister =
+    LocalStorage.getLearnedLanguage_OnRegister();
+  const nativeLanguage_OnRegister = LocalStorage.getNativeLanguage_OnRegister();
+  const learnedCefrLevel_OnRegister =
+    LocalStorage.getLearnedCefrLevel_OnRegister();
 
-  const [learned_language_initial] = useState(learnedLanguage_Initial);
-  const [native_language_initial] = useState(nativeLanguage_Initial);
-  const [learned_cefr_level_initial] = useState(learnedCefrLevel_Initial);
+  const [learned_language_OnRegister] = useState(learnedLanguage_OnRegister);
+  const [native_language_OnRegister] = useState(nativeLanguage_OnRegister);
+  const [learned_cefr_level_OnRegister] = useState(learnedCefrLevel_OnRegister);
 
   const [inviteCode, handleInviteCodeChange] = useFormField("");
   const [name, handleNameChange] = useFormField("");
@@ -72,10 +74,10 @@ export default function CreateAccount({
   }, []);
 
   //Temp local storage entries needed only for account creation
-  function clearInitialLanguageEntries() {
-    LocalStorage.removeLearnedLanguage_Initial();
-    LocalStorage.removeCefrLevel_Initial();
-    LocalStorage.removeNativeLanguage_Initial();
+  function clearOnRegisterLanguageEntries() {
+    LocalStorage.removeLearnedLanguage_OnRegister();
+    LocalStorage.removeCefrLevel_OnRegister();
+    LocalStorage.removeNativeLanguage_OnRegister();
   }
 
   function handleCreate(e) {
@@ -89,9 +91,9 @@ export default function CreateAccount({
       ...user,
       name: name,
       email: email,
-      learned_language: learned_language_initial,
-      learned_cefr_level: learned_cefr_level_initial,
-      native_language: native_language_initial,
+      learned_language: learned_language_OnRegister,
+      learned_cefr_level: learned_cefr_level_OnRegister,
+      native_language: native_language_OnRegister,
     };
 
     api.addUser(
@@ -103,7 +105,7 @@ export default function CreateAccount({
           handleSuccessfulSignIn(user, session);
           setUser(userInfo);
           saveUserInfoIntoCookies(userInfo);
-          clearInitialLanguageEntries()
+          clearOnRegisterLanguageEntries();
           redirect("/select_interests");
         });
       },

--- a/src/pages/ExcludeWordsStep1.js
+++ b/src/pages/ExcludeWordsStep1.js
@@ -21,8 +21,8 @@ export default function ExcludeWordsStep1({ hasExtension }) {
     <InfoPage>
       <Header>
         <Heading>
-          Would you like to exclude articles and exercises containing
-          particular words or&nbsp;phrases?
+          Would you like to exclude articles and exercises containing particular
+          words or&nbsp;phrases?
         </Heading>
       </Header>
       <Main>

--- a/src/pages/ExcludeWordsStep1.js
+++ b/src/pages/ExcludeWordsStep1.js
@@ -21,7 +21,7 @@ export default function ExcludeWordsStep1({ hasExtension }) {
     <InfoPage>
       <Header>
         <Heading>
-          Would you like to filter out articles and exercises containing
+          Would you like to exclude articles and exercises containing
           particular words or&nbsp;phrases?
         </Heading>
       </Header>

--- a/src/pages/InstallExtension.js
+++ b/src/pages/InstallExtension.js
@@ -36,7 +36,7 @@ export default function InstallExtension() {
             {strings.installTheExtension}
           </Button>
           <a className="link" href="/articles">
-            {strings.skipInstallation}
+            {strings.iWillInstallLater}
           </a>
         </ButtonContainer>
       </Footer>

--- a/src/pages/LanguagePreferences.js
+++ b/src/pages/LanguagePreferences.js
@@ -24,11 +24,11 @@ import LoadingAnimation from "../components/LoadingAnimation";
 import { CEFR_LEVELS } from "../assorted/cefrLevels";
 
 export default function LanguagePreferences({ api }) {
-  const [learned_language_initial, handleLearned_language_initial] =
+  const [learned_language_on_register, handleLearned_language_on_register] =
     useFormField("");
-  const [native_language_initial, handleNative_language_initial] =
+  const [native_language_on_register, handleNative_language_on_register] =
     useFormField("en");
-  const [learned_cefr_level_initial, handleLearned_cefr_level_initial] =
+  const [learned_cefr_level_on_register, handleLearned_cefr_level_on_register] =
     useFormField("");
   const [systemLanguages, setSystemLanguages] = useState();
   const [errorMessage, setErrorMessage] = useState("");
@@ -45,16 +45,16 @@ export default function LanguagePreferences({ api }) {
   //The useEffect hooks below take care of updating initial language preferences
   //in real time
   useEffect(() => {
-    LocalStorage.setLearnedLanguage_Initial(learned_language_initial);
-  }, [learned_language_initial]);
+    LocalStorage.setLearnedLanguage_OnRegister(learned_language_on_register);
+  }, [learned_language_on_register]);
 
   useEffect(() => {
-    LocalStorage.setLearnedCefrLevel_Initial(learned_cefr_level_initial);
-  }, [learned_cefr_level_initial]);
+    LocalStorage.setLearnedCefrLevel_OnRegister(learned_cefr_level_on_register);
+  }, [learned_cefr_level_on_register]);
 
   useEffect(() => {
-    LocalStorage.setNativeLanguage_Initial(native_language_initial);
-  }, [native_language_initial]);
+    LocalStorage.setNativeLanguage_OnRegister(native_language_on_register);
+  }, [native_language_on_register]);
 
   if (!systemLanguages) {
     return <LoadingAnimation />;
@@ -62,15 +62,15 @@ export default function LanguagePreferences({ api }) {
 
   let validatorRules = [
     [
-      learned_language_initial === "",
+      learned_language_on_register === "",
       "Please select language you want to practice",
     ],
     [
-      learned_cefr_level_initial === "",
+      learned_cefr_level_on_register === "",
       "Please select your current level in language you want to practice",
     ],
     [
-      native_language_initial === "",
+      native_language_on_register === "",
       "Please select language you want to translations in",
     ],
   ];
@@ -103,36 +103,36 @@ export default function LanguagePreferences({ api }) {
           )}
           <FormSection>
             <SelectOptions
-              value={learned_language_initial}
+              value={learned_language_on_register}
               label={strings.learnedLanguage}
               placeholder={strings.learnedLanguagePlaceholder}
               optionLabel={(e) => e.name}
               optionValue={(e) => e.code}
               id={"practiced-languages"}
               options={systemLanguages.learnable_languages}
-              onChangeHandler={handleLearned_language_initial}
+              onChangeHandler={handleLearned_language_on_register}
             />
 
             <SelectOptions
-              value={learned_cefr_level_initial}
+              value={learned_cefr_level_on_register}
               label={strings.levelOfLearnedLanguage}
               placeholder={strings.levelOfLearnedLanguagePlaceholder}
               optionLabel={(e) => e.label}
               optionValue={(e) => e.value}
               id={"level-of-practiced-languages"}
               options={CEFR_LEVELS}
-              onChangeHandler={handleLearned_cefr_level_initial}
+              onChangeHandler={handleLearned_cefr_level_on_register}
             />
 
             <SelectOptions
-              value={native_language_initial}
+              value={native_language_on_register}
               label={strings.baseLanguage}
               placeholder={strings.baseLanguagePlaceholder}
               optionLabel={(e) => e.name}
               optionValue={(e) => e.code}
               id={"translation-languages"}
               options={systemLanguages.native_languages}
-              onChangeHandler={handleNative_language_initial}
+              onChangeHandler={handleNative_language_on_register}
             />
           </FormSection>
           <p>{strings.youCanChangeLater}</p>


### PR DESCRIPTION
## What's new

This PR contains several minor improvements:

- The naming of the language-related entries and states used for account creation has been modified. More specifically the part that comes after the underscore (`Initial`) has been replaced with `OnRegister`
- The heading in the Hero section has been updated to: **Learn foreign languages while reading what you like**
![localhost_3000_](https://github.com/zeeguu/web/assets/115182912/fda05ed5-f4d4-4eca-9fd7-33919b9c42a9)

- The "**Would you like to filter out articles and exercises containing particular words or phrases?**" question in the first step of the word exclusion has been replaced with "**Would you like to exclude articles and exercises containing particular words or phrases?**". While the respondents understand this step, some in very first seconds of their interaction with this functionality do not notice the "**out**" in "**filter out**", so there is a slight delay in understanding this step that can be avoided.
![localhost_3000_exclude_words_step1](https://github.com/zeeguu/web/assets/115182912/620941a1-c7a8-4806-a444-aac53a81dd41)

- The "**Skip installation**" link has been replaced with "**I will install it later**". While the Respondents have installed the extension so far, I have observed that the "Skip installation" option causes a few seconds of hesitation. I believe that rephrasing it to  "**I will install it later**" might prevent it. 
![localhost_3000_install_extension](https://github.com/zeeguu/web/assets/115182912/36183ce9-4710-450e-90c8-062cf75115ff)

