### PR TITLE
Added api to ArticlePreview in Classroom

### DIFF
--- a/src/articles/ClassroomArticles.js
+++ b/src/articles/ClassroomArticles.js
@@ -65,6 +65,7 @@ export default function ClassroomArticles({ api }) {
       />
       {articleList.map((each) => (
         <ArticlePreview
+          api={api}
           key={each.id}
           article={each}
           dontShowSourceIcon={true}


### PR DESCRIPTION
Today, a user attempted to save an article from the classroom page which raised an exception in Sentry.

It seems the api was not being passed to the ArticlePreview, which is required to save / unsave the article.