### PR TITLE
Fixed Deleting from Exercises

### DIFF
--- a/src/api/userWords.js
+++ b/src/api/userWords.js
@@ -47,8 +47,12 @@ Zeeguu_API.prototype.starBookmark = function (bookmark_id) {
   this._post(`star_bookmark/${bookmark_id}`);
 };
 
-Zeeguu_API.prototype.deleteBookmark = function (bookmark_id, callback) {
-  this._post(`delete_bookmark/${bookmark_id}`, "", callback);
+Zeeguu_API.prototype.deleteBookmark = function (
+  bookmark_id,
+  callback,
+  onError,
+) {
+  this._post(`delete_bookmark/${bookmark_id}`, "", callback, onError);
 };
 
 Zeeguu_API.prototype.setIsFitForStudy = function (bookmark_id) {

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -178,6 +178,7 @@ export default function NextNavigation({
               styling={exercise}
               reload={reload}
               setReload={setReload}
+              setDeleted={setIsDeleted}
             />
           </s.EditSpeakButtonHolder>
           <s.FeedbackButton onClick={(e) => moveToNextExercise()} autoFocus>

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -43,6 +43,7 @@ export default function NextNavigation({
   const [correctMessage, setCorrectMessage] = useState("");
   const [learningCycle, setLearningCycle] = useState(null);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
 
   const productiveExercisesDisabled =
     localStorage.getItem("productiveExercisesEnabled") === "false";
@@ -91,6 +92,12 @@ export default function NextNavigation({
       setCorrectMessage(random(correctStrings));
     }
   }, [isCorrect]);
+
+  useEffect(() => {
+    if (isDeleted) {
+      moveToNextExercise();
+    }
+  });
 
   useEffect(() => {
     if (bookmarkLearned && !SessionStorage.isCelebrationModalShown()) {

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -97,7 +97,7 @@ export default function NextNavigation({
     if (isDeleted) {
       moveToNextExercise();
     }
-  });
+  }, [isDeleted]);
 
   useEffect(() => {
     if (bookmarkLearned && !SessionStorage.isCelebrationModalShown()) {

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -1,6 +1,6 @@
 import strings from "../../i18n/definitions";
 import SpeakButton from "./SpeakButton";
-import EditButton from "../../words/EditButton";
+import EditBookmarkButton from "../../words/EditBookmarkButton";
 import * as s from "./Exercise.sc";
 import SolutionFeedbackLinks from "./SolutionFeedbackLinks";
 import { random } from "../../utils/basic/arrays";
@@ -172,13 +172,13 @@ export default function NextNavigation({
               style="next"
               isReadContext={isReadContext}
             />
-            <EditButton
+            <EditBookmarkButton
               bookmark={exerciseBookmark}
               api={api}
               styling={exercise}
               reload={reload}
               setReload={setReload}
-              setDeleted={setIsDeleted}
+              notifyDelete={() => setIsDeleted(true)}
             />
           </s.EditSpeakButtonHolder>
           <s.FeedbackButton onClick={(e) => moveToNextExercise()} autoFocus>

--- a/src/exercises/exerciseTypes/match/MatchInput.js
+++ b/src/exercises/exerciseTypes/match/MatchInput.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import SpeakButton from "../SpeakButton";
 import * as s from "../Exercise.sc";
 import { removePunctuation } from "../../../utils/preprocessing/preprocessing";
-import EditButton from "../../../words/EditButton.js";
+import EditBookmarkButton from "../../../words/EditBookmarkButton.js";
 import {
   zeeguuOrange,
   darkBlue,
@@ -49,7 +49,10 @@ function MatchInput({
   const [firstSelectionColumn, setFirstSelectionColumn] = useState("");
 
   function handleClick(column, id) {
-    let selectedBookmark = column === "from" ? fromButtonOptions.find(option => option.id === id) : toButtonOptions.find(option => option.id === id);
+    let selectedBookmark =
+      column === "from"
+        ? fromButtonOptions.find((option) => option.id === id)
+        : toButtonOptions.find((option) => option.id === id);
     if (firstSelection !== 0) {
       if (
         (column === "from" && firstSelectionColumn === "from") ||
@@ -111,7 +114,7 @@ function MatchInput({
                 </s.AnimatedMatchButton>
               ) : buttonsToDisable.includes(option.id) || isCorrect ? (
                 <s.ButtonRow key={"L2_Row_" + option.id}>
-                  <EditButton
+                  <EditBookmarkButton
                     bookmark={option}
                     api={api}
                     styling={match}

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -7,13 +7,12 @@ import WordEditForm from "./WordEditForm";
 import { getStaticPath } from "../utils/misc/staticPath.js";
 import { toast } from "react-toastify";
 
-export default function EditButton({
+export default function EditBookmarkButton({
   bookmark,
   api,
   styling,
   reload,
   setReload,
-  setDeleted,
   notifyWordChange,
   notifyDelete,
 }) {
@@ -24,17 +23,30 @@ export default function EditButton({
     setOpen(true);
   }
 
-  function deleteBookmark(bookmark) {
-    api.deleteBookmark(bookmark.id);
-    if (setDeleted) setDeleted(true);
-    if (notifyDelete) notifyDelete(bookmark);
-    api.logReaderActivity(
-      api.DELETE_WORD,
-      bookmark.article_id,
-      bookmark.from,
-      SOURCE_FOR_API_BOOKMARK_DELETE,
+  function deleteBookmark() {
+    api.deleteBookmark(
+      bookmark.id,
+      (response) => {
+        if (response === "OK") {
+          // delete was successful; log and close
+          if (notifyDelete) notifyDelete(bookmark);
+          api.logReaderActivity(
+            api.DELETE_WORD,
+            bookmark.article_id,
+            bookmark.from,
+            SOURCE_FOR_API_BOOKMARK_DELETE,
+          );
+          handleClose();
+        }
+      },
+      (error) => {
+        // onError
+        console.log(error);
+        alert(
+          "something went wrong and we could not delete the bookmark; try again later.",
+        );
+      },
     );
-    handleClose();
   }
 
   function handleClose() {

--- a/src/words/EditButton.js
+++ b/src/words/EditButton.js
@@ -13,13 +13,28 @@ export default function EditButton({
   styling,
   reload,
   setReload,
-  deleteAction,
+  setDeleted,
   notifyWordChange,
+  notifyDelete,
 }) {
   const [open, setOpen] = useState(false);
   const SOURCE_FOR_API_USER_PREFERENCE = "WORD_EDIT_FORM_CHECKBOX";
+  const SOURCE_FOR_API_BOOKMARK_DELETE = "WORD_EDIT_DELETE_BOOKMARK";
   function handleOpen() {
     setOpen(true);
+  }
+
+  function deleteBookmark(bookmark) {
+    api.deleteBookmark(bookmark.id);
+    if (setDeleted) setDeleted(true);
+    if (notifyDelete) notifyDelete(bookmark);
+    api.logReaderActivity(
+      api.DELETE_WORD,
+      bookmark.article_id,
+      bookmark.from,
+      SOURCE_FOR_API_BOOKMARK_DELETE,
+    );
+    handleClose();
   }
 
   function handleClose() {
@@ -109,7 +124,7 @@ export default function EditButton({
             bookmark={bookmark}
             handleClose={handleClose}
             updateBookmark={updateBookmark}
-            deleteAction={deleteAction}
+            deleteAction={deleteBookmark}
           />
         </Box>
       </Modal>

--- a/src/words/Word.js
+++ b/src/words/Word.js
@@ -19,7 +19,6 @@ export default function Word({
   source,
   isReview,
 }) {
-  const [starred, setStarred] = useState(bookmark.starred);
   const [deleted, setDeleted] = useState(false);
   const [reload, setReload] = useState(false);
 
@@ -44,18 +43,6 @@ export default function Word({
     if (notifyWordChange) notifyWordChange(bookmark);
     api.logReaderActivity(
       api.USER_SET_NOT_WORD_PREFERED,
-      bookmark.article_id,
-      bookmark.from,
-      source,
-    );
-  }
-
-  function deleteBookmark(bookmark) {
-    api.deleteBookmark(bookmark.id);
-    setDeleted(true);
-    if (notifyDelete) notifyDelete(bookmark);
-    api.logReaderActivity(
-      api.DELETE_WORD,
       bookmark.article_id,
       bookmark.from,
       source,
@@ -98,11 +85,6 @@ export default function Word({
               />
             </s.AddRemoveStudyPreferenceButton>
           )}
-          {/*!isReview && (
-            <s.TrashIcon onClick={(e) => deleteBookmark(bookmark)}>
-              <img src={APP_DOMAIN + "/static/images/trash.svg"} alt="trash" />
-            </s.TrashIcon>
-          )*/}
           {/*
             Debug user preferences. 
             {bookmark.user_preference !== USER_WORD_PREFERENCE.NO_PREFERENCE && (
@@ -117,7 +99,8 @@ export default function Word({
               reload={reload}
               setReload={setReload}
               notifyWordChange={notifyWordChange}
-              deleteAction={deleteBookmark}
+              notifyDelete={notifyDelete}
+              setDeleted={setDeleted}
             />
           )}
 

--- a/src/words/Word.js
+++ b/src/words/Word.js
@@ -2,7 +2,7 @@ import * as s from "./Word.sc";
 
 import { useState } from "react";
 import SpeakButton from "../exercises/exerciseTypes/SpeakButton";
-import EditButton from "./EditButton";
+import EditBookmarkButton from "./EditBookmarkButton";
 import { darkGrey } from "../components/colors";
 import { CenteredRow } from "../exercises/exerciseTypes/Exercise.sc";
 import { USER_WORD_PREFERENCE } from "./userBookmarkPreferences";
@@ -93,14 +93,16 @@ export default function Word({
           */}
 
           {!isReview && (
-            <EditButton
+            <EditBookmarkButton
               bookmark={bookmark}
               api={api}
               reload={reload}
               setReload={setReload}
               notifyWordChange={notifyWordChange}
-              notifyDelete={notifyDelete}
-              setDeleted={setDeleted}
+              notifyDelete={() => {
+                setDeleted(true);
+                notifyDelete(bookmark);
+              }}
             />
           )}
 


### PR DESCRIPTION
Before Deleting the bookmark was associated with the Word component (the trash icon, but now since we have moved the delete action to the edit form, it doesn't make sense to have this action in the word component.

- Moved the delete action to the EditButton, as now the logic is always handled here.
- NextNavigation has a state for the case of the bookmark being deleted to simply move to the next exercise.
- Deleted Starred State in Word, and TrashIcon commented out code.