### PR TITLE
Reduced space in Match Exercise to make it more compact

### DIFF
--- a/src/exercises/exerciseTypes/Exercise.sc.js
+++ b/src/exercises/exerciseTypes/Exercise.sc.js
@@ -202,8 +202,8 @@ let MatchSpeakButtonHolder = styled.div`
 
 let MatchButton = styled(StyledButton)`
   width: fit-content;
-  margin-top: 2em;
-  margin-bottom: 2em;
+  margin-top: 1.5em;
+  margin-bottom: 1em;
   background: #ffd04799;
   color: black;
   border: 0.125em solid ${zeeguuTransparentLightOrange};
@@ -218,8 +218,8 @@ let MatchButton = styled(StyledButton)`
 `;
 
 let MatchingWords = styled.p`
-  margin-top: 2.125em;
-  margin-bottom: 2.125em;
+  margin-top: 1.6em;
+  margin-bottom: 1.1em;
   padding-top: 0.5em;
   padding-bottom: 0.5em;
   padding-left: 0.5em;


### PR DESCRIPTION
Made Match exercise more compact to save space for smaller screens:

| Desktop | Mobile |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/216a4f59-a9a3-4397-b532-8f9e5ac4c805) | ![image](https://github.com/user-attachments/assets/6d4b53d0-c057-4ef1-b017-50a3dcc38a5f) | 
| ![image](https://github.com/user-attachments/assets/0cd70f46-bcbb-4260-bfce-53b2be498b8b) | ![image](https://github.com/user-attachments/assets/eb02f738-3180-453b-9409-70e53e9a8abd) |