### PR TITLE
Fixed error of articleListRef.current

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -135,17 +135,15 @@ export default function NewArticles() {
         setArticleList(articles);
         setOriginalList([...articles]);
         if (articles.length < 20) setNoMoreArticlesToShow(true);
-        else window.addEventListener("scroll", handleScroll, true);
       });
     } else {
       api.getUserArticles((articles) => {
         setArticleList(articles);
         setOriginalList([...articles]);
         if (articles.length < 20) setNoMoreArticlesToShow(true);
-        else window.addEventListener("scroll", handleScroll, true);
       });
     }
-
+    window.addEventListener("scroll", handleScroll, true);
     document.title = "Recommend Articles: Zeeguu";
     return () => {
       window.removeEventListener("scroll", handleScroll, true);


### PR DESCRIPTION
Since this method was being added in an async call, we would sometimes create the event after we would leave the home page. Which leads to it never being cleared.

This implementation always creates the event, and deletes it whenever it's left from the method. The event itself has a guard in case the user attempts to scroll when no more articles are available which avoids making unnecessary calls to the API.

This error doesn't crash or cause problems directly in the app, but it shows up during development, so it would be good to eliminate it!