### PR TITLE
New exercise assignment based on recognition/recall

### DIFF
--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -33,6 +33,12 @@ export const LEARNING_CYCLE_NAME = Object.freeze({
   2: "productive",
 });
 
+export const LEARNING_CYCLE = Object.freeze({
+  ["NOT_SET"]: 0,
+  ["RECEPTIVE"]: 1,
+  ["PRODUCTIVE"]: 2,
+});
+
 export const PRONOUNCIATION_SETTING = Object.freeze({
   off: 0,
   on: 1,

--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -39,6 +39,11 @@ export const LEARNING_CYCLE = Object.freeze({
   ["PRODUCTIVE"]: 2,
 });
 
+export const MEMORY_TASK = Object.freeze({
+  RECALL: "recall",
+  RECOGNITION: "recognition",
+});
+
 export const PRONOUNCIATION_SETTING = Object.freeze({
   off: 0,
   on: 1,

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -23,10 +23,12 @@ function getExerciseListByLearningCycle(exerciseList) {
 }
 
 function getMemoryTask(bookmark) {
-  return bookmark.consecutive_correct_answers >= 2 &&
-    bookmark.cooling_interval >= 2
-    ? MEMORY_TASK.RECALL
-    : MEMORY_TASK.RECOGNITION;
+  let memoryTask =
+    bookmark.consecutive_correct_answers >= 2 && bookmark.cooling_interval >= 2
+      ? MEMORY_TASK.RECALL
+      : MEMORY_TASK.RECOGNITION;
+
+  return memoryTask;
 }
 
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -3,7 +3,7 @@ import {
   LEARNING_CYCLE_SEQUENCE,
   LEARNING_CYCLE_SEQUENCE_NO_AUDIO,
 } from "./exerciseSequenceTypes";
-import { LEARNING_CYCLE_NAME } from "./ExerciseTypeConstants";
+import { LEARNING_CYCLE_NAME, MEMORY_TASK } from "./ExerciseTypeConstants";
 
 /**
  * The bookmarks fetched by the API are assigned to the various exercises in the defined exercise session --
@@ -22,7 +22,13 @@ function getExerciseListByLearningCycle(exerciseList) {
   return exerciseByLearningCycle;
 }
 
-// It is important that there are exercises requiring only one bookmark for each cateogry (i.e. receptive/productive learning cycle and recall/recognition cognitive focus)
+function getMemoryTask(bookmark) {
+  return bookmark.consecutive_correct_answers >= 2 &&
+    bookmark.cooling_interval >= 2
+    ? MEMORY_TASK.RECALL
+    : MEMORY_TASK.RECOGNITION;
+}
+
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
   function _removeExerciseFromList(exercise, list) {
     return list.filter((ex) => ex !== exercise);
@@ -42,17 +48,13 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
     getExerciseListByLearningCycle(exerciseTypesList);
 
   for (let i = 0; i < bookmarks.length; i++) {
-    let cognitiveFocus =
-      bookmarks[i].consecutive_correct_answers >= 2 &&
-      bookmarks[i].cooling_interval >= 2
-        ? "recall"
-        : "recognition";
+    let memoryTask = getMemoryTask(bookmarks[i]);
     // Filter the exercises based on the learning_cycle attribute of the bookmark
     let learningCycle = LEARNING_CYCLE_NAME[bookmarks[i].learning_cycle];
     let exerciseListForCycle = exercisesByLearningCycle[learningCycle];
 
     let suitableExercises = exerciseListForCycle.filter(
-      (exercise) => exercise.cognitiveFocus === cognitiveFocus,
+      (exercise) => exercise.memoryTask === memoryTask,
     );
 
     let suitableExerciseFound = false;

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -47,7 +47,6 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
       bookmarks[i].cooling_interval >= 2
         ? "recall"
         : "recognition";
-
     // Filter the exercises based on the learning_cycle attribute of the bookmark
     let learningCycle = LEARNING_CYCLE_NAME[bookmarks[i].learning_cycle];
     let exerciseListForCycle = exercisesByLearningCycle[learningCycle];
@@ -56,13 +55,9 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
       (exercise) => exercise.cognitiveFocus === cognitiveFocus,
     );
 
-    console.log(suitableExercises);
-    console.log(bookmarks[i]);
-
     let suitableExerciseFound = false;
     while (!suitableExerciseFound) {
       let selectedExerciseType = random(suitableExercises);
-
       // Check if there are enough bookmarks for the selected exercise
       if (i + selectedExerciseType.requiredBookmarks <= bookmarks.length) {
         let potentialBookmarks = bookmarks.slice(
@@ -85,10 +80,14 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
         }
       }
       if (!suitableExerciseFound) {
-        exerciseListForCycle = _removeExerciseFromList(
+        suitableExercises = _removeExerciseFromList(
           selectedExerciseType,
-          exerciseListForCycle,
+          suitableExercises,
         );
+        // Fallback to default sequence if no suitable exercises are found
+        if (suitableExercises.length === 0) {
+          return assignBookmarksToDefaultSequence(bookmarks, exerciseTypesList);
+        }
       }
     }
   }

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -22,6 +22,7 @@ function getExerciseListByLearningCycle(exerciseList) {
   return exerciseByLearningCycle;
 }
 
+// It is important that there are exercises requiring only one bookmark for each cateogry (i.e. receptive/productive learning cycle and recall/recognition cognitive focus)
 function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
   function _removeExerciseFromList(exercise, list) {
     return list.filter((ex) => ex !== exercise);
@@ -41,13 +42,26 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
     getExerciseListByLearningCycle(exerciseTypesList);
 
   for (let i = 0; i < bookmarks.length; i++) {
+    let cognitiveFocus =
+      bookmarks[i].consecutive_correct_answers >= 2 &&
+      bookmarks[i].cooling_interval >= 2
+        ? "recall"
+        : "recognition";
+
     // Filter the exercises based on the learning_cycle attribute of the bookmark
     let learningCycle = LEARNING_CYCLE_NAME[bookmarks[i].learning_cycle];
     let exerciseListForCycle = exercisesByLearningCycle[learningCycle];
 
+    let suitableExercises = exerciseListForCycle.filter(
+      (exercise) => exercise.cognitiveFocus === cognitiveFocus,
+    );
+
+    console.log(suitableExercises);
+    console.log(bookmarks[i]);
+
     let suitableExerciseFound = false;
     while (!suitableExerciseFound) {
-      let selectedExerciseType = random(exerciseListForCycle);
+      let selectedExerciseType = random(suitableExercises);
 
       // Check if there are enough bookmarks for the selected exercise
       if (i + selectedExerciseType.requiredBookmarks <= bookmarks.length) {

--- a/src/exercises/exerciseSequenceTypes.js
+++ b/src/exercises/exerciseSequenceTypes.js
@@ -12,21 +12,19 @@ import MultipleChoiceL2toL1 from "./exerciseTypes/multipleChoiceL2toL1/MultipleC
 import ClickWordInContext from "./exerciseTypes/wordInContextExercises/ClickWordInContext";
 import MultipleChoiceContext from "./exerciseTypes/multipleChoiceContext/MultipleChoiceContext";
 
-// It is important that there are exercises requiring only one bookmark for each cateogry (i.e. receptive/productive learning cycle and recall/recognition cognitive focus)
-
 const NUMBER_OF_BOOKMARKS_TO_PRACTICE = 12;
 const EX_Match = {
   type: Match,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 2,
 };
 const EX_MultipleChoice = {
   type: MultipleChoice,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 1,
 };
 const EX_FindWordInContext = {
@@ -38,56 +36,56 @@ const EX_SpellWhatYouHear = {
   type: SpellWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  cognitiveFocus: "recall",
+  memoryTask: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceL2toL1 = {
   type: MultipleChoiceL2toL1,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 1,
 };
 const EX_TranslateL2toL1 = {
   type: TranslateL2toL1,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  cognitiveFocus: "recall",
+  memoryTask: "recall",
   testedBookmarks: 1,
 };
 const EX_TranslateWhatYouHear = {
   type: TranslateWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  cognitiveFocus: "recall",
+  memoryTask: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceContext = {
   type: MultipleChoiceContext,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 1,
 };
 const EX_ClickWordInContext = {
   type: ClickWordInContext,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 1,
 };
 const EX_FindWordInContextCloze = {
   type: FindWordInContextCloze,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  cognitiveFocus: "recall",
+  memoryTask: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceAudio = {
   type: MultipleChoiceAudio,
   requiredBookmarks: 3,
   learningCycle: "productive",
-  cognitiveFocus: "recognition",
+  memoryTask: "recognition",
   testedBookmarks: 1,
 };
 const EX_OrderWordsL2 = { type: OrderWordsL2, requiredBookmarks: 1 };
@@ -153,3 +151,55 @@ export {
   LEARNING_CYCLE_SEQUENCE_NO_AUDIO,
   NUMBER_OF_BOOKMARKS_TO_PRACTICE,
 };
+
+// Function to validate that every combination of learningCycle and memoryTask has at least one exercise with requiredBookmarks = 1
+function validateExercises(exerciseList) {
+  const requiredTestedBookmarks = 1;
+
+  function generateKey(learningCycle, memoryTask) {
+    return `${learningCycle}_${memoryTask}`;
+  }
+
+  const exerciseMap = {};
+
+  exerciseList.forEach((exercise) => {
+    if (exercise.requiredBookmarks === requiredTestedBookmarks) {
+      const key = generateKey(
+        exercise.learningCycle || "",
+        exercise.memoryTask || "",
+      );
+      exerciseMap[key] = true;
+    }
+  });
+
+  const requiredCombinations = [
+    "receptive_recognition",
+    "receptive_recall",
+    "productive_recognition",
+    "productive_recall",
+  ];
+
+  requiredCombinations.forEach((combination) => {
+    if (!exerciseMap[combination]) {
+      throw new Error(
+        `Missing required exercise for combination: ${combination}`,
+      );
+    }
+  });
+}
+
+try {
+  validateExercises(LEARNING_CYCLE_SEQUENCE);
+  console.log("LEARNING_CYCLE_SEQUENCE: All exercise requirements are met.");
+} catch (error) {
+  console.error(`LEARNING_CYCLE_SEQUENCE: ${error.message}`);
+}
+
+try {
+  validateExercises(LEARNING_CYCLE_SEQUENCE_NO_AUDIO);
+  console.log(
+    "LEARNING_CYCLE_SEQUENCE_NO_AUDIO: All exercise requirements are met.",
+  );
+} catch (error) {
+  console.error(`LEARNING_CYCLE_SEQUENCE_NO_AUDIO: ${error.message}`);
+}

--- a/src/exercises/exerciseSequenceTypes.js
+++ b/src/exercises/exerciseSequenceTypes.js
@@ -153,7 +153,7 @@ export {
 };
 
 // Function to validate that every combination of learningCycle and memoryTask has at least one exercise with requiredBookmarks = 1
-function validateExercises(exerciseList) {
+function validateExerciseSequence(exerciseList) {
   const requiredTestedBookmarks = 1;
 
   function generateKey(learningCycle, memoryTask) {
@@ -188,18 +188,6 @@ function validateExercises(exerciseList) {
   });
 }
 
-try {
-  validateExercises(LEARNING_CYCLE_SEQUENCE);
-  console.log("LEARNING_CYCLE_SEQUENCE: All exercise requirements are met.");
-} catch (error) {
-  console.error(`LEARNING_CYCLE_SEQUENCE: ${error.message}`);
-}
+validateExerciseSequence(LEARNING_CYCLE_SEQUENCE);
 
-try {
-  validateExercises(LEARNING_CYCLE_SEQUENCE_NO_AUDIO);
-  console.log(
-    "LEARNING_CYCLE_SEQUENCE_NO_AUDIO: All exercise requirements are met.",
-  );
-} catch (error) {
-  console.error(`LEARNING_CYCLE_SEQUENCE_NO_AUDIO: ${error.message}`);
-}
+validateExerciseSequence(LEARNING_CYCLE_SEQUENCE_NO_AUDIO);

--- a/src/exercises/exerciseSequenceTypes.js
+++ b/src/exercises/exerciseSequenceTypes.js
@@ -12,17 +12,21 @@ import MultipleChoiceL2toL1 from "./exerciseTypes/multipleChoiceL2toL1/MultipleC
 import ClickWordInContext from "./exerciseTypes/wordInContextExercises/ClickWordInContext";
 import MultipleChoiceContext from "./exerciseTypes/multipleChoiceContext/MultipleChoiceContext";
 
+// It is important that there are exercises requiring only one bookmark for each cateogry (i.e. receptive/productive learning cycle and recall/recognition cognitive focus)
+
 const NUMBER_OF_BOOKMARKS_TO_PRACTICE = 12;
 const EX_Match = {
   type: Match,
   requiredBookmarks: 3,
   learningCycle: "receptive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 2,
 };
 const EX_MultipleChoice = {
   type: MultipleChoice,
-  requiredBookmarks: 3,
+  requiredBookmarks: 1,
   learningCycle: "productive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 1,
 };
 const EX_FindWordInContext = {
@@ -34,48 +38,56 @@ const EX_SpellWhatYouHear = {
   type: SpellWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "productive",
+  cognitiveFocus: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceL2toL1 = {
   type: MultipleChoiceL2toL1,
   requiredBookmarks: 3,
   learningCycle: "receptive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 1,
 };
 const EX_TranslateL2toL1 = {
   type: TranslateL2toL1,
   requiredBookmarks: 1,
   learningCycle: "receptive",
+  cognitiveFocus: "recall",
   testedBookmarks: 1,
 };
 const EX_TranslateWhatYouHear = {
   type: TranslateWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "receptive",
+  cognitiveFocus: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceContext = {
   type: MultipleChoiceContext,
   requiredBookmarks: 3,
   learningCycle: "receptive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 1,
 };
 const EX_ClickWordInContext = {
   type: ClickWordInContext,
   requiredBookmarks: 1,
   learningCycle: "receptive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 1,
 };
 const EX_FindWordInContextCloze = {
   type: FindWordInContextCloze,
   requiredBookmarks: 1,
   learningCycle: "productive",
+  cognitiveFocus: "recall",
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceAudio = {
   type: MultipleChoiceAudio,
   requiredBookmarks: 3,
   learningCycle: "productive",
+  cognitiveFocus: "recognition",
   testedBookmarks: 1,
 };
 const EX_OrderWordsL2 = { type: OrderWordsL2, requiredBookmarks: 1 };

--- a/src/exercises/exerciseSequenceTypes.js
+++ b/src/exercises/exerciseSequenceTypes.js
@@ -11,20 +11,21 @@ import TranslateWhatYouHear from "./exerciseTypes/translateWhatYouHear/Translate
 import MultipleChoiceL2toL1 from "./exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1";
 import ClickWordInContext from "./exerciseTypes/wordInContextExercises/ClickWordInContext";
 import MultipleChoiceContext from "./exerciseTypes/multipleChoiceContext/MultipleChoiceContext";
+import { MEMORY_TASK } from "./ExerciseTypeConstants";
 
 const NUMBER_OF_BOOKMARKS_TO_PRACTICE = 12;
 const EX_Match = {
   type: Match,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 2,
 };
 const EX_MultipleChoice = {
   type: MultipleChoice,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 1,
 };
 const EX_FindWordInContext = {
@@ -36,56 +37,56 @@ const EX_SpellWhatYouHear = {
   type: SpellWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  memoryTask: "recall",
+  memoryTask: MEMORY_TASK.RECALL,
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceL2toL1 = {
   type: MultipleChoiceL2toL1,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 1,
 };
 const EX_TranslateL2toL1 = {
   type: TranslateL2toL1,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  memoryTask: "recall",
+  memoryTask: MEMORY_TASK.RECALL,
   testedBookmarks: 1,
 };
 const EX_TranslateWhatYouHear = {
   type: TranslateWhatYouHear,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  memoryTask: "recall",
+  memoryTask: MEMORY_TASK.RECALL,
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceContext = {
   type: MultipleChoiceContext,
   requiredBookmarks: 3,
   learningCycle: "receptive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 1,
 };
 const EX_ClickWordInContext = {
   type: ClickWordInContext,
   requiredBookmarks: 1,
   learningCycle: "receptive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 1,
 };
 const EX_FindWordInContextCloze = {
   type: FindWordInContextCloze,
   requiredBookmarks: 1,
   learningCycle: "productive",
-  memoryTask: "recall",
+  memoryTask: MEMORY_TASK.RECALL,
   testedBookmarks: 1,
 };
 const EX_MultipleChoiceAudio = {
   type: MultipleChoiceAudio,
   requiredBookmarks: 3,
   learningCycle: "productive",
-  memoryTask: "recognition",
+  memoryTask: MEMORY_TASK.RECOGNITION,
   testedBookmarks: 1,
 };
 const EX_OrderWordsL2 = { type: OrderWordsL2, requiredBookmarks: 1 };

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -223,18 +223,17 @@ export default function NextNavigation({
           )}
         </>
       )}
-      {isExerciseCorrect &&
-        !(bookmarkLearned || bookmarkProgression || bookmarkLearned) && (
-          <div className="next-nav-feedback">
-            <img
-              src={getStaticPath("icons", "zeeguu-icon-correct.png")}
-              alt="Correct Icon"
-            />
-            <p>
-              <b>{correctMessage}</b>
-            </p>
-          </div>
-        )}
+      {isExerciseCorrect && !(bookmarkLearned || bookmarkProgression) && (
+        <div className="next-nav-feedback">
+          <img
+            src={getStaticPath("icons", "zeeguu-icon-correct.png")}
+            alt="Correct Icon"
+          />
+          <p>
+            <b>{correctMessage}</b>
+          </p>
+        </div>
+      )}
       {isCorrect && !isMultiExerciseType && (
         <>
           <s.BottomRowSmallTopMargin className="bottomRow">

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -54,6 +54,7 @@ export default function NextNavigation({
   const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
   const [matchExerciseProgressionMessage, setMatchExercisesProgressionMessage] =
     useState();
+  const [matchWordsProgressCount, setMatchWordsProgressCount] = useState(0);
   const [isMatchBookmarkProgression, setIsMatchBookmarkProgression] =
     useState(false);
   const productiveExercisesDisabled =
@@ -111,6 +112,7 @@ export default function NextNavigation({
       setMatchExercisesProgressionMessage(
         "'" + wordsProgressed.join("', '") + "'",
       );
+      setMatchWordsProgressCount(wordsProgressed.length);
     }
   }, [isCorrect, exerciseAttemptsLog]);
 
@@ -159,7 +161,7 @@ export default function NextNavigation({
           />
         </>
       )}
-      {isCorrectMatch && isMatchExercise && isMatchBookmarkProgression && (
+      {isCorrect && isMatchExercise && isMatchBookmarkProgression && (
         <>
           <Confetti
             width={window.innerWidth}
@@ -176,7 +178,8 @@ export default function NextNavigation({
             />
             <p>
               <b>
-                {`${matchExerciseProgressionMessage}`} have now moved to your
+                {`${matchExerciseProgressionMessage}`}{" "}
+                {matchWordsProgressCount > 1 ? "have" : "has"} now moved to your
                 productive knowledge.
               </b>
             </p>


### PR DESCRIPTION
This pull request introduces additional difficulty categories based on the memory retrieval concepts of recognition and recall. Research from my thesis highlights the need for more nuanced difficulty levels.

**New Difficulty Levels:** I've added new difficulty categories for exercises, focusing on recognition and recall. Bookmarks are initially tested for receptive/productive recognition, and will be tested for receptive/productive recall, once they have at least 2 consecutive correct answers for recognition and a cooling interval of 2 or more.

![image](https://github.com/user-attachments/assets/a12ce936-0fd4-4bfa-88ba-4c1f777ccf94)

![image](https://github.com/user-attachments/assets/cab474aa-41a0-4b11-b67b-4506d6cb37be)

**API Integration:** This PR relies on changes from the `consecutive_correct-for-recognition/recall-categories` API branch, which includes `consecutive_correct_answers` data now being passed to the frontend.

**Component Refactoring:** The `exerciseSequenceTypes` component has been refactored by @tfnribeiro

**Notes:**
For the new category, I've used `cognitiveFocus` for now. I've also considered `memoryRetrieval`. If you have any suggestions or preferences, please let me know!