### PR TITLE
Support Endless scrolling

### DIFF
--- a/src/api/userArticles.js
+++ b/src/api/userArticles.js
@@ -10,11 +10,27 @@ Zeeguu_API.prototype.getUserArticles = function (callback) {
     // fast deduplication cf. https://stackoverflow.com/a/64791605/1200070
     const ids = articles.map((o) => o.id);
     const deduplicated = articles.filter(
-      ({ id }, index) => !ids.includes(id, index + 1)
+      ({ id }, index) => !ids.includes(id, index + 1),
     );
     console.log(deduplicated);
     callback(deduplicated);
   });
+};
+Zeeguu_API.prototype.getMoreUserArticles = function (count, page, callback) {
+  this._getJSON(
+    "user_articles/recommended/" + count + "/" + page,
+    (articles) => {
+      // sometimes we get duplicates from the server
+      // deduplicate them here
+      // fast deduplication cf. https://stackoverflow.com/a/64791605/1200070
+      const ids = articles.map((o) => o.id);
+      const deduplicated = articles.filter(
+        ({ id }, index) => !ids.includes(id, index + 1),
+      );
+      console.log(deduplicated);
+      callback(deduplicated);
+    },
+  );
 };
 
 Zeeguu_API.prototype.getSavedUserArticles = function (callback) {
@@ -24,12 +40,11 @@ Zeeguu_API.prototype.getSavedUserArticles = function (callback) {
     // fast deduplication cf. https://stackoverflow.com/a/64791605/1200070
     const ids = articles.map((o) => o.id);
     const deduplicated = articles.filter(
-        ({ id }, index) => !ids.includes(id, index + 1)
+      ({ id }, index) => !ids.includes(id, index + 1),
     );
     callback(deduplicated);
   });
 };
