### PR TITLE
Allow hiding the learningCycleIndicator

### DIFF
--- a/src/exercises/LearningCycleIndicator.js
+++ b/src/exercises/LearningCycleIndicator.js
@@ -10,7 +10,11 @@ import { APP_DOMAIN } from "../appConstants.js";
 import NotificationIcon from "../components/NotificationIcon";
 import isBookmarkExpression from "../utils/misc/isBookmarkExpression.js";
 
-export default function LearningCycleIndicator({ bookmark, message }) {
+export default function LearningCycleIndicator({
+  bookmark,
+  message,
+  isHidden,
+}) {
   const [userIsCorrect, setUserIsCorrect] = useState(false);
   const [userIsWrong, setUserIsWrong] = useState(false);
 
@@ -64,7 +68,10 @@ export default function LearningCycleIndicator({ bookmark, message }) {
   return (
     <>
       {Feature.merle_exercises() && (
-        <div className="learningCycleIndicator">
+        <div
+          className="learningCycleIndicator"
+          style={{ visibility: isHidden ? "hidden" : "visible" }}
+        >
           <div className="learningCycleIcon">
             <Tooltip title={getTooltipContent()}>
               <img

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -205,12 +205,12 @@ export default function Match({
       <div className="headlineWithMoreSpace">
         {strings.matchWordWithTranslation}{" "}
       </div>
-      {selectedBookmark && (
-        <LearningCycleIndicator
-          bookmark={selectedBookmark}
-          message={selectedBookmarkMessage}
-        />
-      )}
+
+      <LearningCycleIndicator
+        bookmark={selectedBookmark ? selectedBookmark : bookmarksToStudy[0]}
+        message={selectedBookmarkMessage}
+        isHidden={selectedBookmark === undefined}
+      />
 
       <MatchInput
         fromButtonOptions={fromButtonOptions}


### PR DESCRIPTION
Allows hidding the learningCycleIndicator, a placeholder bookmark still needs to be passed, but a boolean can be used to control the visibility of the component. 

![image](https://github.com/user-attachments/assets/53f87c22-5c73-42b6-9ed4-0e856b4daf63)

We can consider a "disabled" visual component for the LearningCycleIndicator later on. 