### PR TITLE
431 always pronounce the word in an exercise

### DIFF
--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -35,6 +35,7 @@ const LocalStorage = {
     clickedVideoLink: "clicked_video_link",
     DoNotShowRedirectionModal: "do_not_show_redirection_modal",
     ProductiveExercisesEnabled: "productiveExercisesEnabled",
+    AutoPronounceBookmarkExercise: "auto_pronounce_bookmark_exercise",
   },
 
   userInfo: function () {
@@ -173,6 +174,16 @@ const LocalStorage = {
     }
   },
 
+  getAutoPronounceBookmarkExercise: function () {
+    const autoPronounceBookmarkExercise =
+      localStorage[this.Keys.AutoPronounceBookmarkExercise];
+    if (autoPronounceBookmarkExercise === undefined) {
+      return undefined;
+    } else {
+      return autoPronounceBookmarkExercise;
+    }
+  },
+
   hasFeature: function (featureName) {
     try {
       return JSON.parse(localStorage[this.Keys.Features]).includes(featureName);
@@ -271,6 +282,11 @@ const LocalStorage = {
   ) {
     localStorage[this.Keys.DisplayedAudioExperimentQuestionnaire] =
       displayedAudioExperimentQuestionnaire;
+  },
+
+  setAutoPronounceBookmarkExercise: function (AutoPronounceBookmarkExercise) {
+    localStorage[this.Keys.AutoPronounceBookmarkExercise] =
+      AutoPronounceBookmarkExercise;
   },
 
   getTargetNoOfAudioSessions: function () {

--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -32,3 +32,15 @@ export const LEARNING_CYCLE_NAME = Object.freeze({
   1: "receptive",
   2: "productive",
 });
+
+export const PRONOUNCIATION_SETTING = Object.freeze({
+  off: 0,
+  sessionOnly: 1,
+  always: 2,
+});
+
+export const PRONOUNCIATION_SETTING_NAME = Object.freeze({
+  0: "Off",
+  1: "Session Only",
+  2: "Always",
+});

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -30,6 +30,8 @@ import useActivityTimer from "../hooks/useActivityTimer";
 import ActivityTimer from "../components/ActivityTimer";
 import { ExerciseCountContext } from "../exercises/ExerciseCountContext";
 import useShadowRef from "../hooks/useShadowRef";
+import LocalStorage from "../assorted/LocalStorage";
+import { PRONOUNCIATION_SETTING } from "./ExerciseTypeConstants";
 
 const BOOKMARKS_DUE_REVIEW = false;
 const NEW_BOOKMARKS_TO_STUDY = true;
@@ -94,6 +96,15 @@ export default function Exercises({
       setActivityOver(true);
       exerciseNotification.unsetExerciseCounter();
       exerciseNotification.updateReactState();
+      let currentAutoPronounce =
+        LocalStorage.getAutoPronounceBookmarkExercise();
+      if (
+        currentAutoPronounce &&
+        currentAutoPronounce === PRONOUNCIATION_SETTING.sessionOnly
+      )
+        LocalStorage.setAutoPronounceBookmarkExercise(
+          PRONOUNCIATION_SETTING.off,
+        );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/exercises/Exercises.sc.js
+++ b/src/exercises/Exercises.sc.js
@@ -11,6 +11,7 @@ const ExercisesColumn = styled.div`
 `;
 
 const ExForm = styled.div`
+  position: relative;
   margin: auto;
   background-color: rgba(241, 240, 240, 0.274);
 

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -4,16 +4,22 @@ import EditBookmarkButton from "../../words/EditBookmarkButton";
 import * as s from "./Exercise.sc";
 import SolutionFeedbackLinks from "./SolutionFeedbackLinks";
 import { random } from "../../utils/basic/arrays";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import Confetti from "react-confetti";
 import SessionStorage from "../../assorted/SessionStorage.js";
-import { EXERCISE_TYPES } from "../ExerciseTypeConstants";
+import { SpeechContext } from "../../contexts/SpeechContext.js";
+import {
+  EXERCISE_TYPES,
+  PRONOUNCIATION_SETTING,
+} from "../ExerciseTypeConstants";
 
 import CelebrationModal from "../CelebrationModal";
 import { getStaticPath } from "../../utils/misc/staticPath.js";
 
 import Feature from "../../features/Feature";
 import { ExerciseValidation } from "../ExerciseValidation.js";
+import LocalStorage from "../../assorted/LocalStorage.js";
+import useBookmarkAutoPronounce from "../../hooks/useBookmarkAutoPronounce.js";
 
 export default function NextNavigation({
   message,
@@ -33,10 +39,6 @@ export default function NextNavigation({
     strings.correctExercise2,
     strings.correctExercise3,
   ];
-  const solutionStrings = [
-    strings.solutionExercise1,
-    strings.solutionExercise2,
-  ];
 
   const exercise = "exercise";
   const [userIsCorrect, setUserIsCorrect] = useState(false);
@@ -44,9 +46,12 @@ export default function NextNavigation({
   const [learningCycle, setLearningCycle] = useState(null);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
-
+  const [autoPronounceState, autoPronounceString, toggleAutoPronounceValue] =
+    useBookmarkAutoPronounce();
+  const speech = useContext(SpeechContext);
+  const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
   const productiveExercisesDisabled =
-    localStorage.getItem("productiveExercisesEnabled") === "false";
+    LocalStorage.getProductiveExercisesEnabled() === "false";
   const isLastInCycle = exerciseBookmark.is_last_in_cycle;
   const isLearningCycleOne = learningCycle === 1;
   const isLearningCycleTwo = learningCycle === 2;
@@ -71,6 +76,18 @@ export default function NextNavigation({
     (!isMatchExercise || (isMatchExercise && isCorrectMatch)) &&
     !productiveExercisesDisabled &&
     learningCycleFeature;
+
+  async function handleSpeak() {
+    await speech.speakOut(exerciseBookmark.from, setIsButtonSpeaking);
+  }
+  useEffect(() => {
+    if (
+      isCorrect &&
+      autoPronounceState &&
+      autoPronounceState !== PRONOUNCIATION_SETTING.off
+    )
+      handleSpeak();
+  }, [isCorrect]);
 
   useEffect(() => {
     if (exerciseBookmark && "learning_cycle" in exerciseBookmark) {
@@ -164,27 +181,41 @@ export default function NextNavigation({
           </div>
         ))}
       {isCorrect && !isMultiExerciseType && (
-        <s.BottomRowSmallTopMargin className="bottomRow">
-          <s.EditSpeakButtonHolder>
-            <SpeakButton
-              bookmarkToStudy={exerciseBookmark}
-              api={api}
-              style="next"
-              isReadContext={isReadContext}
-            />
-            <EditBookmarkButton
-              bookmark={exerciseBookmark}
-              api={api}
-              styling={exercise}
-              reload={reload}
-              setReload={setReload}
-              notifyDelete={() => setIsDeleted(true)}
-            />
-          </s.EditSpeakButtonHolder>
-          <s.FeedbackButton onClick={(e) => moveToNextExercise()} autoFocus>
-            {strings.next}
-          </s.FeedbackButton>
-        </s.BottomRowSmallTopMargin>
+        <>
+          <s.BottomRowSmallTopMargin className="bottomRow">
+            <s.EditSpeakButtonHolder>
+              <SpeakButton
+                bookmarkToStudy={exerciseBookmark}
+                api={api}
+                style="next"
+                isReadContext={isReadContext}
+                parentIsSpeakingControl={isButtonSpeaking}
+              />
+              <EditBookmarkButton
+                bookmark={exerciseBookmark}
+                api={api}
+                styling={exercise}
+                reload={reload}
+                setReload={setReload}
+                notifyDelete={() => setIsDeleted(true)}
+              />
+            </s.EditSpeakButtonHolder>
+            <s.FeedbackButton onClick={(e) => moveToNextExercise()} autoFocus>
+              {strings.next}
+            </s.FeedbackButton>
+          </s.BottomRowSmallTopMargin>
+          <s.StyledGreyButton
+            onClick={toggleAutoPronounceValue}
+            style={{
+              position: "relative",
+              bottom: "3em",
+              left: "2em",
+              textAlign: "start",
+            }}
+          >
+            {"Auto-Pronounce: " + autoPronounceString}
+          </s.StyledGreyButton>
+        </>
       )}
       {isCorrect && isMultiExerciseType && (
         <s.BottomRowSmallTopMargin className="bottomRow">
@@ -193,6 +224,7 @@ export default function NextNavigation({
           </s.FeedbackButton>
         </s.BottomRowSmallTopMargin>
       )}
+
       <SolutionFeedbackLinks
         handleShowSolution={handleShowSolution}
         toggleShow={toggleShow}

--- a/src/hooks/useBookmarkAutoPronounce.js
+++ b/src/hooks/useBookmarkAutoPronounce.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+import LocalStorage from "../assorted/LocalStorage";
+import {
+  PRONOUNCIATION_SETTING,
+  PRONOUNCIATION_SETTING_NAME,
+} from "../exercises/ExerciseTypeConstants";
+
+export default function useBookmarkAutoPronounce() {
+  const [currentPronouncingState, setCurrentPronouncingState] = useState();
+  const [currentPronouncingString, setCurrentPronouncingString] = useState();
+  const MAX_AVAILABLE_SETTING = Math.max(
+    ...Object.values(PRONOUNCIATION_SETTING),
+  );
+
+  function __updateState(value) {
+    setCurrentPronouncingState(value);
+    setCurrentPronouncingString(PRONOUNCIATION_SETTING_NAME[value]);
+  }
+  useEffect(() => {
+    let currentState = Number(LocalStorage.getAutoPronounceBookmarkExercise());
+    if (currentState === undefined) currentState = PRONOUNCIATION_SETTING.off;
+    __updateState(currentState);
+  });
+
+  function cyclePronounciationState() {
+    let optionSelected;
+    if (currentPronouncingState < MAX_AVAILABLE_SETTING) {
+      optionSelected = currentPronouncingState + 1;
+    } else optionSelected = PRONOUNCIATION_SETTING.off;
+    __updateState(optionSelected);
+    LocalStorage.setAutoPronounceBookmarkExercise(optionSelected);
+  }
+
+  return [
+    currentPronouncingState,
+    currentPronouncingString,
+    cyclePronounciationState,
+  ];
+}


### PR DESCRIPTION
- Added a new setting in the LocalStorage to keep track of the user preference.
- Added a Hook which allows to toggle the state of the auto-pronouncing feature.
- NextNavigation now has a small text under the audio button that allow to toggle to auto-pronounce words.
- There are 3 options:
  - **Off**: No auto-pronouncing
  - **Session Only**: Lasts until the user leaves the Exercise session. This is handled by unsetting the setting when leaving the exercise component.
  - **Always**: Will auto-pronounce until user unsets it again or logs into a different device (stored in local storage).

| Desktop | Mobile |
|-|-|
| ![image](https://github.com/user-attachments/assets/015a4ed7-49b7-441b-b0d3-17d115459843) | ![image](https://github.com/user-attachments/assets/cbcf3c40-8669-4b00-ad2b-801b767a9fb9) |