### PR TITLE
424 choose alternative not removing the actual alternative from the text

### DIFF
--- a/src/utils/preprocessing/preprocessing.js
+++ b/src/utils/preprocessing/preprocessing.js
@@ -13,4 +13,10 @@ function tokenize(sentence) {
   return sentence.split(" ");
 }
 
-export { tokenize, removePunctuation };
+function isWordInSentence(word, sentence) {
+  let tokens = tokenize(removePunctuation(sentence));
+  console.log(tokens);
+  return tokens.includes(word);
+}
+
+export { tokenize, removePunctuation, isWordInSentence };

--- a/src/utils/preprocessing/preprocessing.js
+++ b/src/utils/preprocessing/preprocessing.js
@@ -15,7 +15,6 @@ function tokenize(sentence) {
 
 function isWordInSentence(word, sentence) {
   let tokens = tokenize(removePunctuation(sentence));
-  console.log(tokens);
   return tokens.includes(word);
 }
 

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -81,7 +81,8 @@ export default function EditBookmarkButton({
       setErrorMessage(
         `'${newWord}' is not present in the context. Make sure the context contains the word.`,
       );
-      toast.error("The Word is not present in the context.");
+      // Uncomment to also send a toast
+      // toast.error("The Word is not present in the context.");
       return;
     }
 

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -65,7 +65,6 @@ export default function WordEditForm({
       handleClose();
     } else {
       updateBookmark(bookmark, expression, translation, context, fitForStudy);
-      prepClose();
     }
   }
   return (

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -4,9 +4,11 @@ import strings from "../i18n/definitions";
 import { useState } from "react";
 import { MAX_WORDS_IN_BOOKMARK_FOR_EXERCISES } from "../exercises/ExerciseConstants";
 import isBookmarkExpression from "../utils/misc/isBookmarkExpression";
+import FullWidthErrorMsg from "../pages/info_page_shared/FullWidthErrorMsg";
 
 export default function WordEditForm({
   bookmark,
+  errorMessage,
   handleClose,
   updateBookmark,
   deleteAction,
@@ -27,7 +29,6 @@ export default function WordEditForm({
     setExpression(bookmark.from);
     setContext(bookmark.context);
     setFitForStudy(bookmark.fit_for_study);
-    handleClose();
   }
   function handleFitForStudyCheck() {
     setFitForStudy((state) => !state);
@@ -45,6 +46,7 @@ export default function WordEditForm({
   }
 
   function handleSubmit(event) {
+    event.preventDefault();
     if (translation === "" || expression === "" || context === "") {
       if (translation === "") {
         setTranslation(bookmark.to);
@@ -60,6 +62,7 @@ export default function WordEditForm({
       }
     } else if (isNotEdited) {
       prepClose();
+      handleClose();
     } else {
       updateBookmark(bookmark, expression, translation, context, fitForStudy);
       prepClose();
@@ -73,6 +76,7 @@ export default function WordEditForm({
         <s.Headline>{strings.editWord}</s.Headline>
       )}
       <form onSubmit={handleSubmit}>
+        {errorMessage && <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>}
         {isBookmarkExpression(bookmark) ? (
           <s.CustomTextField
             id="outlined-basic"


### PR DESCRIPTION
- Added utility function to test if token is part of a sentence.
- Editing the Word could result in word not being present in the context. This would cause situations where in Exercises where the word has to be hidden wouldn't occur.
- With this change the user is warned if the word is not present in the context, but they have to change the word themselves in the context.

![image](https://github.com/user-attachments/assets/b3c08a7b-c5c8-423a-b115-606ae6b183f1)

