### PR TITLE
Fix Edit Form Sending Toasty when No edit was made

### DIFF
--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -15,6 +15,12 @@ export default function WordEditForm({
   const [context, setContext] = useState(bookmark.context);
   const [fitForStudy, setFitForStudy] = useState(bookmark.fit_for_study);
 
+  const isEdited =
+    bookmark.to === translation &&
+    bookmark.from === expression &&
+    bookmark.context === context &&
+    bookmark.fit_for_study === fitForStudy;
+
   function prepClose() {
     setTranslation(bookmark.to);
     setExpression(bookmark.from);
@@ -51,12 +57,7 @@ export default function WordEditForm({
         setContext(bookmark.context);
         event.preventDefault();
       }
-    } else if (
-      bookmark.to === translation &&
-      bookmark.from === expression &&
-      bookmark.context === context &&
-      bookmark.fitForStudy === fitForStudy
-    ) {
+    } else if (isEdited) {
       prepClose();
     } else {
       updateBookmark(bookmark, expression, translation, context, fitForStudy);
@@ -121,10 +122,7 @@ export default function WordEditForm({
           </s.CustomCheckBoxDiv>
         )}
 
-        {bookmark.to === translation &&
-        bookmark.from === expression &&
-        bookmark.context === context &&
-        bookmark.fit_for_study === fitForStudy ? (
+        {isEdited ? (
           <s.DoneButtonHolder>
             <st.FeedbackDelete
               onClick={(e) => deleteAction(bookmark)}

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -15,7 +15,7 @@ export default function WordEditForm({
   const [context, setContext] = useState(bookmark.context);
   const [fitForStudy, setFitForStudy] = useState(bookmark.fit_for_study);
 
-  const isEdited =
+  const isNotEdited =
     bookmark.to === translation &&
     bookmark.from === expression &&
     bookmark.context === context &&
@@ -57,7 +57,7 @@ export default function WordEditForm({
         setContext(bookmark.context);
         event.preventDefault();
       }
-    } else if (isEdited) {
+    } else if (isNotEdited) {
       prepClose();
     } else {
       updateBookmark(bookmark, expression, translation, context, fitForStudy);
@@ -122,10 +122,10 @@ export default function WordEditForm({
           </s.CustomCheckBoxDiv>
         )}
 
-        {isEdited ? (
+        {isNotEdited ? (
           <s.DoneButtonHolder>
             <st.FeedbackDelete
-              onClick={(e) => deleteAction(bookmark)}
+              onClick={() => deleteAction(bookmark)}
               value={strings.deleteWord}
             />
             <st.FeedbackSubmit


### PR DESCRIPTION
Issue: If the user opens the Edit word, it will send the "Thank you for the contribution!" toasty even if the user has not edited the bookmark. 

I found out that the condition to test if anything had been edited from the edit form was incorrect.

It was trying to access an undefined property 'fitForStudy' instead of the correct 'fit_for_study'.

I have moved this to a constant to be easier to call rather than having multiple places where it's re-written.
