### PR TITLE
442 when in only pronounciation mode we should still underline the word even if its not translated

### DIFF
--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -14,6 +14,7 @@ export default function TranslatableWord({
 }) {
   const [showingAlterMenu, setShowingAlterMenu] = useState(false);
   const [refToTranslation, clickedOutsideTranslation] = useClickOutside();
+  const [isClickToPronounce, setIsClickToPronounce] = useState(false);
 
   function clickOnWord(e, word) {
     if (word.translation) {
@@ -32,7 +33,8 @@ export default function TranslatableWord({
         setTranslatedWords(copyOfWords);
       }
     }
-    if (pronouncing) {
+    if (pronouncing || isClickToPronounce) {
+      setIsClickToPronounce(true);
       interactiveText.pronounce(word);
     }
   }
@@ -72,7 +74,7 @@ export default function TranslatableWord({
   }
 
   //disableTranslation so user cannot translate words that are being tested
-  if (!word.translation || disableTranslation) {
+  if ((!word.translation && !isClickToPronounce) || disableTranslation) {
     return (
       <>
         <z-tag onClick={(e) => clickOnWord(e, word)}>{word.word + " "}</z-tag>
@@ -82,15 +84,16 @@ export default function TranslatableWord({
   return (
     <>
       <z-tag>
-        <z-tran
-          chosen={word.translation}
-          translation0={word.translation}
-          ref={refToTranslation}
-          onClick={(e) => toggleAlterMenu(e, word)}
-        >
-          <span className="arrow">▼</span>
-        </z-tran>
-
+        {word.translation && (
+          <z-tran
+            chosen={word.translation}
+            translation0={word.translation}
+            ref={refToTranslation}
+            onClick={(e) => toggleAlterMenu(e, word)}
+          >
+            <span className="arrow">▼</span>
+          </z-tran>
+        )}
         <z-orig>
           <span onClick={(e) => clickOnWord(e, word)}>{word.word} </span>
           {showingAlterMenu && (

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -14,7 +14,7 @@ export default function TranslatableWord({
 }) {
   const [showingAlterMenu, setShowingAlterMenu] = useState(false);
   const [refToTranslation, clickedOutsideTranslation] = useClickOutside();
-  const [isClickToPronounce, setIsClickToPronounce] = useState(false);
+  const [isClickedToPronounce, setIsClickedToPronounce] = useState(false);
 
   function clickOnWord(e, word) {
     if (word.translation) {
@@ -33,8 +33,8 @@ export default function TranslatableWord({
         setTranslatedWords(copyOfWords);
       }
     }
-    if (pronouncing || isClickToPronounce) {
-      setIsClickToPronounce(true);
+    if (pronouncing || isClickedToPronounce) {
+      setIsClickedToPronounce(true);
       interactiveText.pronounce(word);
     }
   }
@@ -67,14 +67,13 @@ export default function TranslatableWord({
   }
 
   function hideTranslation(e, word) {
-    console.log(word);
     word.translation = undefined;
     word.splitIntoComponents();
     wordUpdated();
   }
 
   //disableTranslation so user cannot translate words that are being tested
-  if ((!word.translation && !isClickToPronounce) || disableTranslation) {
+  if ((!word.translation && !isClickedToPronounce) || disableTranslation) {
     return (
       <>
         <z-tag onClick={(e) => clickOnWord(e, word)}>{word.word + " "}</z-tag>


### PR DESCRIPTION
Words that have been pronounced change CSS to represent that they can be clicked again:

![image](https://github.com/user-attachments/assets/398681c3-1d72-4cdc-a59c-51ad46bf2882)

Enabling the translation will still retrieve the translation and show it:

![image](https://github.com/user-attachments/assets/8a37f43b-f8c4-4056-8670-8b4b5f17ddcc)


