### PR TITLE
Fix to Exercises not rendering when new words are being tested

### DIFF
--- a/src/exercises/LearningCycleIndicator.js
+++ b/src/exercises/LearningCycleIndicator.js
@@ -30,6 +30,9 @@ export default function LearningCycleIndicator({
       return "/static/icons/active-icon-lightGrey.png";
     }
     switch (LEARNING_CYCLE_NAME[learningCycle]) {
+      // If there is no learning cycle (it is a new word) treat as
+      // receptive.
+      case "not set":
       case "receptive":
         return "/static/icons/receptive-icon.png";
       case "productive":
@@ -41,6 +44,9 @@ export default function LearningCycleIndicator({
 
   const getTooltipContent = () => {
     switch (LEARNING_CYCLE_NAME[learningCycle]) {
+      // If there is no learning cycle (it is a new word) treat as
+      // receptive.
+      case "not set":
       case "receptive":
         return strings.receptiveTooltip;
       case "productive":

--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -29,7 +29,9 @@ function getMemoryTask(bookmark) {
   return memoryTask;
 }
 function getBookmarkCycleTaskKey(b) {
-  return [b.learning_cycle, getMemoryTask(b)];
+  // If there is no learning cycle (it is a new word) treat as
+  // receptive.
+  return [b.learning_cycle === 0 ? 1 : b.learning_cycle, getMemoryTask(b)];
 }
 
 function getExerciseCycleTaskKey(e) {

--- a/src/words/Learning.js
+++ b/src/words/Learning.js
@@ -122,7 +122,7 @@ export default function Learning({ api }) {
           <div className="top-message-icon">{strings.toLearnMsg}</div>
         </s.TopMessage>
         {toLearnWords.length === 0 ? (
-          <s.TopMessage>{strings.noProductiveWords}</s.TopMessage>
+          <s.TopMessage>{strings.noToLearnWords}</s.TopMessage>
         ) : (
           toLearnWords.map((each) => (
             <Word


### PR DESCRIPTION
- New words weren't being assigned due to the fact that we do exercises based on the learning cycle, and there were none defined for a not set word (which now happens as they aren't scheduled)

This only seems to happen to the Merle branch (as it has to do with the way we assign exercises)

- I also saw that the wrong message was being used in the Not To Learn words, so I made this fix also in this PR.