### PR TITLE
Fixed check if word is in Context

### DIFF
--- a/src/utils/preprocessing/preprocessing.js
+++ b/src/utils/preprocessing/preprocessing.js
@@ -14,8 +14,9 @@ function tokenize(sentence) {
 }
 
 function isWordInSentence(word, sentence) {
-  let tokens = tokenize(removePunctuation(sentence));
-  return tokens.includes(word);
+  let tokens = tokenize(sentence);
+  tokens = tokens.map((each) => removePunctuation(each));
+  return tokens.includes(removePunctuation(word));
 }
 
 export { tokenize, removePunctuation, isWordInSentence };


### PR DESCRIPTION
Reported by Merle:

![image](https://github.com/user-attachments/assets/439096eb-129b-4115-9baf-556cf3ec6486)

The removing punctuation was working at sentence level rather than token level, resulting in punctuation being present when comparing the Word token to the sentence tokens.
