### PR TITLE
Fixed users being able to highlight text in the delete button.

### DIFF
--- a/src/exercises/bottomActions/FeedbackButtons.sc.js
+++ b/src/exercises/bottomActions/FeedbackButtons.sc.js
@@ -109,7 +109,7 @@ const FeedbackCancel = styled(FeedbackSubmit)`
 const FeedbackDelete = styled(FeedbackSubmit)`
   margin-left: 1em;
   margin-top: 1em;
-  max-width: 100px;
+  max-width: 200px;
   text-align: center;
   background-color: white;
   border: 0.1em solid ${zeeguuDarkRed};

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -130,6 +130,7 @@ export default function WordEditForm({
         {isNotEdited ? (
           <s.DoneButtonHolder>
             <st.FeedbackDelete
+              type="button"
               onClick={() => deleteAction(bookmark)}
               value={strings.deleteWord}
             />


### PR DESCRIPTION
It seems this was caused because I didn't define the type for the DeleteButton, as it was extended from a input component. 

I am unable to select text anymore, so it should be fixed. I haven't tried it on the phone, but using the browser Phone view it also seems to work there.