### PR TITLE
Autofocus the form not the text

### DIFF
--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -77,7 +77,7 @@ export default function WordEditForm({
       ) : (
         <s.Headline>{strings.editWord}</s.Headline>
       )}
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} autoFocus={true}>
         {errorMessage && <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>}
         {isBookmarkExpression(bookmark) ? (
           <s.CustomTextField
@@ -86,7 +86,6 @@ export default function WordEditForm({
             variant="outlined"
             fullWidth
             value={expression}
-            autoFocus={true}
             onChange={typingExpression}
           />
         ) : (
@@ -96,7 +95,6 @@ export default function WordEditForm({
             variant="outlined"
             fullWidth
             value={expression}
-            autoFocus={true}
             onChange={typingExpression}
           />
         )}


### PR DESCRIPTION
I am unable to test on my phone (having problems accessing the Dev deployment again), but I set the focus to the form rather than the fields, so I don't think the Keyboard should come up in that case.