### PR TITLE
Fix for Extension: [BUG] Extension can't click Revise Words and Styling wrong #59

### DIFF
--- a/src/reader/ReviewVocabularyInfoBox.js
+++ b/src/reader/ReviewVocabularyInfoBox.js
@@ -4,18 +4,21 @@ import { StyledButton } from "../components/allButtons.sc.js";
 import { useHistory } from "react-router-dom";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { useEffect } from "react";
+import { getStaticPath } from "../utils/misc/staticPath.js";
 
 export default function ReviewVocabularyInfoBox({
   articleID,
   clickedOnReviewVocab,
   setClickedOnReviewVocab,
+  openReview,
 }) {
   useUILanguage();
 
   const history = useHistory();
 
   const handleButtonClick = () => {
-    setClickedOnReviewVocab(true);
+    if (setClickedOnReviewVocab) setClickedOnReviewVocab(true);
+    if (openReview) openReview();
   };
 
   useEffect(() => {
@@ -30,7 +33,7 @@ export default function ReviewVocabularyInfoBox({
             <h2>Exercises</h2>
             <div>
               <img
-                src="/static/images/zeeguuWhiteLogo.svg"
+                src={getStaticPath("images", "zeeguuWhiteLogo.svg")}
                 alt="Zeeguu Logo - The Elephant"
               />
             </div>


### PR DESCRIPTION
https://github.com/zeeguu/browser-extension/issues/59

The extension was not showing the elephant and the button wasn't working as there is a different prop that is used. 

I have added checks to call the props if available in the handleClick logic + used the getStaticPath to render the elephant.