### PR TITLE
Fix to: 523 smaller screens cannot see error msg on create account

### DIFF
--- a/src/pages/ResetPasswordStep1.js
+++ b/src/pages/ResetPasswordStep1.js
@@ -60,7 +60,11 @@ export default function ResetPasswordStep1({
         />
       </FormSection>
       <ButtonContainer className={"padding-medium"}>
-        <Button className={"full-width-btn"} onClick={handleResetPassword}>
+        <Button
+          type={"submit"}
+          className={"full-width-btn"}
+          onClick={handleResetPassword}
+        >
           {strings.resetPassword}
         </Button>
       </ButtonContainer>

--- a/src/pages/ResetPasswordStep2.js
+++ b/src/pages/ResetPasswordStep2.js
@@ -102,7 +102,11 @@ export default function ResetPasswordStep2({ api, email }) {
       </FormSection>
 
       <ButtonContainer className={"padding-medium"}>
-        <Button className={"full-width-btn"} onClick={handleResetPassword}>
+        <Button
+          type={"submit"}
+          className={"full-width-btn"}
+          onClick={handleResetPassword}
+        >
           {strings.setNewPassword}
         </Button>
       </ButtonContainer>

--- a/src/pages/Settings/AudioExercises.js
+++ b/src/pages/Settings/AudioExercises.js
@@ -99,7 +99,9 @@ export default function AudioExercises({ api }) {
             </FormSection>
           )}
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
-            <Button onClick={handleSave}>{strings.save}</Button>
+            <Button type={"submit"} onClick={handleSave}>
+              {strings.save}
+            </Button>
           </ButtonContainer>
         </Form>
       </Main>

--- a/src/pages/Settings/Languages.js
+++ b/src/pages/Settings/Languages.js
@@ -144,7 +144,9 @@ export default function Languages({ api, setUser }) {
             />
           </FormSection>
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
-            <Button onClick={handleSave}>{strings.save}</Button>
+            <Button type={"submit"} onClick={handleSave}>
+              {strings.save}
+            </Button>
           </ButtonContainer>
         </Form>
       </Main>

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -101,7 +101,9 @@ export default function ProfileDetails({ api, setUser }) {
             />
           </FormSection>
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
-            <Button onClick={handleSave}>{strings.save}</Button>
+            <Button type={"submit"} onClick={handleSave}>
+              {strings.save}
+            </Button>
           </ButtonContainer>
         </Form>
       </Main>

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -67,13 +67,17 @@ export default function SignIn({ api, handleSuccessfulSignIn }) {
               helperText={<a href="/reset_pass">{strings.forgotPassword}</a>}
             />
           </FormSection>
+          <ButtonContainer className={"padding-medium"}>
+            <Button
+              type={"submit"}
+              className={"full-width-btn"}
+              onClick={handleSignIn}
+            >
+              {strings.login}
+            </Button>
+          </ButtonContainer>
         </Form>
       </Main>
-      <ButtonContainer className={"padding-medium"}>
-        <Button className={"full-width-btn"} onClick={handleSignIn}>
-          {strings.login}
-        </Button>
-      </ButtonContainer>
       <Footer>
         <p>
           {strings.dontHaveAnAccount + " "}

--- a/src/pages/_pages_shared/Button.js
+++ b/src/pages/_pages_shared/Button.js
@@ -1,8 +1,8 @@
 import * as s from "./Button.sc";
 
-export default function Button({ children, className, href, onClick }) {
+export default function Button({ children, className, onClick, type }) {
   return (
-    <s.Button className={className} role="button" onClick={onClick}>
+    <s.Button type={type} className={className} role="button" onClick={onClick}>
       {children}
     </s.Button>
   );

--- a/src/pages/_pages_shared/Button.js
+++ b/src/pages/_pages_shared/Button.js
@@ -1,6 +1,6 @@
 import * as s from "./Button.sc";
 
-export default function Button({ children, className, onClick, type }) {
+export default function Button({ children, className, href, onClick, type }) {
   return (
     <s.Button type={type} className={className} role="button" onClick={onClick}>
       {children}

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -140,9 +140,6 @@ export default function CreateAccount({
       </Header>
       <Main>
         <Form action={""} method={"POST"}>
-          {errorMessage && (
-            <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>
-          )}
           <FormSection>
             <InputField
               type={"text"}
@@ -191,36 +188,41 @@ export default function CreateAccount({
               helperText={strings.passwordHelperText}
             />
           </FormSection>
-          <FormSection>
-            <sC.CheckboxWrapper>
-              <input
-                onChange={handleCheckPrivacyNote}
-                checked={checkPrivacyNote}
-                id="checkbox"
-                name=""
-                value=""
-                type="checkbox"
-              ></input>
-              <label>
-                By checking this box you agree to our &nbsp;
-                <a
-                  onClick={() => {
-                    setShowPrivacyNotice(true);
-                  }}
-                >
-                  {strings.privacyNotice}
-                </a>
-              </label>
-            </sC.CheckboxWrapper>
-          </FormSection>
+          <sC.CheckboxWrapper>
+            <input
+              onChange={handleCheckPrivacyNote}
+              checked={checkPrivacyNote}
+              id="checkbox"
+              name=""
+              value=""
+              type="checkbox"
+            ></input>
+            <label>
+              By checking this box you agree to our &nbsp;
+              <a
+                onClick={() => {
+                  setShowPrivacyNotice(true);
+                }}
+              >
+                {strings.privacyNotice}
+              </a>
+            </label>
+          </sC.CheckboxWrapper>
+          {errorMessage && (
+            <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>
+          )}
+          <ButtonContainer className={"padding-medium"}>
+            <Button
+              type={"submit"}
+              className={"full-width-btn"}
+              onClick={handleCreate}
+            >
+              {strings.createAccount}
+            </Button>
+          </ButtonContainer>
         </Form>
       </Main>
       <Footer>
-        <ButtonContainer className={"padding-medium"}>
-          <Button className={"full-width-btn"} onClick={handleCreate}>
-            {strings.createAccount}
-          </Button>
-        </ButtonContainer>
         <p>
           {strings.alreadyHaveAccount + " "}
           <a className="bold underlined-link" href="/login">

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -105,11 +105,6 @@ export default function CreateAccount({
       native_language: native_language_on_register,
     };
 
-    const handleError = (error) => {
-      setErrorMessage(error); // Set the error message
-      scrollToTop(); // Scroll to the top whenever there's an error
-    };
-
     api.addUser(
       inviteCode,
       password,
@@ -124,7 +119,7 @@ export default function CreateAccount({
         });
       },
       (error) => {
-        handleError(error);
+        setErrorMessage(error);
       },
     );
   }

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -1,6 +1,7 @@
-import { useState, useContext } from "react";
+import { useState, useContext, useEffect } from "react";
 
 import redirect from "../../utils/routing/routing";
+import { scrollToTop } from "../../utils/misc/scrollToTop";
 import * as sC from "../../components/modal_shared/Checkbox.sc";
 import useFormField from "../../hooks/useFormField";
 
@@ -75,6 +76,12 @@ export default function CreateAccount({
     });
   }, []);
 
+  useEffect(() => {
+    if (errorMessage) {
+      scrollToTop();
+    }
+  }, [errorMessage]);
+
   //Clear temp local storage entries needed only for account creation
   function clearOnRegisterLanguageEntries() {
     LocalStorage.removeLearnedLanguage_OnRegister();
@@ -98,6 +105,11 @@ export default function CreateAccount({
       native_language: native_language_on_register,
     };
 
+    const handleError = (error) => {
+      setErrorMessage(error); // Set the error message
+      scrollToTop(); // Scroll to the top whenever there's an error
+    };
+
     api.addUser(
       inviteCode,
       password,
@@ -112,7 +124,7 @@ export default function CreateAccount({
         });
       },
       (error) => {
-        setErrorMessage(error);
+        handleError(error);
       },
     );
   }
@@ -140,6 +152,9 @@ export default function CreateAccount({
       </Header>
       <Main>
         <Form action={""} method={"POST"}>
+          {errorMessage && (
+            <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>
+          )}
           <FormSection>
             <InputField
               type={"text"}
@@ -208,9 +223,6 @@ export default function CreateAccount({
               </a>
             </label>
           </sC.CheckboxWrapper>
-          {errorMessage && (
-            <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>
-          )}
           <ButtonContainer className={"padding-medium"}>
             <Button
               type={"submit"}

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -137,7 +137,11 @@ export default function LanguagePreferences({ api }) {
           </FormSection>
           <p>{strings.youCanChangeLater}</p>
           <ButtonContainer className={"padding-medium"}>
-            <Button className={"full-width-btn"} onClick={validateAndRedirect}>
+            <Button
+              type={"submit"}
+              className={"full-width-btn"}
+              onClick={validateAndRedirect}
+            >
               {strings.next} <ArrowForwardRoundedIcon />
             </Button>
           </ButtonContainer>

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 
 import LocalStorage from "../../assorted/LocalStorage";
 
+import { scrollToTop } from "../../utils/misc/scrollToTop";
+
 import redirect from "../../utils/routing/routing";
 import useFormField from "../../hooks/useFormField";
 
@@ -32,6 +34,12 @@ export default function LanguagePreferences({ api }) {
     useFormField("");
   const [systemLanguages, setSystemLanguages] = useState();
   const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (errorMessage) {
+      scrollToTop();
+    }
+  }, [errorMessage]);
 
   useEffect(() => {
     api.getSystemLanguages((languages) => {

--- a/src/utils/misc/scrollToTop.js
+++ b/src/utils/misc/scrollToTop.js
@@ -1,0 +1,6 @@
+export function scrollToTop() {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  });
+}


### PR DESCRIPTION
## `scrollToTop` behaviour added

- On the longer pages with forms (Language Preferences, Create Account), when an error occurs, the page automatically scrolls to the top to show the error.
- I explored an alternative approach: showing the error at the bottom. However, in forms with multiple fields, it looked like it was associated with the last field only, so I decided to continue with the error message at the top.

## Other changes
- On pages containing forms, the buttons submitting the form are moved inside the `<Form/>` component
- Buttons responsible for submitting the form are given `type="submit"`