### PR TITLE
Moved the logic of pronouncing flag inside the hook

### DIFF
--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -8,11 +8,7 @@ import { useEffect, useState, useContext } from "react";
 import Confetti from "react-confetti";
 import SessionStorage from "../../assorted/SessionStorage.js";
 import { SpeechContext } from "../../contexts/SpeechContext.js";
-import {
-  EXERCISE_TYPES,
-  LEARNING_CYCLE,
-  PRONOUNCIATION_SETTING,
-} from "../ExerciseTypeConstants";
+import { EXERCISE_TYPES, LEARNING_CYCLE } from "../ExerciseTypeConstants";
 
 import CelebrationModal from "../CelebrationModal";
 import { getStaticPath } from "../../utils/misc/staticPath.js";
@@ -49,7 +45,7 @@ export default function NextNavigation({
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
   const [
-    IsPronounceBookmark,
+    isPronounceBookmark,
     currentPronouncingState,
     autoPronounceString,
     toggleAutoPronounceValue,
@@ -89,8 +85,9 @@ export default function NextNavigation({
   async function handleSpeak() {
     await speech.speakOut(exerciseBookmark.from, setIsButtonSpeaking);
   }
+
   useEffect(() => {
-    if (isCorrect && IsPronounceBookmark && !isMatchExercise) handleSpeak();
+    if (isCorrect && isPronounceBookmark && !isMatchExercise) handleSpeak();
     if (exerciseAttemptsLog) {
       let wordsProgressed = [];
       for (let i = 0; i < exerciseAttemptsLog.length; i++) {

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -44,12 +44,8 @@ export default function NextNavigation({
   const [learningCycle, setLearningCycle] = useState(null);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
-  const [
-    isPronounceBookmark,
-    currentPronouncingState,
-    autoPronounceString,
-    toggleAutoPronounceValue,
-  ] = useBookmarkAutoPronounce();
+  const [autoPronounceBookmark, autoPronounceString, toggleAutoPronounceValue] =
+    useBookmarkAutoPronounce();
   const speech = useContext(SpeechContext);
   const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
   const [matchExerciseProgressionMessage, setMatchExercisesProgressionMessage] =
@@ -87,7 +83,7 @@ export default function NextNavigation({
   }
 
   useEffect(() => {
-    if (isCorrect && isPronounceBookmark && !isMatchExercise) handleSpeak();
+    if (isCorrect && autoPronounceBookmark && !isMatchExercise) handleSpeak();
     if (exerciseAttemptsLog) {
       let wordsProgressed = [];
       for (let i = 0; i < exerciseAttemptsLog.length; i++) {

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -44,7 +44,7 @@ export default function NextNavigation({
   const [learningCycle, setLearningCycle] = useState(null);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
-  const [autoPronounceBookmark, autoPronounceString, toggleAutoPronounceValue] =
+  const [autoPronounceBookmark, autoPronounceString, toggleAutoPronounceState] =
     useBookmarkAutoPronounce();
   const speech = useContext(SpeechContext);
   const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
@@ -260,7 +260,7 @@ export default function NextNavigation({
       )}
       {isCorrect && (
         <s.StyledGreyButton
-          onClick={toggleAutoPronounceValue}
+          onClick={toggleAutoPronounceState}
           style={{
             position: "relative",
             bottom: "3em",

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -48,8 +48,12 @@ export default function NextNavigation({
   const [learningCycle, setLearningCycle] = useState(null);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
-  const [autoPronounceState, autoPronounceString, toggleAutoPronounceValue] =
-    useBookmarkAutoPronounce();
+  const [
+    IsPronounceBookmark,
+    currentPronouncingState,
+    autoPronounceString,
+    toggleAutoPronounceValue,
+  ] = useBookmarkAutoPronounce();
   const speech = useContext(SpeechContext);
   const [isButtonSpeaking, setIsButtonSpeaking] = useState(false);
   const [matchExerciseProgressionMessage, setMatchExercisesProgressionMessage] =
@@ -86,13 +90,7 @@ export default function NextNavigation({
     await speech.speakOut(exerciseBookmark.from, setIsButtonSpeaking);
   }
   useEffect(() => {
-    if (
-      isCorrect &&
-      autoPronounceState &&
-      autoPronounceState !== PRONOUNCIATION_SETTING.off &&
-      !isMatchExercise
-    )
-      handleSpeak();
+    if (isCorrect && IsPronounceBookmark && !isMatchExercise) handleSpeak();
     if (exerciseAttemptsLog) {
       let wordsProgressed = [];
       for (let i = 0; i < exerciseAttemptsLog.length; i++) {

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -14,6 +14,7 @@ import useSubSessionTimer from "../../../hooks/useSubSessionTimer.js";
 import { toast } from "react-toastify";
 import isBookmarkExpression from "../../../utils/misc/isBookmarkExpression.js";
 import LocalStorage from "../../../assorted/LocalStorage.js";
+import useBookmarkAutoPronounce from "../../../hooks/useBookmarkAutoPronounce.js";
 
 // The user has to match three L1 words to their correct L2 translations.
 // This tests the user's passive knowledge.
@@ -68,6 +69,7 @@ export default function Match({
   const [getCurrentSubSessionDuration] = useSubSessionTimer(
     activeSessionDuration,
   );
+  const [IsPronounceBookmark] = useBookmarkAutoPronounce();
   const [isPronouncing, setIsPronouncing] = useState(false);
   const [lastCorrectBookmarkId, setLastCorrectBookmarkId] = useState(null);
   const [selectedBookmark, setSelectedBookmark] = useState();
@@ -87,9 +89,7 @@ export default function Match({
   }
   const speech = useContext(SpeechContext);
   async function handleSpeak(bookmark) {
-    if (
-      LocalStorage.getAutoPronounceInExercises() !== PRONOUNCIATION_SETTING.off
-    ) {
+    if (IsPronounceBookmark) {
       await speech.speakOut(bookmark.from, setIsPronouncing);
     }
   }

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -2,10 +2,7 @@ import { useState, useEffect, useContext } from "react";
 import * as s from "../Exercise.sc.js";
 import strings from "../../../i18n/definitions";
 import shuffle from "../../../assorted/fisherYatesShuffle";
-import {
-  EXERCISE_TYPES,
-  PRONOUNCIATION_SETTING,
-} from "../../ExerciseTypeConstants.js";
+import { EXERCISE_TYPES } from "../../ExerciseTypeConstants.js";
 import LearningCycleIndicator from "../../LearningCycleIndicator.js";
 import { SpeechContext } from "../../../contexts/SpeechContext.js";
 import NextNavigation from "../NextNavigation";
@@ -13,7 +10,6 @@ import MatchInput from "./MatchInput.js";
 import useSubSessionTimer from "../../../hooks/useSubSessionTimer.js";
 import { toast } from "react-toastify";
 import isBookmarkExpression from "../../../utils/misc/isBookmarkExpression.js";
-import LocalStorage from "../../../assorted/LocalStorage.js";
 import useBookmarkAutoPronounce from "../../../hooks/useBookmarkAutoPronounce.js";
 
 // The user has to match three L1 words to their correct L2 translations.
@@ -69,7 +65,7 @@ export default function Match({
   const [getCurrentSubSessionDuration] = useSubSessionTimer(
     activeSessionDuration,
   );
-  const [IsPronounceBookmark] = useBookmarkAutoPronounce();
+  const [isPronounceBookmark] = useBookmarkAutoPronounce();
   const [isPronouncing, setIsPronouncing] = useState(false);
   const [lastCorrectBookmarkId, setLastCorrectBookmarkId] = useState(null);
   const [selectedBookmark, setSelectedBookmark] = useState();
@@ -87,9 +83,11 @@ export default function Match({
   function inputFirstClick() {
     if (firstPressTime === undefined) setFirstPressTime(new Date());
   }
+
   const speech = useContext(SpeechContext);
+
   async function handleSpeak(bookmark) {
-    if (IsPronounceBookmark) {
+    if (isPronounceBookmark) {
       await speech.speakOut(bookmark.from, setIsPronouncing);
     }
   }

--- a/src/exercises/exerciseTypes/match/Match.js
+++ b/src/exercises/exerciseTypes/match/Match.js
@@ -65,7 +65,7 @@ export default function Match({
   const [getCurrentSubSessionDuration] = useSubSessionTimer(
     activeSessionDuration,
   );
-  const [isPronounceBookmark] = useBookmarkAutoPronounce();
+  const [autoPronounceBookmark] = useBookmarkAutoPronounce();
   const [isPronouncing, setIsPronouncing] = useState(false);
   const [lastCorrectBookmarkId, setLastCorrectBookmarkId] = useState(null);
   const [selectedBookmark, setSelectedBookmark] = useState();
@@ -87,7 +87,7 @@ export default function Match({
   const speech = useContext(SpeechContext);
 
   async function handleSpeak(bookmark) {
-    if (isPronounceBookmark) {
+    if (autoPronounceBookmark) {
       await speech.speakOut(bookmark.from, setIsPronouncing);
     }
   }

--- a/src/hooks/useBookmarkAutoPronounce.js
+++ b/src/hooks/useBookmarkAutoPronounce.js
@@ -8,7 +8,7 @@ import {
 export default function useBookmarkAutoPronounce() {
   const [currentPronouncingState, setCurrentPronouncingState] = useState();
   const [currentPronouncingString, setCurrentPronouncingString] = useState();
-  const [IsPronounceBookmark, setIsPronounceBookmark] = useState();
+  const [isPronounceBookmark, setIsPronounceBookmark] = useState();
   const MAX_AVAILABLE_SETTING = Math.max(
     ...Object.values(PRONOUNCIATION_SETTING),
   );
@@ -35,7 +35,7 @@ export default function useBookmarkAutoPronounce() {
   }
 
   return [
-    IsPronounceBookmark,
+    isPronounceBookmark,
     currentPronouncingState,
     currentPronouncingString,
     cyclePronounciationState,

--- a/src/hooks/useBookmarkAutoPronounce.js
+++ b/src/hooks/useBookmarkAutoPronounce.js
@@ -8,6 +8,7 @@ import {
 export default function useBookmarkAutoPronounce() {
   const [currentPronouncingState, setCurrentPronouncingState] = useState();
   const [currentPronouncingString, setCurrentPronouncingString] = useState();
+  const [IsPronounceBookmark, setIsPronounceBookmark] = useState();
   const MAX_AVAILABLE_SETTING = Math.max(
     ...Object.values(PRONOUNCIATION_SETTING),
   );
@@ -15,6 +16,7 @@ export default function useBookmarkAutoPronounce() {
   function __updateState(value) {
     setCurrentPronouncingState(value);
     setCurrentPronouncingString(PRONOUNCIATION_SETTING_NAME[value]);
+    setIsPronounceBookmark(value !== PRONOUNCIATION_SETTING.off);
   }
 
   useEffect(() => {
@@ -33,6 +35,7 @@ export default function useBookmarkAutoPronounce() {
   }
 
   return [
+    IsPronounceBookmark,
     currentPronouncingState,
     currentPronouncingString,
     cyclePronounciationState,

--- a/src/hooks/useBookmarkAutoPronounce.js
+++ b/src/hooks/useBookmarkAutoPronounce.js
@@ -6,9 +6,20 @@ import {
 } from "../exercises/ExerciseTypeConstants";
 
 export default function useBookmarkAutoPronounce() {
+  /*
+    Handles the Auto-Pronounce feature for the exercises.
+
+    This setting is stored in the LocalStorage and can be toggled On/Off.
+
+    If enabled, then the bookmark being practiced is pronounced when the exercise
+    is completed, or, in the case of match, when it's correctly linked. 
+
+    This hooks manages the state of the setting based on whether it's on/off, and
+    updates it when the user toggles it in the exercises.
+  */
   const [currentPronouncingState, setCurrentPronouncingState] = useState();
   const [currentPronouncingString, setCurrentPronouncingString] = useState();
-  const [isPronounceBookmark, setIsPronounceBookmark] = useState();
+  const [autoPronounceBookmark, setAutoPronounceBookmark] = useState();
   const MAX_AVAILABLE_SETTING = Math.max(
     ...Object.values(PRONOUNCIATION_SETTING),
   );
@@ -16,7 +27,7 @@ export default function useBookmarkAutoPronounce() {
   function __updateState(value) {
     setCurrentPronouncingState(value);
     setCurrentPronouncingString(PRONOUNCIATION_SETTING_NAME[value]);
-    setIsPronounceBookmark(value !== PRONOUNCIATION_SETTING.off);
+    setAutoPronounceBookmark(value !== PRONOUNCIATION_SETTING.off);
   }
 
   useEffect(() => {
@@ -35,8 +46,7 @@ export default function useBookmarkAutoPronounce() {
   }
 
   return [
-    isPronounceBookmark,
-    currentPronouncingState,
+    autoPronounceBookmark,
     currentPronouncingString,
     cyclePronounciationState,
   ];

--- a/src/hooks/useBookmarkAutoPronounce.js
+++ b/src/hooks/useBookmarkAutoPronounce.js
@@ -36,7 +36,7 @@ export default function useBookmarkAutoPronounce() {
     __updateState(currentState);
   });
 
-  function cyclePronounciationState() {
+  function toggleAutoPronounceState() {
     let optionSelected;
     if (currentPronouncingState < MAX_AVAILABLE_SETTING) {
       optionSelected = currentPronouncingState + 1;
@@ -48,6 +48,6 @@ export default function useBookmarkAutoPronounce() {
   return [
     autoPronounceBookmark,
     currentPronouncingString,
-    cyclePronounciationState,
+    toggleAutoPronounceState,
   ];
 }


### PR DESCRIPTION
- Bug was due to the fact that the pronunciation wasn't set so the comparison between undefined and off would result in true for match, which wasn't using the hook.
- This has been fixed by introducing a flag that is handled at the hook level, which in itself handles the case where the user has not interacted with the feature yet. (Defaults to Off)