### PR TITLE
Fix match message if productive disabled

### DIFF
--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -155,6 +155,7 @@ export default function NextNavigation({
   const showCoffetti =
     isCorrect &&
     (isMatchBookmarkProgression || bookmarkProgression || bookmarkLearned);
+
   return (
     <>
       {learningCycleFeature && (
@@ -186,8 +187,17 @@ export default function NextNavigation({
             <p>
               <b>
                 {`${matchExerciseProgressionMessage}`}{" "}
-                {matchWordsProgressCount > 1 ? "have" : "has"} now moved to your
-                productive knowledge.
+                {LocalStorage.getProductiveExercisesEnabled()
+                  ? matchWordsProgressCount > 1
+                    ? "have"
+                    : "has"
+                  : matchWordsProgressCount > 1
+                    ? "are"
+                    : "is"}{" "}
+                {LocalStorage.getProductiveExercisesEnabled() &&
+                  "now moved to your productive knowledge."}
+                {!LocalStorage.getProductiveExercisesEnabled() &&
+                  "now learned!"}
               </b>
             </p>
           </div>

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -156,6 +156,16 @@ export default function NextNavigation({
     isCorrect &&
     (isMatchBookmarkProgression || bookmarkProgression || bookmarkLearned);
 
+  function celebrationMessageMatch() {
+    if (LocalStorage.getProductiveExercisesEnabled()) {
+      let verb = matchWordsProgressCount > 1 ? "have" : "has";
+      return `${verb} now moved to your productive knowledge.`;
+    } else {
+      let verb = matchWordsProgressCount > 1 ? "are" : "is";
+      return `${verb} now learned!`;
+    }
+  }
+
   return (
     <>
       {learningCycleFeature && (
@@ -187,17 +197,7 @@ export default function NextNavigation({
             <p>
               <b>
                 {`${matchExerciseProgressionMessage}`}{" "}
-                {LocalStorage.getProductiveExercisesEnabled()
-                  ? matchWordsProgressCount > 1
-                    ? "have"
-                    : "has"
-                  : matchWordsProgressCount > 1
-                    ? "are"
-                    : "is"}{" "}
-                {LocalStorage.getProductiveExercisesEnabled() &&
-                  "now moved to your productive knowledge."}
-                {!LocalStorage.getProductiveExercisesEnabled() &&
-                  "now learned!"}
+                {celebrationMessageMatch()}
               </b>
             </p>
           </div>


### PR DESCRIPTION
- Fixed the Match exercise message not showing learned if the Productive exercises were disabled:

## Disabled Productive Exercises

![image](https://github.com/user-attachments/assets/b42e912f-1f23-4978-8e2e-7677e4501ef0)
![image](https://github.com/user-attachments/assets/d1ffab24-506b-4bad-afb3-cb984daae210)

## Enabled Productive Exercises

![image](https://github.com/user-attachments/assets/6736e306-d98b-4d53-bd75-7de111717276)
![image](https://github.com/user-attachments/assets/2206d698-cb24-4257-9214-03a9d5d6b689)
