### PR TITLE
528 search allow users to define if they prefer recency over their level relevance

### DIFF
--- a/src/articles/CustomizeSearchToolbar.js
+++ b/src/articles/CustomizeSearchToolbar.js
@@ -1,0 +1,41 @@
+import FormGroup from "@mui/material/FormGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormHelperText from "@mui/material/FormHelperText";
+import { ThemeProvider } from "@mui/material/styles";
+import { t, Android12Switch } from "../components/MUIToggleThemes";
+import toggle from "../utils/misc/toggle";
+
+export default function CustomizeSearchToolbar({
+  searchPublishPriority,
+  setSearchPublishPriority,
+  searchDifficultyPriority,
+  setSearchDifficultyPriority,
+}) {
+  return (
+    <>
+      <ThemeProvider theme={t}>
+        <FormGroup>
+          <FormHelperText>{<small>{"Adjust search:"}</small>}</FormHelperText>
+          <FormControlLabel
+            checked={searchPublishPriority}
+            control={<Android12Switch />}
+            className={searchPublishPriority ? "selected" : ""}
+            onClick={(e) =>
+              toggle(searchPublishPriority, setSearchPublishPriority)
+            }
+            label={<small>{"Prioritize recent articles"}</small>}
+          />
+          <FormControlLabel
+            checked={searchDifficultyPriority}
+            control={<Android12Switch />}
+            className={searchDifficultyPriority ? "selected" : ""}
+            onClick={(e) =>
+              toggle(searchDifficultyPriority, setSearchDifficultyPriority)
+            }
+            label={<small>{"Prioritize articles in my level"}</small>}
+          />
+        </FormGroup>
+      </ThemeProvider>
+    </>
+  );
+}

