### PR TITLE
Hide the logout container if sidebar is minized

### DIFF
--- a/src/components/SideBar.sc.js
+++ b/src/components/SideBar.sc.js
@@ -115,6 +115,10 @@ const sidebarMinimizedCommon = css`
   .navigationLink {
     display: none;
   }
+
+  .SettingsLogoutContainer {
+    display: none;
+  }
 `;
 
 const navigationVisibleCommon = css`
@@ -133,6 +137,7 @@ const navigationVisibleCommon = css`
   }
 
   .SettingsLogoutContainer {
+    display: block;
     position: absolute;
     bottom: 2.5rem;
     width: 100%;


### PR DESCRIPTION
- The Settings and the Feedback button were still being rendered, albeit not visible, while the sidebar was minimized. This change forces the component to `display:none` if it's collapsed.

This is particularly evident with High Contrast mode:

| Desktop High Contrast (with Fix) | (without Fix) |
| :-: | :-: |
| ![{70E098CB-A798-4326-903B-3E7104367AE6}](https://github.com/user-attachments/assets/b40d1c98-7495-4896-944f-362ad7227bc4) | ![{D626079B-3453-43BD-9124-063C8E9BE8E1}](https://github.com/user-attachments/assets/17c77f84-dce2-4e66-8d83-abf1c7d73aa6) |

| Desktop No Constrast (with Fix) | (without Fix) |
| :-: | :-: |
| ![{720D54F7-37AC-4AA3-9339-D27792731124}](https://github.com/user-attachments/assets/52a426f5-591a-46c1-8dfa-cc8dfb48c548) | ![{8FEFD50A-A382-4629-BB0D-8D83E24541A5}](https://github.com/user-attachments/assets/f92c15bf-50a6-4620-a714-fc867680e30b) |
| | ![{2442C530-8570-4A27-8744-F81B1697AF20}](https://github.com/user-attachments/assets/2b502874-beab-4521-885a-cfd67d9e9af8) |




P.S. Thanks to Theodor for having High Contrast On otherwise this would have slipped under the radar for a while. 