### PR TITLE
Fixed situation where user translates after finishing the exercise

### DIFF
--- a/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
+++ b/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
@@ -98,7 +98,7 @@ export default function WordInContextExercise({
       });
     });
 
-    if (solutionDiscovered) {
+    if (solutionDiscovered && !isCorrect) {
       // Check how many translations were made
       let translationCount = 0;
       for (let i = 0; i < messageToAPI.length; i++) {


### PR DESCRIPTION
After the user finished the WordInContext exercise, if they translated the word again, they would submit a new outcome to the API with an extra correct. 

The change ensures that after the exercise is correct, nothing is sent to the API. The message is updated, but won't be logged. 