### PR TITLE
Moved the Logout from Sidebar to Profile Details

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -9,7 +9,6 @@ import { APIContext } from "../contexts/APIContext";
 import { ExerciseCountContext } from "../exercises/ExerciseCountContext";
 import NotificationIcon from "./NotificationIcon";
 import SettingsIcon from "@mui/icons-material/Settings";
-import LogoutIcon from "@mui/icons-material/Logout";
 import { Tooltip } from "@mui/material";
 
 export default function SideBar(props) {
@@ -102,20 +101,6 @@ export default function SideBar(props) {
                 sx={{ color: "white" }}
               />
             </a>
-          </Tooltip>
-          <Tooltip title="Logout">
-            <Link
-              to="/"
-              onClick={() => {
-                user.logoutMethod();
-              }}
-            >
-              <LogoutIcon
-                fontSize="large"
-                className="navigationIcon"
-                sx={{ color: "white" }}
-              />
-            </Link>
           </Tooltip>
         </div>
       </div>

--- a/src/components/allButtons.sc.js
+++ b/src/components/allButtons.sc.js
@@ -13,10 +13,17 @@ const RoundButton = styled.div`
   color: white !important;
   font-weight: 500;
   text-align: center;
+  vertical
 
   cursor: pointer;
   margin-top: 3px;
   box-sizing: border-box;
+`;
+
+const WhiteRoundButton = styled(RoundButton)`
+  background-color: white;
+  color: ${zeeguuOrange} !important;
+  border: 2px solid ${zeeguuOrange};
 `;
 
 const OrangeRoundButton = styled(RoundButton)`
@@ -37,7 +44,8 @@ const ClearSearchButton = styled.div`
   border-style: solid;
   border-color: white;
   border-radius: 100%;
-  background: -webkit-linear-gradient(
+  background:
+    -webkit-linear-gradient(
       -45deg,
       transparent 0%,
       transparent 46%,
@@ -65,26 +73,26 @@ const BigSquareButton = styled(RoundButton)`
 `;
 
 const StyledButton = styled.button`
-color: black;
-height: auto;
-display: flex;
-padding: 1em;
-margin: 1em;
-border-style: none;
-border-width: 2px;
-border-radius: 10px;
-font-size: 1em;
-font-weight: bold;
-cursor: pointer;
-align-items: center;
-justify-content: center;
+  color: black;
+  height: auto;
+  display: flex;
+  padding: 1em;
+  margin: 1em;
+  border-style: none;
+  border-width: 2px;
+  border-radius: 10px;
+  font-size: 1em;
+  font-weight: bold;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
 
-// Primary
+  // Primary
   ${(props) =>
     props.primary &&
     css`
       background-color: ${zeeguuOrange};
-      :hover{
+      :hover {
         background-color: ${lightOrange};
       }
     `}
@@ -94,7 +102,7 @@ justify-content: center;
     props.secondary &&
     css`
       background-color: white;
-      :hover{
+      :hover {
         text-decoration: underline;
       }
     `}
@@ -108,5 +116,11 @@ justify-content: center;
     `}
 `;
 
-
-export { RoundButton, OrangeRoundButton, BigSquareButton, ClearSearchButton, StyledButton};
+export {
+  RoundButton,
+  OrangeRoundButton,
+  WhiteRoundButton,
+  BigSquareButton,
+  ClearSearchButton,
+  StyledButton,
+};

--- a/src/pages/Settings/LogOutButton.js
+++ b/src/pages/Settings/LogOutButton.js
@@ -1,0 +1,19 @@
+import { LogOutButtonStyle } from "./LogOutButton.sc";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { zeeguuOrange } from "../../components/colors";
+import { useContext } from "react";
+import { UserContext } from "../../contexts/UserContext";
+
+export default function LogOutButton({}) {
+  const user = useContext(UserContext);
+  return (
+    <LogOutButtonStyle
+      onClick={() => {
+        user.logoutMethod();
+      }}
+    >
+      Log Out{" "}
+      <LogoutIcon className="navigationIcon" sx={{ color: zeeguuOrange }} />
+    </LogOutButtonStyle>
+  );
+}

--- a/src/pages/Settings/LogOutButton.sc.js
+++ b/src/pages/Settings/LogOutButton.sc.js
@@ -1,0 +1,28 @@
+import { zeeguuDarkOrange } from "../../components/colors";
+import { WhiteRoundButton } from "../../components/allButtons.sc";
+import styled from "styled-components";
+
+const LogOutButtonStyle = styled(WhiteRoundButton)`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.7em 2em;
+  border-radius: 4em;
+  font-weight: 600;
+  box-shadow: 0 0.2em ${zeeguuDarkOrange};
+  transition: all ease-in 0.08s;
+  overflow: hidden;
+  white-space: nowrap;
+  margin-bottom: 1rem;
+  margin-top: 2rem;
+
+  &:active {
+    box-shadow: none;
+    transform: translateY(0.2em);
+    transition: all ease-in 0.08s;
+  }
+`;
+
+export { LogOutButtonStyle };

--- a/src/pages/Settings/LogOutButton.sc.js
+++ b/src/pages/Settings/LogOutButton.sc.js
@@ -17,6 +17,7 @@ const LogOutButtonStyle = styled(WhiteRoundButton)`
   white-space: nowrap;
   margin-bottom: 1rem;
   margin-top: 2rem;
+  cursor: pointer;
 
   &:active {
     box-shadow: none;

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -17,6 +17,7 @@ import BackArrow from "./settings_pages_shared/BackArrow";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg";
 
 import LoadingAnimation from "../../components/LoadingAnimation";
+import LogOutButton from "./LogOutButton";
 
 export default function ProfileDetails({ api, setUser }) {
   const [userDetails, setUserDetails] = useState(null);
@@ -106,6 +107,9 @@ export default function ProfileDetails({ api, setUser }) {
             </Button>
           </ButtonContainer>
         </Form>
+        <ButtonContainer className={"adaptive-alignment-horizontal"}>
+          <LogOutButton />
+        </ButtonContainer>
       </Main>
     </PreferencesPage>
   );

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -42,7 +42,6 @@ export default function Settings() {
         <SettingsItem path={"/account_settings/interests"}>
           {strings.interests}
         </SettingsItem>
-        <LogOutButton />
       </ListOfSettingsItems>
       <ListOfSettingsItems header={strings.exercises}>
         <SettingsItem path={"/account_settings/exercise_type_preferences"}>

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -8,7 +8,6 @@ import SettingsItem from "./settings_pages_shared/SettingsItem";
 import ListOfSettingsItems from "./settings_pages_shared/ListOfSettingsItems";
 
 import * as s from "./Settings.sc";
-import LogOutButton from "./LogOutButton";
 
 export default function Settings() {
   const user = useContext(UserContext);

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -8,6 +8,7 @@ import SettingsItem from "./settings_pages_shared/SettingsItem";
 import ListOfSettingsItems from "./settings_pages_shared/ListOfSettingsItems";
 
 import * as s from "./Settings.sc";
+import LogOutButton from "./LogOutButton";
 
 export default function Settings() {
   const user = useContext(UserContext);
@@ -41,8 +42,8 @@ export default function Settings() {
         <SettingsItem path={"/account_settings/interests"}>
           {strings.interests}
         </SettingsItem>
+        <LogOutButton />
       </ListOfSettingsItems>
-
       <ListOfSettingsItems header={strings.exercises}>
         <SettingsItem path={"/account_settings/exercise_type_preferences"}>
           {strings.exerciseTypePreferences}


### PR DESCRIPTION
Our logout button was too close to the settings button on mobile, which can lead to misclicks. Also, it's not a very common action for users, so it doesn't need to be so easily accessible.

## Changes:
- Added a new WhiteRoundButton which is inverted of the orange button.
- Moved logout button to the Profile Details
- The Button is White Button to differentiate it from the Save Button

## Preview:

| Desktop | Phone |
| :-: | :-: |
| ![{3246C99E-CDD8-496F-8BCC-AF44479194C3}](https://github.com/user-attachments/assets/aeb03983-c3ea-427b-97a2-30c349be6281) | ![{FCFAAD03-002F-44D9-9947-69F5C915661D}](https://github.com/user-attachments/assets/77cd2313-4189-46a2-bc5c-79831860fa6f)  |
|   |  ![{6CF50DF8-75A8-44B4-A523-242BED62C3E9}](https://github.com/user-attachments/assets/0878f07b-f662-4983-ae4a-db30c7be5d8a)  |