### PR TITLE
Check at the end of the session

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -166,7 +166,6 @@ export default function Exercises({
   }
   function startExercising(is_new_scheduled_words) {
     resetExerciseState();
-    updateIsAbleToAddNewBookmarksToStudy();
     if (is_new_scheduled_words) {
       exercise_new_bookmarks();
     } else {
@@ -305,6 +304,7 @@ export default function Exercises({
     exerciseNotification.updateReactState();
     if (newIndex === fullExerciseProgression.length) {
       setFinished(true);
+      updateIsAbleToAddNewBookmarksToStudy();
       return;
     }
     setCurrentBookmarksToStudy(fullExerciseProgression[newIndex].bookmarks);


### PR DESCRIPTION
- When checking at the start of words that are being added to learning, then the final congratulation screen will still show new words are available (while referring to the words the user just learned).

Checking at the finished, will fix this as it will see that the words have been moved to the scheduler.