### PR TITLE
Avoid querying the API when there are no more results.

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -14,7 +14,10 @@ import ShowLinkRecommendationsIfNoArticles from "./ShowLinkRecommendationsIfNoAr
 import { useLocation } from "react-router-dom";
 import { APIContext } from "../contexts/APIContext";
 import useExtensionCommunication from "../hooks/useExtensionCommunication";
-import { getPixelsFromScrollBarToEnd } from "../utils/misc/getScrollLocation";
+import {
+  getPixelsFromScrollBarToEnd,
+  isScrollable,
+} from "../utils/misc/getScrollLocation";
 // A custom hook that builds on useLocation to parse
 // the query string for you.
 function useQuery() {
@@ -66,11 +69,11 @@ export default function NewArticles() {
   };
   function handleScroll() {
     let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
+
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
       !isWaitingForNewArticlesRef.current &&
-      !noMoreArticlesToShowRef.current &&
-      articleListRef.current !== undefined
+      !noMoreArticlesToShowRef.current
     ) {
       setIsWaitingForNewArticles(true);
       document.title = "Getting more articles...";
@@ -133,15 +136,17 @@ export default function NewArticles() {
         setArticleList(articles);
         setOriginalList([...articles]);
         if (articles.length < 20) setNoMoreArticlesToShow(true);
+        else window.addEventListener("scroll", handleScroll, true);
       });
     } else {
       api.getUserArticles((articles) => {
         setArticleList(articles);
         setOriginalList([...articles]);
         if (articles.length < 20) setNoMoreArticlesToShow(true);
+        else window.addEventListener("scroll", handleScroll, true);
       });
     }
-    window.addEventListener("scroll", handleScroll, true);
+
     document.title = "Recommend Articles: Zeeguu";
     return () => {
       window.removeEventListener("scroll", handleScroll, true);

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -69,7 +69,8 @@ export default function NewArticles() {
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
       !isWaitingForNewArticlesRef.current &&
-      !noMoreArticlesToShowRef.current
+      !noMoreArticlesToShowRef.current &&
+      articleListRef.current !== undefined
     ) {
       setIsWaitingForNewArticles(true);
       document.title = "Getting more articles...";
@@ -131,11 +132,13 @@ export default function NewArticles() {
       api.search(searchQuery, (articles) => {
         setArticleList(articles);
         setOriginalList([...articles]);
+        if (articles.length < 20) setNoMoreArticlesToShow(true);
       });
     } else {
       api.getUserArticles((articles) => {
         setArticleList(articles);
         setOriginalList([...articles]);
+        if (articles.length < 20) setNoMoreArticlesToShow(true);
       });
     }
     window.addEventListener("scroll", handleScroll, true);
@@ -216,7 +219,7 @@ export default function NewArticles() {
       {isWaitingForNewArticles && (
         <LoadingAnimation delay={0}></LoadingAnimation>
       )}
-      {noMoreArticlesToShow && (
+      {noMoreArticlesToShow && articleList.length > 0 && (
         <div
           style={{
             display: "flex",

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -46,8 +46,10 @@ export default function NewArticles() {
   const [isWaitingForNewArticles, setIsWaitingForNewArticles] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
 
+  const [noMoreArticlesToShow, setNoMoreArticlesToShow] = useState(false);
   const articleListRef = useShadowRef(articleList);
   const currentPageRef = useShadowRef(currentPage);
+  const noMoreArticlesToShowRef = useShadowRef(noMoreArticlesToShow);
   const isWaitingForNewArticlesRef = useShadowRef(isWaitingForNewArticles);
   console.log(articleList);
   const handleArticleClick = (articleId, index) => {
@@ -62,17 +64,19 @@ export default function NewArticles() {
       articleSeenListString,
     );
   };
-
   function handleScroll() {
     let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
-      !isWaitingForNewArticlesRef.current
+      !isWaitingForNewArticlesRef.current &&
+      !noMoreArticlesToShowRef.current
     ) {
       setIsWaitingForNewArticles(true);
       document.title = "Getting more articles...";
+
       let newCurrentPage = currentPageRef.current + 1;
       let newArticles = [...articleListRef.current];
+
       if (searchQuery) {
         api.searchMore(searchQuery, newCurrentPage, (articles) => {
           insertNewArticlesIntoArticleList(
@@ -98,6 +102,9 @@ export default function NewArticles() {
     newCurrentPage,
     newArticles,
   ) {
+    if (fetchedArticles.length === 0) {
+      setNoMoreArticlesToShow(true);
+    }
     newArticles = newArticles.concat(fetchedArticles);
     setArticleList(newArticles);
     setOriginalList([...newArticles]);
@@ -208,6 +215,18 @@ export default function NewArticles() {
       )}
       {isWaitingForNewArticles && (
         <LoadingAnimation delay={0}></LoadingAnimation>
+      )}
+      {noMoreArticlesToShow && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-around",
+            margin: "2em 0px",
+          }}
+        >
+          There are no more results.
+        </div>
       )}
     </>
   );

--- a/src/utils/misc/getScrollLocation.js
+++ b/src/utils/misc/getScrollLocation.js
@@ -31,4 +31,15 @@ function getPixelsFromScrollBarToEnd(shortenPageHeightPixels = 0) {
   return endPage - scrollY;
 }
 
-export { getScrollRatio, getPixelsFromScrollBarToEnd };
+/**
+ * Returns true when the user is able to scroll the "scrollHolder" element.
+ * Should be used before using getPixelsFromScrollBarToEnd or getScrollRatio.
+ * @returns {boolean}
+ */
+function isScrollable() {
+  let scrollElement = document.getElementById("scrollHolder");
+  if (scrollElement === null) return false;
+  return scrollElement.scrollHeight > scrollElement.clientHeight;
+}
+
+export { getScrollRatio, getPixelsFromScrollBarToEnd, isScrollable };


### PR DESCRIPTION
- The user could re-attempt to scroll which would call the API repeatably, without getting any updated results.
- This adds a little message stating that there aren't more results so the user knows they have reached the end.
- It also avoids making the call to the API if that's the case.
- This is especially important when the user searches for a keyword, where it's more likely there won't be infinite results. 

![image](https://github.com/zeeguu/web/assets/17390076/e5be9851-7627-4db4-a995-457a6f14f697)
