### PR TITLE
Added safeguard

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -61,11 +61,15 @@ export default function FindArticles({ content, searchQuery }) {
   };
   function handleScroll() {
     let scrollBarPixelDistToPageEnd = getPixelsFromScrollBarToEnd();
+    let articlesHaveBeenFetched =
+      currentPageRef.current !== undefined &&
+      articleListRef.current !== undefined;
 
     if (
       scrollBarPixelDistToPageEnd <= 50 &&
       !isWaitingForNewArticlesRef.current &&
-      !noMoreArticlesToShowRef.current
+      !noMoreArticlesToShowRef.current &&
+      articlesHaveBeenFetched
     ) {
       setIsWaitingForNewArticles(true);
       document.title = "Getting more articles...";


### PR DESCRIPTION
On development, I have noticed when using the back navigation in a browser it would often trigger an error of `articleListRef.current` being undefined. I believe this might have to do with the fact of how the scrollholder is handled in these situations, and to avoid throwing errors and breaking the event, there is a check to ensure the variables are run before executing the code. 

- Avoid calling the handleScroll in case the articles have not been loaded from the API. Avoid exceptions when scrolling or disabling the event.
