### PR TITLE
page should reload after the "install the extension" dialog is closed.

### DIFF
--- a/src/articles/ExtensionMessage.js
+++ b/src/articles/ExtensionMessage.js
@@ -25,6 +25,7 @@ export default function ExtensionMessage({
     setExtensionMessageOpen(false);
     setDisplayedExtensionPopup(true);
     LocalStorage.setDisplayedExtensionPopup(true);
+    window.location.reload();
   }
 
   if (

--- a/src/components/redirect_notification/SupportedNotification_NotInstalled.js
+++ b/src/components/redirect_notification/SupportedNotification_NotInstalled.js
@@ -14,12 +14,13 @@ export default function SupportedNotification_NotInstalled({
   handleCloseRedirectionModal,
   open,
 }) {
-  function handleCancel() {
+  function handleClose() {
     handleCloseRedirectionModal();
+    window.location.reload();
   }
 
   return (
-    <Modal open={open} onClose={handleCancel}>
+    <Modal open={open} onClose={handleClose}>
       <Header>
         <Heading>
           <Icon src={"../static/images/zeeguuLogo.svg"} />


### PR DESCRIPTION
otherwise, even if the user has installed the extension, the extension is not detected, so the user would try to open the article again and see the message again, although the extension is not installed.

@igawaclawska - are there any other places in the code where the same thing would need to be done? 