### PR TITLE
improved word overview and TranslateWhatYouHear component

### DIFF
--- a/src/components/TopMessage.sc.js
+++ b/src/components/TopMessage.sc.js
@@ -12,6 +12,9 @@ let TopMessage = styled.div`
   margin: 2em;
   padding: 0.5em 0.5em;
   font-size: large;
+  @media (max-width: 720px) {
+    font-size: small;
+  }
 
   @media (min-width: 768px) {
     width: 36em;
@@ -21,6 +24,9 @@ let TopMessage = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    @media (max-width: 720px) {
+      flex-direction: column;
+    }
   }
 `;
 

--- a/src/exercises/exerciseTypes/BottomInput.js
+++ b/src/exercises/exerciseTypes/BottomInput.js
@@ -26,6 +26,7 @@ export default function BottomInput({
   const [isLongerThanSolution, setIsLongerThanSolution] = useState(false);
   const [isInputWrongLanguage, setIsInputWrongLanguage] = useState(false);
   const [feedbackMessage, setFeedbackMessage] = useState("");
+  const [firstHint, setFirstHint] = useState(true);
   const levenshtein = require("fast-levenshtein");
 
   const normalizedLearningWord = normalizeAnswer(bookmarksToStudy[0].from);
@@ -39,12 +40,11 @@ export default function BottomInput({
     : bookmarksToStudy[0].from_lang;
 
   function handleHint() {
-    setUsedHint(true);
-
-    if (exerciseType === EXERCISE_TYPES.translateWhatYouHear) {
+    if (exerciseType === EXERCISE_TYPES.translateWhatYouHear && firstHint) {
+      setFirstHint(false);
       onHintUsed();
-      setMessageToAPI(messageToAPI + "H");
     } else {
+      setUsedHint(true);
       let hint;
       if (currentInput === targetWord.substring(0, currentInput.length)) {
         hint = targetWord.substring(0, currentInput.length + 1);

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -41,7 +41,7 @@ export default function TranslateWhatYouHear({
   const [getCurrentSubSessionDuration] = useSubSessionTimer(
     activeSessionDuration,
   );
-  const [usedHint, setUsedHint] = useState(false);
+  const [showHintText, setShowHintText] = useState(false);
 
   async function handleSpeak() {
     await speech.speakOut(bookmarkToStudy.from, setIsButtonSpeaking);
@@ -133,7 +133,7 @@ export default function TranslateWhatYouHear({
         bookmark={bookmarksToStudy[0]}
         message={messageToAPI}
       />
-      {!isCorrect && !usedHint && (
+      {!isCorrect && (
         <>
           <s.CenteredRowTall>
             <SpeakButton
@@ -143,7 +143,18 @@ export default function TranslateWhatYouHear({
               parentIsSpeakingControl={isButtonSpeaking}
             />
           </s.CenteredRowTall>
-
+          {showHintText && (
+            <div className="contextExample">
+              <TranslatableText
+                isCorrect={isCorrect}
+                interactiveText={interactiveText}
+                translating={true}
+                pronouncing={false}
+                bookmarkToStudy={bookmarksToStudy[0].from}
+                exerciseType={EXERCISE_TYPE}
+              />
+            </div>
+          )}
           <BottomInput
             handleCorrectAnswer={handleCorrectAnswer}
             handleIncorrectAnswer={handleIncorrectAnswer}
@@ -152,44 +163,11 @@ export default function TranslateWhatYouHear({
             setMessageToAPI={setMessageToAPI}
             isL1Answer={true}
             exerciseType={EXERCISE_TYPE}
-            onHintUsed={() => setUsedHint(true)}
+            onHintUsed={() => setShowHintText(true)}
           />
         </>
       )}
-      {!isCorrect && usedHint && (
-        <>
-          <s.CenteredRowTall>
-            <SpeakButton
-              bookmarkToStudy={bookmarkToStudy}
-              api={api}
-              styling="large"
-              parentIsSpeakingControl={isButtonSpeaking}
-            />
-          </s.CenteredRowTall>
 
-          <div className="contextExample">
-            <TranslatableText
-              isCorrect={isCorrect}
-              interactiveText={interactiveText}
-              translating={true}
-              pronouncing={false}
-              bookmarkToStudy={bookmarksToStudy[0].from}
-              exerciseType={EXERCISE_TYPE}
-            />
-          </div>
-
-          <BottomInput
-            handleCorrectAnswer={handleCorrectAnswer}
-            handleIncorrectAnswer={handleIncorrectAnswer}
-            bookmarksToStudy={bookmarksToStudy}
-            messageToAPI={messageToAPI}
-            setMessageToAPI={setMessageToAPI}
-            isL1Answer={true}
-            exerciseType={EXERCISE_TYPE}
-            onHintUsed={() => setUsedHint(true)}
-          />
-        </>
-      )}
       {isCorrect && (
         <>
           <br></br>


### PR DESCRIPTION
Previously, the Translate What You Hear exercise only showed the context as a hint. Now it first shows the context and then provides the first letter of the solution, if the user asked for another hint. So the context is not considered a hint in the database anymore. I've also refactored the code to avoid duplication and re-rendering of the component when it's not necessary.

<img width="386" alt="Screenshot 2024-06-13 at 10 10 28" src="https://github.com/zeeguu/web/assets/147062323/b671b034-217f-4f4e-9a87-58cf12c0f7c5">



This PR also includes a slight layout improvement of the word overview for small screen sizes. The text is now smaller and the icon has been moved to the top.

<p float="left">

<img width="313" alt="Screenshot 2024-06-13 at 09 39 18" src="https://github.com/zeeguu/web/assets/147062323/6a38bf7e-56db-456c-b9d3-027e5aca02b4">


<img width="316" alt="Screenshot 2024-06-13 at 09 39 01" src="https://github.com/zeeguu/web/assets/147062323/f348bcb0-67f4-4e02-86b2-f393ef66bd75">
</p>