### PR TITLE
Fix to concurrency update when changing to new language.

### DIFF
--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -46,6 +46,10 @@ export default function Settings({ api, setUser }) {
     // eslint-disable-next-line
   }, []);
 
+  function onSysChange(lang) {
+    setUiLanguage(lang);
+  }
+
   function setCEFRlevel(data) {
     const levelKey = data.learned_language + "_cefr_level";
     const levelNumber = data[levelKey];

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -46,29 +46,15 @@ export default function Settings({ api, setUser }) {
     // eslint-disable-next-line
   }, []);
 
-  function onSysChange(lang) {
-    setUiLanguage(lang);
-  }
-
   function setCEFRlevel(data) {
     const levelKey = data.learned_language + "_cefr_level";
     const levelNumber = data[levelKey];
     setCEFR("" + levelNumber);
+    setUserDetails({
+      ...data,
+      cefr_level: levelNumber,
+    });
   }
-
-  const modifyCEFRlevel = (languageID, cefrLevel) => {
-    api.modifyCEFRlevel(
-      languageID,
-      cefrLevel,
-      (res) => {
-        console.log("Update '" + languageID + "' CEFR level to: " + cefrLevel);
-        console.log("API returns update status: " + res);
-      },
-      () => {
-        console.log("Connection to server failed...");
-      },
-    );
-  };
 
   useEffect(() => {
     api.getUserDetails((data) => {
@@ -108,11 +94,28 @@ export default function Settings({ api, setUser }) {
     saveUserInfoIntoCookies(info);
   }
 
-  function nativeLanguageUpdated(e) {
-    let code = e.target[e.target.selectedIndex].getAttribute("code");
+  function getLanguageCodeFromSelector(e) {
+    return e.target[e.target.selectedIndex].getAttribute("code");
+  }
+
+  function updateNativeLanguage(lang_code) {
     setUserDetails({
       ...userDetails,
-      native_language: code,
+      native_language: lang_code,
+    });
+  }
+
+  function updateCEFRLevel(level) {
+    setUserDetails({
+      ...userDetails,
+      cefr_level: level,
+    });
+  }
+
+  function updateLearnedLanguage(lang_code) {
+    setUserDetails({
+      ...userDetails,
+      learned_language: lang_code,
     });
   }
 
@@ -122,25 +125,21 @@ export default function Settings({ api, setUser }) {
     strings.setLanguage(uiLanguage.code);
     LocalStorage.setUiLanguage(uiLanguage);
 
-    modifyCEFRlevel(userDetails.learned_language, cefr);
+    // modifyCEFRlevel(userDetails.learned_language, cefr);
 
-    console.log("saving: productiveExercises: " + productiveExercises);
     SessionStorage.setAudioExercisesEnabled(audioExercises);
+    api.saveUserPreferences({
+      audio_exercises: audioExercises,
+      productive_exercises: productiveExercises,
+    });
+
     api.saveUserDetails(userDetails, setErrorMessage, () => {
-      api.saveUserPreferences(
-        {
-          audio_exercises: audioExercises,
-          productive_exercises: productiveExercises,
-        },
-        () => {
-          updateUserInfo(userDetails);
-          if (history.length > 1) {
-            history.goBack();
-          } else {
-            window.close();
-          }
-        },
-      );
+      updateUserInfo(userDetails);
+      if (history.length > 1) {
+        history.goBack();
+      } else {
+        window.close();
+      }
     });
   }
 
@@ -222,12 +221,7 @@ export default function Settings({ api, setUser }) {
                 languages.learnable_languages,
               )}
               onChange={(e) => {
-                let code =
-                  e.target[e.target.selectedIndex].getAttribute("code");
-                setUserDetails({
-                  ...userDetails,
-                  learned_language: code,
-                });
+                updateLearnedLanguage(getLanguageCodeFromSelector(e));
               }}
             />
 
@@ -235,7 +229,9 @@ export default function Settings({ api, setUser }) {
               elements={CEFR_LEVELS}
               label={(e) => e.label}
               val={(e) => e.value}
-              updateFunction={setCEFR}
+              updateFunction={(e) => {
+                updateCEFRLevel(e);
+              }}
               current={cefr}
             />
 
@@ -249,7 +245,9 @@ export default function Settings({ api, setUser }) {
                 userDetails.native_language,
                 languages.native_languages,
               )}
-              onChange={nativeLanguageUpdated}
+              onChange={(e) => {
+                updateNativeLanguage(getLanguageCodeFromSelector(e));
+              }}
             />
 
             <label>Exercise Type Preferences</label>
@@ -337,6 +335,7 @@ export default function Settings({ api, setUser }) {
 
 function language_for_id(id, language_list) {
   for (let i = 0; i < language_list.length; i++) {
+    console.log(language_list[i].code, id);
     if (language_list[i].code === id) {
       return language_list[i].name;
     }


### PR DESCRIPTION
Whenever a user would update the language they were learning it could cause a concurrency issue in the backend if they had not selected the language before.

To fix this, I have made changes on how the Save is handled both in the Web and API to simply do it in one endpoint call, rather than multiple endpoint calls.

The user preferences are handled separately, as these are not needed for the user details update.

## Implementation:

- `modifyCEFRlevel` - is no longer called in the settings. Maybe if at some point we have a component that needs this individual update it's still available to be called. I believe this was the cause for the concurrency - as we would call a set `UserLanguage` both here and in `saveUserDetails`. 
- `saveUserDetails` will now update all the fields that are being edited in the frontend - ensure they mirror what the user inputs. 
- `api.isaveUserPreferences` and `api.saveUserDetails` do not wait for each other as they are independent of their own updates.

## Depends on:

https://github.com/zeeguu/api/pull/165