### PR TITLE
BUG Infinite Loading when no scheduled bookmarks are available for exercises

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -126,6 +126,7 @@ export default function Exercises({
       // that we tried to schedule new bookmarks but none
       // were found.
       setShowOutOfWordsMessage(true);
+      updateIsAbleToAddNewBookmarksToStudy();
       return;
     }
     setCountBookmarksToPractice(bookmarks.length);


### PR DESCRIPTION
- Fixed by checking if there are no bookmarks fetched we also set the state of being able to addBookmarks so the correct page can be rendered.