### PR TITLE
Fixed toggle not switching on text-click

### DIFF
--- a/src/articles/CustomizeSearchToolbar.js
+++ b/src/articles/CustomizeSearchToolbar.js
@@ -18,20 +18,26 @@ export default function CustomizeSearchToolbar({
           <FormHelperText>{<small>{"Adjust search:"}</small>}</FormHelperText>
           <FormControlLabel
             checked={searchPublishPriority}
-            control={<Android12Switch />}
-            className={searchPublishPriority ? "selected" : ""}
-            onClick={(e) =>
-              toggle(searchPublishPriority, setSearchPublishPriority)
+            control={
+              <Android12Switch
+                onClick={(e) =>
+                  toggle(searchPublishPriority, setSearchPublishPriority)
+                }
+              />
             }
+            className={searchPublishPriority ? "selected" : ""}
             label={<small>{"Prioritize recent articles"}</small>}
           />
           <FormControlLabel
             checked={searchDifficultyPriority}
-            control={<Android12Switch />}
-            className={searchDifficultyPriority ? "selected" : ""}
-            onClick={(e) =>
-              toggle(searchDifficultyPriority, setSearchDifficultyPriority)
+            control={
+              <Android12Switch
+                onClick={(e) =>
+                  toggle(searchDifficultyPriority, setSearchDifficultyPriority)
+                }
+              />
             }
+            className={searchDifficultyPriority ? "selected" : ""}
             label={<small>{"Prioritize articles in my level"}</small>}
           />
         </FormGroup>

--- a/src/reader/ToolbarButtons.js
+++ b/src/reader/ToolbarButtons.js
@@ -22,16 +22,22 @@ export default function ToolbarButtons({
           </FormHelperText>
           <FormControlLabel
             checked={translating}
-            control={<Android12Switch />}
+            control={
+              <Android12Switch
+                onClick={(e) => toggle(translating, setTranslating)}
+              />
+            }
             className={translating ? "selected" : ""}
-            onClick={(e) => toggle(translating, setTranslating)}
             label={<small>{"See translation"}</small>}
           />
           <FormControlLabel
             checked={pronouncing}
-            control={<Android12Switch />}
+            control={
+              <Android12Switch
+                onClick={(e) => toggle(pronouncing, setPronouncing)}
+              />
+            }
             className={pronouncing ? "selected" : ""}
-            onClick={(e) => toggle(pronouncing, setPronouncing)}
             label={<small>{"Hear pronunciation"}</small>}
           />
         </FormGroup>


### PR DESCRIPTION
- By passing the onClick function to the switch, the FormControl will still activate the onClick function. This results in a user being able to click the control or text to switch the state.

This change was applied to both the reader and the search toggle.

https://github.com/user-attachments/assets/a34f19bc-b812-4117-8295-bdc5b6f9ac94

