### PR TITLE
Update Speech once there is a learned_language update

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,12 @@ function App() {
   let { handleRedirectLinkOrGoTo } = useRedirectLink();
 
   useEffect(() => {
+    if (userData && userData.learned_language) {
+      setZeeguuSpeech(new ZeeguuSpeech(api, userData.learned_language));
+    }
+  }, [userData]);
+
+  useEffect(() => {
     console.log("Got the API URL:" + API_ENDPOINT);
     console.log("Got the Domain URL:" + APP_DOMAIN);
     console.log("Extension ID: " + process.env.REACT_APP_EXTENSION_ID);


### PR DESCRIPTION
- We fixed this for the reader by checking the article language was different than the speech language, but the context might not be updated when we change the languages.
- To ensure this doesn't happen, when the learned language is set, we update the ZeeguuSpeech context to be based on the userData learned language.

This is a very edge case, as we are likely to not have users practice multiple languages in a row. 