### PR TITLE
Allow a user to edit a word into an expression

### DIFF
--- a/src/utils/misc/isBookmarkExpression.js
+++ b/src/utils/misc/isBookmarkExpression.js
@@ -1,3 +1,5 @@
+import { isExpression } from "../preprocessing/preprocessing";
+
 export default function isBookmarkExpression(bookmark) {
-  return bookmark.from.includes(" ");
+  return isExpression(bookmark.from);
 }

--- a/src/utils/preprocessing/preprocessing.js
+++ b/src/utils/preprocessing/preprocessing.js
@@ -15,17 +15,17 @@ function tokenize(sentence) {
   return sentence.split(" ");
 }
 
-function isExpression(word) {
-  return word.includes(" ");
+function isExpression(text) {
+  return text.includes(" ");
 }
 
-function isWordInSentence(word, sentence) {
-  if (isExpression(word)) {
-    return sentence.includes(word);
+function isTextInSentence(text, sentence) {
+  if (isExpression(text)) {
+    return sentence.includes(text);
   }
   let tokens = tokenize(sentence);
   tokens = tokens.map((each) => removePunctuation(each));
-  return tokens.includes(removePunctuation(word));
+  return tokens.includes(removePunctuation(text));
 }
 
-export { tokenize, removePunctuation, isWordInSentence, isExpression };
+export { tokenize, removePunctuation, isTextInSentence, isExpression };

--- a/src/utils/preprocessing/preprocessing.js
+++ b/src/utils/preprocessing/preprocessing.js
@@ -1,3 +1,5 @@
+import isBookmarkExpression from "../misc/isBookmarkExpression";
+
 // doesn't remove punctuation when it is part of a word, e.g. "l'Italie" or "it's"
 function removePunctuation(string) {
   let removeLeadingPunctuation =
@@ -13,10 +15,17 @@ function tokenize(sentence) {
   return sentence.split(" ");
 }
 
+function isExpression(word) {
+  return word.includes(" ");
+}
+
 function isWordInSentence(word, sentence) {
+  if (isExpression(word)) {
+    return sentence.includes(word);
+  }
   let tokens = tokenize(sentence);
   tokens = tokens.map((each) => removePunctuation(each));
   return tokens.includes(removePunctuation(word));
 }
 
-export { tokenize, removePunctuation, isWordInSentence };
+export { tokenize, removePunctuation, isWordInSentence, isExpression };

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -6,7 +6,7 @@ import Modal from "@mui/material/Modal";
 import WordEditForm from "./WordEditForm";
 import { getStaticPath } from "../utils/misc/staticPath.js";
 import { toast } from "react-toastify";
-import { isWordInSentence } from "../utils/preprocessing/preprocessing.js";
+import { isTextInSentence } from "../utils/preprocessing/preprocessing.js";
 
 export default function EditBookmarkButton({
   bookmark,
@@ -77,7 +77,7 @@ export default function EditBookmarkButton({
       " instead of: ",
       bookmark.context,
     );
-    if (!isWordInSentence(newWord, newContext)) {
+    if (!isTextInSentence(newWord, newContext)) {
       setErrorMessage(
         `'${newWord}' is not present in the context. Make sure the context contains the word.`,
       );


### PR DESCRIPTION
- Seperated the `isBookmarkExpression` into a function, `isExpression`, that expects a string and tests for "Expression" (has space). 
- When a user word is an expression text to see if it's part of the context string. 