### PR TITLE
446 new tag should be attached to word not exercise in match

### DIFF
--- a/src/components/NotificationIcon.js
+++ b/src/components/NotificationIcon.js
@@ -1,11 +1,19 @@
 import * as s from "./NotificationIcon.sc";
 import React from "react";
+import { Tooltip } from "@mui/material";
 
-export default function NotificationIcon({ text, position, style }) {
+export default function NotificationIcon({
+  text,
+  position,
+  style,
+  tooltipText,
+}) {
   const notificationLocation = position ? position : "top";
   return (
     <s.NotificationIcon className={notificationLocation} style={style}>
-      <div>{text}</div>
+      <Tooltip title={tooltipText}>
+        <div>{text}</div>
+      </Tooltip>
     </s.NotificationIcon>
   );
 }

--- a/src/exercises/LearningCycleIndicator.js
+++ b/src/exercises/LearningCycleIndicator.js
@@ -64,21 +64,30 @@ export default function LearningCycleIndicator({ bookmark, message }) {
     <>
       {Feature.merle_exercises() && (
         <div className="learningCycleIndicator">
-          <Tooltip title={getTooltipContent()}>
-            <div className="learningCycleIcon">
+          <div className="learningCycleIcon">
+            <Tooltip title={getTooltipContent()}>
               <img
                 src={APP_DOMAIN + getLearningCycleIcon()}
                 alt={`${LEARNING_CYCLE_NAME[learningCycle]}-icon`}
                 style={{ height: "2.5em", width: "2.5em" }}
               />
-              {coolingInterval === null && (
-                <NotificationIcon
-                  style={{ marginRight: "-2.2em", top: "-2em", left: "-0.8em" }}
-                  text={"New!"}
-                ></NotificationIcon>
-              )}
-            </div>
-          </Tooltip>
+            </Tooltip>
+            {coolingInterval === null && (
+              <NotificationIcon
+                style={{
+                  marginRight: "-2.2em",
+                  top: "-2em",
+                  left: "-0.8em",
+                }}
+                text={"New!"}
+                tooltipText={
+                  bookmark.from.split(" ").length > 1
+                    ? strings.newExpressionExercisesTooltip
+                    : strings.newWordExercisesTooltip
+                }
+              ></NotificationIcon>
+            )}
+          </div>
 
           <div className="cooling-bars">
             {[...Array(5)].map((_, index) => {

--- a/src/exercises/LearningCycleIndicator.js
+++ b/src/exercises/LearningCycleIndicator.js
@@ -8,6 +8,7 @@ import { ExerciseValidation } from "./ExerciseValidation";
 import { LEARNING_CYCLE_NAME } from "./ExerciseTypeConstants";
 import { APP_DOMAIN } from "../appConstants.js";
 import NotificationIcon from "../components/NotificationIcon";
+import isBookmarkExpression from "../utils/misc/isBookmarkExpression.js";
 
 export default function LearningCycleIndicator({ bookmark, message }) {
   const [userIsCorrect, setUserIsCorrect] = useState(false);
@@ -81,7 +82,7 @@ export default function LearningCycleIndicator({ bookmark, message }) {
                 }}
                 text={"New!"}
                 tooltipText={
-                  bookmark.from.split(" ").length > 1
+                  isBookmarkExpression(bookmark)
                     ? strings.newExpressionExercisesTooltip
                     : strings.newWordExercisesTooltip
                 }

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -67,7 +67,7 @@ export default function Match({
   );
   const [isPronouncing, setIsPronouncing] = useState(false);
   const [lastCorrectBookmarkId, setLastCorrectBookmarkId] = useState(null);
-  const [selectedBookmark, setSelectedBookmark] = useState(bookmarksToStudy[0]);
+  const [selectedBookmark, setSelectedBookmark] = useState();
   const [selectedBookmarkMessage, setSelectedBookmarkMessage] = useState("");
 
   useEffect(() => {
@@ -200,10 +200,12 @@ export default function Match({
       <div className="headlineWithMoreSpace">
         {strings.matchWordWithTranslation}{" "}
       </div>
-      <LearningCycleIndicator
-        bookmark={selectedBookmark}
-        message={selectedBookmarkMessage}
-      />
+      {selectedBookmark && (
+        <LearningCycleIndicator
+          bookmark={selectedBookmark}
+          message={selectedBookmarkMessage}
+        />
+      )}
 
       <MatchInput
         fromButtonOptions={fromButtonOptions}

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -405,6 +405,9 @@ let strings = new LocalizedStrings(
       correctExercise3: "Good job!",
       solutionExercise1: "Check the solution!",
       solutionExercise2: "See the solution above!",
+      newWordExercisesTooltip: "This is the first time you practice this word!",
+      newExpressionExercisesTooltip:
+        "This is the first time you practice this expression!",
       //LearnedWordsList
       studentHasNotLearnedWords: "The student has not learned any words yet.",
 


### PR DESCRIPTION
Match will now only show the progress if one of the bookmarks has been selected. Before, it was assumed the first bookmark would be used:

![image](https://github.com/user-attachments/assets/e86eb9ce-6b60-45ee-a04a-55dd17d4ff9e)

![image](https://github.com/user-attachments/assets/73132b1f-1fb8-43df-b0d4-1efa34f52bdb)

New! has a tooltip for itself now, adapts to Word / Expression, though not using a util function that is included in https://github.com/zeeguu/web/pull/441, once that is merged it should be updated.

![image](https://github.com/user-attachments/assets/16ce1648-e4bd-40f8-aaa3-55622403f9f8)

![image](https://github.com/user-attachments/assets/28901f40-9078-4c4a-9745-ec1dafb3ea08)

