### PR TITLE
Fix to the "install the extension" dialogs still present after installing the Zeeguu Reader

### DIFF
--- a/src/articles/ExtensionMessage.js
+++ b/src/articles/ExtensionMessage.js
@@ -60,10 +60,7 @@ export default function ExtensionMessage({
         </Main>
         <Footer>
           <ButtonContainer buttonCountNum={1}>
-            <GoToButton
-              target={"_blank"}
-              href={getExtensionInstallationLinks()}
-            >
+            <GoToButton target={"_self"} href={getExtensionInstallationLinks()}>
               <FileDownloadOutlinedIcon fontSize="small" />
               Install the Extension
             </GoToButton>

--- a/src/components/redirect_notification/SupportedNotification_NotInstalled.js
+++ b/src/components/redirect_notification/SupportedNotification_NotInstalled.js
@@ -38,7 +38,7 @@ export default function SupportedNotification_NotInstalled({
       </Main>
       <Footer>
         <ButtonContainer buttonCountNum={1}>
-          <GoToButton target={"_blank"} href={getExtensionInstallationLinks()}>
+          <GoToButton target={"_self"} href={getExtensionInstallationLinks()}>
             <DownloadRoundedIcon fontSize="small" />
             Install the Extension
           </GoToButton>


### PR DESCRIPTION
This is an alternative solution to #502.
It prevents:
- The Zeeguu Homepage being open in two cards at once after installing the extension
- The` ExtensionMessage.js` and `SupportedNotification_NotInstalled.js` components lingering on the Zeeguu Homepage after installation of the extension