### PR TITLE
changes the headline in multiple choice context to native language

### DIFF
--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -39,6 +39,9 @@ export default function MultipleChoiceContext({
   const [clickedIndex, setClickedIndex] = useState(null);
   const [clickedOption, setClickedOption] = useState(null);
   const [showSolution, setShowSolution] = useState(false);
+  const [wordInContextHeadline, setWordInContextHeadline] = useState(
+    removePunctuation(bookmarksToStudy[0].from),
+  );
 
   useEffect(() => {
     setExerciseType(EXERCISE_TYPE);
@@ -84,6 +87,7 @@ export default function MultipleChoiceContext({
       setClickedIndex(index);
       notifyCorrectAnswer(bookmarksToStudy[0]);
       setIsCorrect(true);
+      setWordInContextHeadline(removePunctuation(bookmarksToStudy[0].to));
       let concatMessage = messageToAPI + "C";
       handleAnswer(concatMessage);
     } else {
@@ -126,9 +130,7 @@ export default function MultipleChoiceContext({
         bookmark={bookmarksToStudy[0]}
         message={messageToAPI}
       />
-      <h1 className="wordInContextHeadline">
-        {removePunctuation(bookmarksToStudy[0].from)}
-      </h1>
+      <h1 className="wordInContextHeadline">{wordInContextHeadline}</h1>
       {exerciseBookmarks.map((option, index) => (
         <s.MultipleChoiceContext
           key={index}


### PR DESCRIPTION
This pull request contains a change in the multiple choice context exercise that changes the headline to the native language when the user chooses the correct answer.

<img width="398" alt="Screenshot 2024-08-12 at 20 35 39" src="https://github.com/user-attachments/assets/a764d4d8-d84e-4fab-a5d0-4b556b0a5ba2">
