### PR TITLE
updated message when progressing to productive knowledge

### DIFF
--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -328,7 +328,7 @@ let strings = new LocalizedStrings(
 
       //LearningCycle
       nextLearningCycle:
-        "This word has now moved to your productive knowledge.",
+        "This word has now moved to your productive exercises.",
       wordLearned: "You've learned a new word!",
       receptiveTooltip:
         "This word is part of your receptive vocabulary knowledge. Receptive means the capability to comprehend a word when you hear or see it.",


### PR DESCRIPTION
The message when progressing to productive knowledge is now: _"This word has now moved to your productive exercises."_ instead of the previous _"productive knowledge"_