### PR TITLE
Fix uncaught exception when back navigating to articles

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -64,6 +64,10 @@ export default function NewArticles() {
   };
 
   function handleScroll() {
+    // If the user navigates backwards while at the end
+    // of the page it would trigger the scroll without
+    // having the first articles, causing an error.
+    if (!articleListRef.current) return;
     let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
     if (
       scrollBarPixelDistToPageEnd <= 50 &&


### PR DESCRIPTION
![image](https://github.com/zeeguu/web/assets/17390076/09793622-9274-4a50-bfdf-5554ca7c8913)

"articleListRef.current is not iterable" occurs when the user is at the bottom of a page and clicks on the "Go Back" browser navigation. This triggers the handleScroll which wouldn't have any reference to the current articles.

I added a safeguard that doesn't run the method if `articleListRef.current` is undefined, which fixed the issue. 