-
 
 Zeeguu_API.prototype.search = function (term, callback) {
   return this._getJSON(`search/${term}`, (articles) => {
@@ -38,7 +53,20 @@ Zeeguu_API.prototype.search = function (term, callback) {
     // fast deduplication cf. https://stackoverflow.com/a/64791605/1200070
     const ids = articles.map((o) => o.id);
     const deduplicated = articles.filter(
-      ({ id }, index) => !ids.includes(id, index + 1)
+      ({ id }, index) => !ids.includes(id, index + 1),
+    );
+    callback(deduplicated);
+  });
+};
+
+Zeeguu_API.prototype.searchMore = function (term, page, callback) {
+  return this._getJSON(`search/${term}/${page}`, (articles) => {
+    // sometimes we get duplicates from the server
+    // deduplicate them here
+    // fast deduplication cf. https://stackoverflow.com/a/64791605/1200070
+    const ids = articles.map((o) => o.id);
+    const deduplicated = articles.filter(
+      ({ id }, index) => !ids.includes(id, index + 1),
     );
     callback(deduplicated);
   });
@@ -62,7 +90,7 @@ Zeeguu_API.prototype.setArticleInfo = function (articleInfo, callback) {
     `article_id=${articleInfo.id}` +
       `&starred=${articleInfo.starred}` +
       `&liked=${articleInfo.liked}`,
-    callback
+    callback,
   );
 };
 
@@ -81,19 +109,18 @@ Zeeguu_API.prototype.findOrCreateArticle = function (articleInfo, callback) {
 };
 
 Zeeguu_API.prototype.makePersonalCopy = function (articleId, callback) {
-  let param = qs.stringify({article_id: articleId})
+  let param = qs.stringify({ article_id: articleId });
   this._post(`/make_personal_copy`, param, callback);
 };
 
-
 Zeeguu_API.prototype.removePersonalCopy = function (articleId, callback) {
-  let param = qs.stringify({article_id: articleId})
+  let param = qs.stringify({ article_id: articleId });
   this._post(`/remove_personal_copy`, param, callback);
 };
 
 Zeeguu_API.prototype.isArticleLanguageSupported = function (
   htmlContent,
-  callback
+  callback,
 ) {
   let article = { htmlContent: htmlContent };
   this._post(`/is_article_language_supported`, qs.stringify(article), callback);
@@ -105,7 +132,7 @@ Zeeguu_API.prototype.sendFeedback = function (feedback, callback) {
 
 Zeeguu_API.prototype.submitArticleDifficultyFeedback = function (
   feedback,
-  callback
+  callback,
 ) {
   this._post(`/article_difficulty_feedback`, qs.stringify(feedback), callback);
 };

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -64,7 +64,7 @@ export default function NewArticles() {
   };
 
   function handleScroll() {
-    let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd({});
+    let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
       !isWaitingForNewArticlesRef.current

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -64,7 +64,7 @@ export default function NewArticles() {
   };
 
   function handleScroll() {
-    let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
+    let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd({});
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
       !isWaitingForNewArticlesRef.current
@@ -77,6 +77,7 @@ export default function NewArticles() {
   }
 
   function insertNewArticlesIntoArticleList(newCurrentPage, newArticles) {
+    document.title = "Getting more articles...";
     if (searchQuery) {
       api.searchMore(searchQuery, newCurrentPage, (articles) => {
         newArticles = newArticles.concat(articles);
@@ -84,6 +85,7 @@ export default function NewArticles() {
         setOriginalList([...newArticles]);
         setCurrentPage(newCurrentPage);
         setIsWaitingForNewArticles(false);
+        document.title = "Recommend Articles: Zeeguu";
       });
     } else {
       api.getMoreUserArticles(20, newCurrentPage, (articles) => {
@@ -92,6 +94,7 @@ export default function NewArticles() {
         setOriginalList([...newArticles]);
         setCurrentPage(newCurrentPage);
         setIsWaitingForNewArticles(false);
+        document.title = "Recommend Articles: Zeeguu";
       });
     }
   }
@@ -122,7 +125,7 @@ export default function NewArticles() {
       });
     }
     window.addEventListener("scroll", handleScroll, true);
-    document.title = "Zeeguu";
+    document.title = "Recommend Articles: Zeeguu";
     return () => {
       window.removeEventListener("scroll", handleScroll, true);
     };

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -64,8 +64,11 @@ export default function NewArticles() {
   };
 
   function handleScroll() {
-    let pixelsFromPageEnd = getPixelsFromScrollBarToEnd();
-    if (pixelsFromPageEnd <= 50 && !isWaitingForNewArticlesRef.current) {
+    let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
+    if (
+      scrollBarPixelDistToPageEnd <= 50 &&
+      !isWaitingForNewArticlesRef.current
+    ) {
       setIsWaitingForNewArticles(true);
       let newCurrentPage = currentPageRef.current + 1;
       let newArticles = [...articleListRef.current];

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -70,33 +70,40 @@ export default function NewArticles() {
       !isWaitingForNewArticlesRef.current
     ) {
       setIsWaitingForNewArticles(true);
+      document.title = "Getting more articles...";
       let newCurrentPage = currentPageRef.current + 1;
       let newArticles = [...articleListRef.current];
-      insertNewArticlesIntoArticleList(newCurrentPage, newArticles);
+      if (searchQuery) {
+        api.searchMore(searchQuery, newCurrentPage, (articles) => {
+          insertNewArticlesIntoArticleList(
+            articles,
+            newCurrentPage,
+            newArticles,
+          );
+        });
+      } else {
+        api.getMoreUserArticles(20, newCurrentPage, (articles) => {
+          insertNewArticlesIntoArticleList(
+            articles,
+            newCurrentPage,
+            newArticles,
+          );
+        });
+      }
     }
   }
 
-  function insertNewArticlesIntoArticleList(newCurrentPage, newArticles) {
-    document.title = "Getting more articles...";
-    if (searchQuery) {
-      api.searchMore(searchQuery, newCurrentPage, (articles) => {
-        newArticles = newArticles.concat(articles);
-        setArticleList(newArticles);
-        setOriginalList([...newArticles]);
-        setCurrentPage(newCurrentPage);
-        setIsWaitingForNewArticles(false);
-        document.title = "Recommend Articles: Zeeguu";
-      });
-    } else {
-      api.getMoreUserArticles(20, newCurrentPage, (articles) => {
-        newArticles = newArticles.concat(articles);
-        setArticleList(newArticles);
-        setOriginalList([...newArticles]);
-        setCurrentPage(newCurrentPage);
-        setIsWaitingForNewArticles(false);
-        document.title = "Recommend Articles: Zeeguu";
-      });
-    }
+  function insertNewArticlesIntoArticleList(
+    fetchedArticles,
+    newCurrentPage,
+    newArticles,
+  ) {
+    newArticles = newArticles.concat(fetchedArticles);
+    setArticleList(newArticles);
+    setOriginalList([...newArticles]);
+    setCurrentPage(newCurrentPage);
+    setIsWaitingForNewArticles(false);
+    document.title = "Recommend Articles: Zeeguu";
   }
 
   useEffect(() => {

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -65,7 +65,6 @@ export default function NewArticles() {
 
   function handleScroll() {
     let pixelToEndScrolling = getScrollPixelsToEnd();
-    console.log(isLoadingNewArticle);
     if (pixelToEndScrolling <= 50 && !isLoadingNewArticleRef.current) {
       setIsLoadingNewArticles(true);
       let newCurrentPage = currentPageRef.current + 1;

--- a/src/components/LoadingAnimation.js
+++ b/src/components/LoadingAnimation.js
@@ -3,14 +3,14 @@ import strings from "../i18n/definitions";
 import React from "react";
 import { useState, useEffect } from "react";
 
-export default function LoadingAnimation({ text }) {
+export default function LoadingAnimation({ text, delay = 1000 }) {
   let _text = text ? text : strings.loadingMsg;
   const [showLoadingScreen, setShowLoadingScreen] = useState(false);
 
   useEffect(() => {
     // Code from: https://stackoverflow.com/questions/53090432/react-hooks-right-way-to-clear-timeouts-and-intervals
     // Only show the loading if more that 1000ms have passed.
-    let loadingTimer = setTimeout(() => setShowLoadingScreen(true), 1000);
+    let loadingTimer = setTimeout(() => setShowLoadingScreen(true), delay);
     return () => {
       clearTimeout(loadingTimer);
     };

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -119,7 +119,8 @@ export default function ArticleReader({ api, teacherArticleID }) {
     }
     // getScrollRatio supports passing a pixel offset which is
     // removed from the total length of the page.
-    let ratio = getScrollRatio(bottomRowHeight);
+    const pixelOffset = { shortenPageHeightPixels: bottomRowHeight };
+    let ratio = getScrollRatio(pixelOffset);
     setScrollPosition(ratio);
     let percentage = Math.floor(ratio * 100);
     let currentReadingTimer = activityTimerRef.current;

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -110,17 +110,15 @@ export default function ArticleReader({ api, teacherArticleID }) {
     let bottomRowElement = document.getElementById("bottomRow");
 
     // We use this to avoid counting the feedback elements
-    // as part of the article lenght when updating the
+    // as part of the article length when updating the
     // scroll bar.
-    // 450 Is a default in case we can't acess the property
+    // 450 Is a default in case we can't access the property
     let bottomRowHeight = 450;
     if (bottomRowElement) {
       bottomRowHeight = bottomRowElement.offsetHeight;
     }
-    // getScrollRatio supports passing a pixel offset which is
-    // removed from the total length of the page.
-    const pixelOffset = { shortenPageHeightPixels: bottomRowHeight };
-    let ratio = getScrollRatio(pixelOffset);
+
+    let ratio = getScrollRatio(bottomRowHeight);
     setScrollPosition(ratio);
     let percentage = Math.floor(ratio * 100);
     let currentReadingTimer = activityTimerRef.current;

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -25,7 +25,7 @@ import useActivityTimer from "../hooks/useActivityTimer";
 import ActivityTimer from "../components/ActivityTimer";
 import useShadowRef from "../hooks/useShadowRef";
 import strings from "../i18n/definitions";
-import ratio from "../utils/basic/ratio";
+import { getScrollRatio } from "../utils/misc/getScrollLocation";
 
 let FREQUENCY_KEEPALIVE = 30 * 1000; // 30 seconds
 let previous_time = 0; // since sent a scroll update
@@ -90,23 +90,6 @@ export default function ArticleReader({ api, teacherArticleID }) {
     }
   }
 
-  function getScrollRatio() {
-    let scrollElement = document.getElementById("scrollHolder");
-    let scrollY = scrollElement.scrollTop;
-    let bottomRowHeight = document.getElementById("bottomRow");
-    if (!bottomRowHeight) {
-      bottomRowHeight = 450; // 450 Is a default in case we can't acess the property
-    } else {
-      bottomRowHeight = bottomRowHeight.offsetHeight;
-    }
-    let endArticle =
-      scrollElement.scrollHeight - scrollElement.clientHeight - bottomRowHeight;
-    let ratioValue = ratio(scrollY, endArticle);
-    // Should we allow the ratio to go above 1?
-    // Above 1 is the area where the feedback + exercises are.
-    return ratioValue;
-  }
-
   useEffect(() => {
     onCreate();
     return () => {
@@ -124,7 +107,13 @@ export default function ArticleReader({ api, teacherArticleID }) {
   };
 
   const handleScroll = () => {
-    let ratio = getScrollRatio();
+    let bottomRowHeight = document.getElementById("bottomRow");
+    if (!bottomRowHeight) {
+      bottomRowHeight = 450; // 450 Is a default in case we can't acess the property
+    } else {
+      bottomRowHeight = bottomRowHeight.offsetHeight;
+    }
+    let ratio = getScrollRatio(bottomRowHeight);
     setScrollPosition(ratio);
     let percentage = Math.floor(ratio * 100);
     let currentReadingTimer = activityTimerRef.current;

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -107,12 +107,18 @@ export default function ArticleReader({ api, teacherArticleID }) {
   };
 
   const handleScroll = () => {
-    let bottomRowHeight = document.getElementById("bottomRow");
-    if (!bottomRowHeight) {
-      bottomRowHeight = 450; // 450 Is a default in case we can't acess the property
-    } else {
-      bottomRowHeight = bottomRowHeight.offsetHeight;
+    let bottomRowElement = document.getElementById("bottomRow");
+
+    // We use this to avoid counting the feedback elements
+    // as part of the article lenght when updating the
+    // scroll bar.
+    // 450 Is a default in case we can't acess the property
+    let bottomRowHeight = 450;
+    if (bottomRowElement) {
+      bottomRowHeight = bottomRowElement.offsetHeight;
     }
+    // getScrollRatio supports passing a pixel offset which is
+    // removed from the total length of the page.
     let ratio = getScrollRatio(bottomRowHeight);
     setScrollPosition(ratio);
     let percentage = Math.floor(ratio * 100);

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -8,7 +8,9 @@ import ratio from "../basic/ratio";
   removing it from the calculation of the ScrollHeight.
 
   Implemented using "named-parameters": https://byby.dev/js-named-parameters
+  To call method without defining parameter use: getScrollRatio({})
 */
+
 function getScrollRatio({ shortenPageHeightPixels = 0 }) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -1,8 +1,8 @@
 import ratio from "../basic/ratio";
 
 /*
-  shortenPageHeightPixels, expects a positive int value in Pixels to remove
-  from the total height of the page.
+  shortenPageHeightPixels: int (OPTIONAL), expects a positive int value in Pixels 
+  to remove from the total height of the page.
   For example, this is used in the reader to ignore the InfoBoxes at the end
   which are not part of the article. One can pass in the height of the divs,
   removing it from the calculation of the ScrollHeight.

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -1,28 +1,31 @@
 import ratio from "../basic/ratio";
 
-function getScrollRatio(endPageAdjustment = 0) {
-  // End page Adjustment means if you have some elements that you want to ignore
-  // when calculating the End of the page.
-  // This should be a value in Pixels. For example, this is used in the Reader
-  // to exclude the elemnts of user feedback in the ratio calculation.
+/*
+  shortenPageHeightPixels, expects a positive int value in Pixels to remove
+  from the total height of the page.
+  For example, this is used in the reader to ignore the InfoBoxes at the end
+  which are not part of the article. One can pass in the height of the divs,
+  removing it from the calculation of the ScrollHeight.
+*/
+function getScrollRatio(shortenPageHeightPixels = 0) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
   let endPage =
-    scrollElement.scrollHeight - scrollElement.clientHeight - endPageAdjustment;
+    scrollElement.scrollHeight -
+    scrollElement.clientHeight -
+    shortenPageHeightPixels;
   let ratioValue = ratio(scrollY, endPage);
   return ratioValue;
 }
 
-function getScrollPixelsToEnd(endPageAdjustment = 0) {
-  // End page Adjustment means if you have some elements that you want to ignore
-  // when calculating the End of the page.
-  // This should be a value in Pixels. For example, this is used in the Reader
-  // to exclude the elemnts of user feedback in the ratio calculation.
+function getPixelsFromScrollBarToEnd(shortenPageHeightPixels = 0) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
   let endPage =
-    scrollElement.scrollHeight - scrollElement.clientHeight - endPageAdjustment;
+    scrollElement.scrollHeight -
+    scrollElement.clientHeight -
+    shortenPageHeightPixels;
   return endPage - scrollY;
 }
 
-export { getScrollRatio, getScrollPixelsToEnd };
+export { getScrollRatio, getPixelsFromScrollBarToEnd };

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -1,0 +1,28 @@
+import ratio from "../basic/ratio";
+
+function getScrollRatio(endPageAdjustment = 0) {
+  // End page Adjustment means if you have some elements that you want to ignore
+  // when calculating the End of the page.
+  // This should be a value in Pixels. For example, this is used in the Reader
+  // to exclude the elemnts of user feedback in the ratio calculation.
+  let scrollElement = document.getElementById("scrollHolder");
+  let scrollY = scrollElement.scrollTop;
+  let endPage =
+    scrollElement.scrollHeight - scrollElement.clientHeight - endPageAdjustment;
+  let ratioValue = ratio(scrollY, endPage);
+  return ratioValue;
+}
+
+function getScrollPixelsToEnd(endPageAdjustment = 0) {
+  // End page Adjustment means if you have some elements that you want to ignore
+  // when calculating the End of the page.
+  // This should be a value in Pixels. For example, this is used in the Reader
+  // to exclude the elemnts of user feedback in the ratio calculation.
+  let scrollElement = document.getElementById("scrollHolder");
+  let scrollY = scrollElement.scrollTop;
+  let endPage =
+    scrollElement.scrollHeight - scrollElement.clientHeight - endPageAdjustment;
+  return endPage - scrollY;
+}
+
+export { getScrollRatio, getScrollPixelsToEnd };

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -1,28 +1,27 @@
 import ratio from "../basic/ratio";
 
-/*
-  shortenPageHeightPixels: int (OPTIONAL), expects a positive int value in Pixels 
-  to remove from the total height of the page.
-  For example, this is used in the reader to ignore the InfoBoxes at the end
-  which are not part of the article. One can pass in the height of the divs,
-  removing it from the calculation of the ScrollHeight.
-
-  Implemented using "named-parameters": https://byby.dev/js-named-parameters
-  To call method without defining parameter use: getScrollRatio({})
-*/
-
-function getScrollRatio({ shortenPageHeightPixels = 0 }) {
+/**
+ *
+ * @param {number} shortenPageHeightPixels - [optional] expects a positive int value in Pixels to remove from the total height of the page.
+ * @returns {number} - ratio of scrolled pixels to total page height
+ */
+function getScrollRatio(shortenPageHeightPixels = 0) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
+
   let endPage =
     scrollElement.scrollHeight -
     scrollElement.clientHeight -
     shortenPageHeightPixels;
-  let ratioValue = ratio(scrollY, endPage);
-  return ratioValue;
+  return ratio(scrollY, endPage);
 }
 
-function getPixelsFromScrollBarToEnd({ shortenPageHeightPixels = 0 }) {
+/**
+ *
+ * @param {number} shortenPageHeightPixels - [optional] expects a positive int value in Pixels to remove from the total height of the page.
+ * @returns {number}
+ */
+function getPixelsFromScrollBarToEnd(shortenPageHeightPixels = 0) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
   let endPage =

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -6,8 +6,10 @@ import ratio from "../basic/ratio";
   For example, this is used in the reader to ignore the InfoBoxes at the end
   which are not part of the article. One can pass in the height of the divs,
   removing it from the calculation of the ScrollHeight.
+
+  Implemented using "named-parameters": https://byby.dev/js-named-parameters
 */
-function getScrollRatio(shortenPageHeightPixels = 0) {
+function getScrollRatio({ shortenPageHeightPixels = 0 }) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
   let endPage =
@@ -18,7 +20,7 @@ function getScrollRatio(shortenPageHeightPixels = 0) {
   return ratioValue;
 }
 
-function getPixelsFromScrollBarToEnd(shortenPageHeightPixels = 0) {
+function getPixelsFromScrollBarToEnd({ shortenPageHeightPixels = 0 }) {
   let scrollElement = document.getElementById("scrollHolder");
   let scrollY = scrollElement.scrollTop;
   let endPage =


### PR DESCRIPTION
This only works when combined with the changes introduced in https://github.com/zeeguu/api/pull/154

Move the functions to get the scroll location to a utility function as they might be useful in other places. I decide to use absolute pixels to avoid expanding the articles to much and loading the articles despite not having scrolled to the end.

Otherwise the users will see the loading animation at the bottom of the articles indefinitely.

**Question:** Should we limit the total articles a user can retrieve? At the moment I can see that they can keep going, I scrolled for a while and I got to 639 articles, it will still work but maybe it is a lot of information to keep storing all the articles?