### PR TITLE
Fixed holder not displaying on phone

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -8,6 +8,7 @@ import * as s from "./SideBar.sc";
 import { APIContext } from "../contexts/APIContext";
 import { ExerciseCountContext } from "../exercises/ExerciseCountContext";
 import NotificationIcon from "./NotificationIcon";
+import { Tooltip } from "@mui/material";
 
 export default function SideBar(props) {
   const user = useContext(UserContext);
@@ -89,6 +90,31 @@ export default function SideBar(props) {
           setIsOnStudentSide={setIsOnStudentSide}
         />
       )}
+      <div className="SettingsLogoutContainer">
+        <div className="SettingsLogoutHolder">
+          <Tooltip title="Settings">
+            <a href="/account_settings">
+              <img
+                className="navigationIcon"
+                src="static/icons/options_v2.png"
+              ></img>
+            </a>
+          </Tooltip>
+          <Tooltip title="Logout">
+            <Link
+              to="/"
+              onClick={() => {
+                user.logoutMethod();
+              }}
+            >
+              <img
+                className="navigationIcon"
+                src="static/icons/logout_v2.png"
+              ></img>
+            </Link>
+          </Tooltip>
+        </div>
+      </div>
     </>
   );
 

--- a/src/components/SideBar.sc.js
+++ b/src/components/SideBar.sc.js
@@ -136,6 +136,9 @@ const navigationVisibleCommon = css`
     position: absolute;
     bottom: 1em;
     width: 100%;
+    @media (max-width: 768px) {
+      bottom: 5em;
+    }
   }
 
   .SettingsLogoutHolder {

--- a/src/components/StudentSpecificSidebarOptions.js
+++ b/src/components/StudentSpecificSidebarOptions.js
@@ -1,9 +1,7 @@
 import strings from "../i18n/definitions";
-import { Link } from "react-router-dom";
 import { useContext, useEffect, useState } from "react";
 import { MAX_EXERCISE_TO_DO_NOTIFICATION } from "../exercises/ExerciseConstants";
 import { ExerciseCountContext } from "../exercises/ExerciseCountContext";
-import { Tooltip } from "@mui/material";
 
 export default function StudentSpecificSidebarOptions({ SidebarLink, user }) {
   const is_teacher = user.is_teacher === "true" || user.is_teacher === true;
@@ -47,31 +45,6 @@ export default function StudentSpecificSidebarOptions({ SidebarLink, user }) {
       {is_teacher && (
         <SidebarLink text={strings.teacherSite} to="/teacher/classes" />
       )}
-      <div className="SettingsLogoutContainer">
-        <div className="SettingsLogoutHolder">
-          <Tooltip title="Settings">
-            <a href="/account_settings">
-              <img
-                className="navigationIcon"
-                src="static/icons/options_v2.png"
-              ></img>
-            </a>
-          </Tooltip>
-          <Tooltip title="Logout">
-            <Link
-              to="/"
-              onClick={() => {
-                user.logoutMethod();
-              }}
-            >
-              <img
-                className="navigationIcon"
-                src="static/icons/logout_v2.png"
-              ></img>
-            </Link>
-          </Tooltip>
-        </div>
-      </div>
     </>
   );
 }


### PR DESCRIPTION
- The problem seems to be related with using absolute position and "em" resulting with the space on the phone being too small and as a result it's hidden in the phone.

This is strange because the webview of the phone doesn't accuratly represent how it's show in the mobile.

Here is an example:

| **Desktop - Mobile View** | **Actual Rendering in Phone** |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/8f5e1999-f88a-4213-be05-e4d98292796d) | ![image](https://github.com/user-attachments/assets/977d392a-b097-4f92-9846-d65e593e9c64) |
