### PR TITLE
BUG: Fixed Match reporting words to productive on exercise correct

### DIFF
--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -33,6 +33,12 @@ export const LEARNING_CYCLE_NAME = Object.freeze({
   2: "productive",
 });
 
+export const LEARNING_CYCLE = Object.freeze({
+  ["NOT_SET"]: 0,
+  ["RECEPTIVE"]: 1,
+  ["PRODUCTIVE"]: 2,
+});
+
 export const PRONOUNCIATION_SETTING = Object.freeze({
   off: 0,
   on: 1,

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -223,18 +223,17 @@ export default function NextNavigation({
           )}
         </>
       )}
-      {isExerciseCorrect &&
-        !(bookmarkLearned || bookmarkProgression || bookmarkLearned) && (
-          <div className="next-nav-feedback">
-            <img
-              src={getStaticPath("icons", "zeeguu-icon-correct.png")}
-              alt="Correct Icon"
-            />
-            <p>
-              <b>{correctMessage}</b>
-            </p>
-          </div>
-        )}
+      {isExerciseCorrect && !(bookmarkLearned || bookmarkProgression) && (
+        <div className="next-nav-feedback">
+          <img
+            src={getStaticPath("icons", "zeeguu-icon-correct.png")}
+            alt="Correct Icon"
+          />
+          <p>
+            <b>{correctMessage}</b>
+          </p>
+        </div>
+      )}
       {isCorrect && !isMultiExerciseType && (
         <>
           <s.BottomRowSmallTopMargin className="bottomRow">

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -54,6 +54,7 @@ export default function NextNavigation({
   const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
   const [matchExerciseProgressionMessage, setMatchExercisesProgressionMessage] =
     useState();
+  const [matchWordsProgressCount, setMatchWordsProgressCount] = useState(0);
   const [isMatchBookmarkProgression, setIsMatchBookmarkProgression] =
     useState(false);
   const productiveExercisesDisabled =
@@ -111,6 +112,7 @@ export default function NextNavigation({
       setMatchExercisesProgressionMessage(
         "'" + wordsProgressed.join("', '") + "'",
       );
+      setMatchWordsProgressCount(wordsProgressed.length);
     }
   }, [isCorrect, exerciseAttemptsLog]);
 
@@ -159,7 +161,7 @@ export default function NextNavigation({
           />
         </>
       )}
-      {isCorrectMatch && isMatchExercise && isMatchBookmarkProgression && (
+      {isCorrect && isMatchExercise && isMatchBookmarkProgression && (
         <>
           <Confetti
             width={window.innerWidth}
@@ -176,7 +178,8 @@ export default function NextNavigation({
             />
             <p>
               <b>
-                {`${matchExerciseProgressionMessage}`} have now moved to your
+                {`${matchExerciseProgressionMessage}`}{" "}
+                {matchWordsProgressCount > 1 ? "have" : "has"} now moved to your
                 productive knowledge.
               </b>
             </p>


### PR DESCRIPTION
Merle spotted a bug where the Match was showing that words progressed to Productive knowledge with an empty string.

The Bug was that since I moved the logic of Match to be it's own thing, it wasn't checking that bookmarks had progressed to show that message. I added new states that track if there is any word that progresses in the match exercise.

Bug image:
| Bug | Fix |
| ---- | --- |
| ![image](https://github.com/user-attachments/assets/9238518b-d344-4650-8c98-2d67c7b071a5)   | ![image](https://github.com/user-attachments/assets/73279eeb-1ad3-4bbe-90b8-0f37aa8116c9) |

**Bonus: ** I hadn't considered this, but we can have situations where 1 word progresses and the other 2 don't (are wrong), so in that case we should still show the message that one word has progressed:

![image](https://github.com/user-attachments/assets/a2f908fc-05ca-4aa8-a580-efa01ca891e1)
