### PR TITLE
555 inform the user that a search yielded no results

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -216,6 +216,12 @@ export default function FindArticles({
         </>
       )}
 
+      {searchQuery && (
+        <s.SearchHolder>
+          <SearchField api={api} query={searchQuery} />
+        </s.SearchHolder>
+      )}
+
       {/* This is where the content of the Search component will be rendered */}
       {content}
       {reloadingSearchArticles && <LoadingAnimation></LoadingAnimation>}
@@ -235,6 +241,9 @@ export default function FindArticles({
             onArticleClick={() => handleArticleClick(each.id, index)}
           />
         ))}
+      {!reloadingSearchArticles && articleList.length === 0 && (
+        <p>No searches were found for this query.</p>
+      )}
 
       {!searchQuery && (
         <>

--- a/src/articles/SearchField.js
+++ b/src/articles/SearchField.js
@@ -1,7 +1,10 @@
 import { useRef, useState } from "react";
 import strings from "../i18n/definitions";
 import * as s from "./SearchField.sc";
-import { ClearSearchButton } from "../components/allButtons.sc";
+import {
+  ClearSearchButton,
+  ZeeguuSearchIcon,
+} from "../components/allButtons.sc";
 import redirect from "../utils/routing/routing";
 
 export default function SearchField({ api, query }) {
@@ -56,14 +59,7 @@ export default function SearchField({ api, query }) {
       )}
 
       <a style={{ cursor: "pointer" }} onClick={(e) => handleSearch()}>
-        <svg
-          focusable="false"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          style={{ width: "1.8em", fill: "orange" }}
-        >
-          <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-        </svg>
+        <ZeeguuSearchIcon />
       </a>
     </s.SearchField>
   );

--- a/src/articles/SearchField.js
+++ b/src/articles/SearchField.js
@@ -1,10 +1,7 @@
 import { useRef, useState } from "react";
 import strings from "../i18n/definitions";
 import * as s from "./SearchField.sc";
-import {
-  ClearSearchButton,
-  ZeeguuSearchIcon,
-} from "../components/allButtons.sc";
+import { ClearSearchButton, SearchIcon } from "../components/allButtons.sc";
 import redirect from "../utils/routing/routing";
 
 export default function SearchField({ api, query }) {
@@ -59,7 +56,7 @@ export default function SearchField({ api, query }) {
       )}
 
       <a style={{ cursor: "pointer" }} onClick={(e) => handleSearch()}>
-        <ZeeguuSearchIcon />
+        <SearchIcon />
       </a>
     </s.SearchField>
   );

--- a/src/components/allButtons.sc.js
+++ b/src/components/allButtons.sc.js
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { zeeguuOrange, lightOrange, lightGrey } from "./colors";
-import SearchIcon from "@mui/icons-material/Search";
+import MUISearchIcon from "@mui/icons-material/Search";
 
 const RoundButton = styled.div`
   user-select: none;
@@ -24,7 +24,7 @@ const OrangeRoundButton = styled(RoundButton)`
   background-color: ${zeeguuOrange};
 `;
 
-const ZeeguuSearchIcon = styled(SearchIcon)`
+const SearchIcon = styled(MUISearchIcon)`
   color: ${zeeguuOrange};
   &:hover {
     filter: brightness(120%);
@@ -126,5 +126,5 @@ export {
   BigSquareButton,
   ClearSearchButton,
   StyledButton,
-  ZeeguuSearchIcon,
+  SearchIcon,
 };

--- a/src/components/allButtons.sc.js
+++ b/src/components/allButtons.sc.js
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { zeeguuOrange, lightOrange, lightGrey } from "./colors";
+import SearchIcon from "@mui/icons-material/Search";
 
 const RoundButton = styled.div`
   user-select: none;
@@ -23,21 +24,32 @@ const OrangeRoundButton = styled(RoundButton)`
   background-color: ${zeeguuOrange};
 `;
 
+const ZeeguuSearchIcon = styled(SearchIcon)`
+  color: ${zeeguuOrange};
+  &:hover {
+    filter: brightness(120%);
+  }
+`;
+
 // from: https://stackoverflow.com/questions/10019797/pure-css-close-button
 const ClearSearchButton = styled.div`
   display: block;
   float: left;
-  margin-top: 3px;
+  margin-top: 2px;
   margin-left: -1.6em;
   box-sizing: border-box;
   width: 1.4em;
   height: 1.4em;
-
+  cursor: pointer;
   border-width: 3px;
   border-style: solid;
   border-color: white;
   border-radius: 100%;
-  background: -webkit-linear-gradient(
+  &:hover {
+    filter: brightness(120%);
+  }
+  background:
+    -webkit-linear-gradient(
       -45deg,
       transparent 0%,
       transparent 46%,
@@ -65,26 +77,26 @@ const BigSquareButton = styled(RoundButton)`
 `;
 
 const StyledButton = styled.button`
-color: black;
-height: auto;
-display: flex;
-padding: 1em;
-margin: 1em;
-border-style: none;
-border-width: 2px;
-border-radius: 10px;
-font-size: 1em;
-font-weight: bold;
-cursor: pointer;
-align-items: center;
-justify-content: center;
+  color: black;
+  height: auto;
+  display: flex;
+  padding: 1em;
+  margin: 1em;
+  border-style: none;
+  border-width: 2px;
+  border-radius: 10px;
+  font-size: 1em;
+  font-weight: bold;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
 
-// Primary
+  // Primary
   ${(props) =>
     props.primary &&
     css`
       background-color: ${zeeguuOrange};
-      :hover{
+      :hover {
         background-color: ${lightOrange};
       }
     `}
@@ -94,7 +106,7 @@ justify-content: center;
     props.secondary &&
     css`
       background-color: white;
-      :hover{
+      :hover {
         text-decoration: underline;
       }
     `}
@@ -108,5 +120,11 @@ justify-content: center;
     `}
 `;
 
-
-export { RoundButton, OrangeRoundButton, BigSquareButton, ClearSearchButton, StyledButton};
+export {
+  RoundButton,
+  OrangeRoundButton,
+  BigSquareButton,
+  ClearSearchButton,
+  StyledButton,
+  ZeeguuSearchIcon,
+};


### PR DESCRIPTION
## Changes:

- Use mui/icons-material for the search icon rather than a svg tag (that is already handled by the mui component).
- Add an on hover brightness and pointer to the buttons in the search.
- Better aligned the cross to not overlap the border.
- Added the search bar to when a user search something they can easily change it without having to go back to home
- Added a string when a search yields no changes

## Preview

### Empty search message:

![{3D748F60-678A-4B69-AEC4-6DA38029711E}](https://github.com/user-attachments/assets/de747b45-7aa9-4044-875c-82390e52969d)

### New icon + Hover effects

https://github.com/user-attachments/assets/082cb83e-bf57-4f1f-a20a-67e8abb4ed75