--- a/src/articles/MySearches.js
+++ b/src/articles/MySearches.js
@@ -28,7 +28,7 @@ export default function MySearches({ api }) {
 
   async function topArticlesForSearchTerm(searchTerm) {
     return new Promise((resolve) => {
-      api.search(searchTerm, (articles) => {
+      api.latestSearch(searchTerm, (articles) => {
         const firstTwoArticles = articles.slice(0, 2);
         resolve({ searchTerm, articles: firstTwoArticles });
       });

--- a/src/articles/MySearches.js
+++ b/src/articles/MySearches.js
@@ -63,14 +63,16 @@ export default function MySearches({ api }) {
         <div key={searchTerm}>
           <d.HeadlineSavedSearches>{searchTerm}</d.HeadlineSavedSearches>
           <SubscribeSearchButton api={api} query={searchTerm} />
-
+          {articles.length === 0 && (
+            <p>No recent articles were found for this keyword.</p>
+          )}
           {articles.map((each) => (
             <ArticlePreview key={each.id} api={api} article={each} />
           ))}
           <d.buttonMoreArticles
             onClick={(e) => redirect(`/search?search=${searchTerm}`)}
           >
-            See more articles
+            {articles.length === 0 ? "Search for Keyword" : "See more articles"}
           </d.buttonMoreArticles>
         </div>
       ))}

--- a/src/articles/Search.js
+++ b/src/articles/Search.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import * as s from "./Search.sc";
 import useQuery from "../hooks/useQuery";
 import SubscribeSearchButton from "./SubscribeSearchButton";

--- a/src/articles/Search.js
+++ b/src/articles/Search.js
@@ -3,22 +3,36 @@ import * as s from "./Search.sc";
 import useQuery from "../hooks/useQuery";
 import SubscribeSearchButton from "./SubscribeSearchButton";
 import FindArticles from "./FindArticles";
+import CustomizeSearchToolbar from "./CustomizeSearchToolbar";
 
 export default function Search({ api }) {
   const searchQuery = useQuery().get("search");
+  const [searchPublishPriority, setSearchPublishPriority] = useState(false);
+  const [searchDifficultyPriority, setSearchDifficultyPriority] =
+    useState(true);
 
   return (
     <FindArticles
+      searchPublishPriority={searchPublishPriority}
+      searchDifficultyPriority={searchDifficultyPriority}
       searchQuery={searchQuery}
       content={
-        <>
-          <s.RowHeadlineSearch>
-            <s.ContainerH1Subscribe>
-              <s.HeadlineSearch>{searchQuery}</s.HeadlineSearch>
-            </s.ContainerH1Subscribe>
-          </s.RowHeadlineSearch>
-          <SubscribeSearchButton api={api} query={searchQuery} />
-        </>
+        <s.SearchTopBar>
+          <s.ContainerTitleSubscribe>
+            <s.RowHeadlineSearch>
+              <s.ContainerH1Subscribe>
+                <s.HeadlineSearch>{searchQuery}</s.HeadlineSearch>
+              </s.ContainerH1Subscribe>
+            </s.RowHeadlineSearch>
+            <SubscribeSearchButton api={api} query={searchQuery} />
+          </s.ContainerTitleSubscribe>
+          <CustomizeSearchToolbar
+            searchPublishPriority={searchPublishPriority}
+            setSearchPublishPriority={setSearchPublishPriority}
+            searchDifficultyPriority={searchDifficultyPriority}
+            setSearchDifficultyPriority={setSearchDifficultyPriority}
+          />
+        </s.SearchTopBar>
       }
     />
   );

--- a/src/articles/Search.sc.js
+++ b/src/articles/Search.sc.js
@@ -1,12 +1,25 @@
 import styled from "styled-components";
 import { almostBlack } from "../components/colors";
 
+const SearchTopBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1rem;
+  }
+`;
 const HeadlineSearch = styled.h1`
   color: ${almostBlack};
   margin: 0;
   font-size: 34px;
   font-weight: bold;
   margin-right: 1.4em;
+`;
+
+const ContainerTitleSubscribe = styled.div`
+  display: block;
 `;
 
 const ContainerH1Subscribe = styled.div`
@@ -21,4 +34,10 @@ const RowHeadlineSearch = styled.div`
   align-items: baseline;
 `;
 
-export { HeadlineSearch, RowHeadlineSearch, ContainerH1Subscribe };
+export {
+  SearchTopBar,
+  ContainerTitleSubscribe,
+  HeadlineSearch,
+  RowHeadlineSearch,
+  ContainerH1Subscribe,
+};

--- a/src/pages/_pages_shared/Tag.sc.js
+++ b/src/pages/_pages_shared/Tag.sc.js
@@ -29,15 +29,18 @@ const Tag = styled.button`
     border: 1.5px solid ${zeeguuOrange};
   }
 
+  &.small {
+    padding: 0.5rem 1rem;
+    margin: 0.25rem;
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
   &.outlined-blue {
     align-items: center;
     border: 1.5px solid ${blue500};
     background-color: ${blue200};
     color: ${blue800};
-    padding: 0.5rem 1rem;
-    margin: 0.25rem;
-    font-weight: 500;
-    font-size: 0.9rem;
   }
 
   &.selected {

--- a/src/pages/onboarding/ExcludeWordsStep2.js
+++ b/src/pages/onboarding/ExcludeWordsStep2.js
@@ -70,7 +70,7 @@ export default function ExcludeWordsStep2({ api, hasExtension }) {
           {unwantedKeywords.map((keyword) => (
             <div key={keyword.id} id={keyword.id}>
               <Tag
-                className={"outlined-blue"}
+                className={"outlined-blue small"}
                 onClick={() => removeUnwantedKeyword(keyword)}
               >
                 {keyword.search}

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -27,7 +27,6 @@ import useShadowRef from "../hooks/useShadowRef";
 import strings from "../i18n/definitions";
 import { getScrollRatio } from "../utils/misc/getScrollLocation";
 import useUserPreferences from "../hooks/useUserPreferences";
-import toggle from "../utils/misc/toggle";
 
 export const UMR_SOURCE = "UMR";
 

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -27,6 +27,7 @@ import useShadowRef from "../hooks/useShadowRef";
 import strings from "../i18n/definitions";
 import { getScrollRatio } from "../utils/misc/getScrollLocation";
 import useUserPreferences from "../hooks/useUserPreferences";
+import toggle from "../utils/misc/toggle";
 
 export const UMR_SOURCE = "UMR";
 
@@ -42,10 +43,6 @@ export function onFocus(api, articleID, source) {
 
 export function onBlur(api, articleID, source) {
   api.logReaderActivity(api.ARTICLE_UNFOCUSED, articleID, "", source);
-}
-
-export function toggle(state, togglerFunction) {
-  togglerFunction(!state);
 }
 
 export default function ArticleReader({ api, teacherArticleID }) {

--- a/src/reader/ToolbarButtons.js
+++ b/src/reader/ToolbarButtons.js
@@ -1,5 +1,5 @@
 import * as s from "./ArticleReader.sc";
-import { toggle } from "./ArticleReader";
+import toggle from "../utils/misc/toggle";
 import * as React from "react";
 import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";

--- a/src/utils/misc/toggle.js
+++ b/src/utils/misc/toggle.js
@@ -1,0 +1,3 @@
+export default function toggle(state, togglerFunction) {
+  togglerFunction(!state);
+}


### PR DESCRIPTION
Added a way to allow users to customize their search. These changes go with the API PR: https://github.com/zeeguu/api/pull/207

## Preview

https://github.com/user-attachments/assets/11dc7c59-b422-4398-a297-a7b5a18199f8

## Changes

- Endpoints for Search now send the state of the user preferences. Currently, we have a default for the search which is prioritizing the Keyword and Level. At the moment this is always used by default and the user can then toggle their preferences.
- Added the component CustomizeSearchToolbar, which display the buttons. This removes the sort by length / difficulty in the UI.
- Fixed a bug where the UI would say no more articles were available, when that wasn't the case.
- Change the call in MySearches to get the latest articles available for the users level. Showing a message in case no article is found. 



