### PR TITLE
removed the headline hiding the progress bar for match

### DIFF
--- a/src/exercises/LearningCycleIndicator.js
+++ b/src/exercises/LearningCycleIndicator.js
@@ -87,10 +87,7 @@ export default function LearningCycleIndicator({
   return (
     <>
       {Feature.merle_exercises() && (
-        <div
-          className="learningCycleIndicator"
-          style={{ visibility: isHidden ? "hidden" : "visible" }}
-        >
+        <div className="learningCycleIndicator">
           <div className="learningCycleIcon">
             <Tooltip title={getTooltipContent()}>
               <img


### PR DESCRIPTION
This pr makes sure the progress bar is now greyed out before the first word is clicked. 