### PR TITLE
427 deleting a word from match exercise

### DIFF
--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -9,6 +9,7 @@ import NextNavigation from "../NextNavigation";
 import MatchInput from "./MatchInput.js";
 import useSubSessionTimer from "../../../hooks/useSubSessionTimer.js";
 import { toast } from "react-toastify";
+import isBookmarkExpression from "../../../utils/misc/isBookmarkExpression.js";
 
 // The user has to match three L1 words to their correct L2 translations.
 // This tests the user's passive knowledge.
@@ -85,7 +86,10 @@ export default function Match({
   }, [selectedBookmark]);
 
   function notifyBookmarkDeletion(bookmark) {
-    toast.success("The word " + bookmark.to + " is deleted!");
+    let word_expression = "";
+    if (isBookmarkExpression(bookmark)) word_expression = "expression";
+    else word_expression = "word";
+    toast.success(`The ${word_expression} '${bookmark.from}' is deleted!`);
   }
 
   function notifyChoiceSelection(firstChoice, secondChoice) {

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -8,6 +8,7 @@ import LearningCycleIndicator from "../../LearningCycleIndicator.js";
 import NextNavigation from "../NextNavigation";
 import MatchInput from "./MatchInput.js";
 import useSubSessionTimer from "../../../hooks/useSubSessionTimer.js";
+import { toast } from "react-toastify";
 
 // The user has to match three L1 words to their correct L2 translations.
 // This tests the user's passive knowledge.
@@ -82,6 +83,10 @@ export default function Match({
         setSelectedBookmarkMessage(currentBookmarkLog.messageToAPI);
     }
   }, [selectedBookmark]);
+
+  function notifyBookmarkDeletion(bookmark) {
+    toast.success("The word " + bookmark.to + " is deleted!");
+  }
 
   function notifyChoiceSelection(firstChoice, secondChoice) {
     console.log("checking result...");
@@ -192,6 +197,7 @@ export default function Match({
         reload={reload}
         setReload={setReload}
         onBookmarkSelected={setSelectedBookmark}
+        notifyBookmarkDeletion={notifyBookmarkDeletion}
       />
       <NextNavigation
         message={messageToNextNav}

--- a/src/exercises/exerciseTypes/match/MatchInput.js
+++ b/src/exercises/exerciseTypes/match/MatchInput.js
@@ -23,6 +23,7 @@ function MatchInput({
   reload,
   setReload,
   onBookmarkSelected,
+  notifyBookmarkDeletion,
 }) {
   const answerColors = [
     {
@@ -120,6 +121,7 @@ function MatchInput({
                     styling={match}
                     reload={reload}
                     setReload={setReload}
+                    notifyDelete={() => notifyBookmarkDeletion(option)}
                   />
                   <s.MatchingWords
                     className="matchingWords"

--- a/src/utils/misc/isBookmarkExpression.js
+++ b/src/utils/misc/isBookmarkExpression.js
@@ -1,0 +1,3 @@
+export default function isBookmarkExpression(bookmark) {
+  return bookmark.from.includes(" ");
+}

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -3,6 +3,7 @@ import * as st from "../exercises/bottomActions/FeedbackButtons.sc";
 import strings from "../i18n/definitions";
 import { useState } from "react";
 import { MAX_WORDS_IN_BOOKMARK_FOR_EXERCISES } from "../exercises/ExerciseConstants";
+import isBookmarkExpression from "../utils/misc/isBookmarkExpression";
 
 export default function WordEditForm({
   bookmark,
@@ -66,13 +67,13 @@ export default function WordEditForm({
   }
   return (
     <>
-      {bookmark.from.includes(" ") ? (
+      {isBookmarkExpression(bookmark) ? (
         <s.Headline>{strings.editExpression}</s.Headline>
       ) : (
         <s.Headline>{strings.editWord}</s.Headline>
       )}
       <form onSubmit={handleSubmit}>
-        {bookmark.from.includes(" ") ? (
+        {isBookmarkExpression(bookmark) ? (
           <s.CustomTextField
             id="outlined-basic"
             label={strings.expression}


### PR DESCRIPTION
- Added a toast.success notification on deleting a bookmark from the Match exercise.
- Added a new util function to return true if a bookmark is an expression

The notification is as follows for the following exercise:

![image](https://github.com/user-attachments/assets/5c13720b-ce52-4f1e-9db6-bcaa08cd5c08)

![image](https://github.com/user-attachments/assets/24e8491c-5f5b-47cc-900f-ba9acebd113b)

![image](https://github.com/user-attachments/assets/e48e6349-5917-4164-a91a-c92f7edc3cf0)
