### PR TITLE
headline changes to translation when solution is shown

### DIFF
--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -88,6 +88,7 @@ export default function MultipleChoiceContext({
     setIsCorrect(true);
     handleAnswer(message);
     setShowSolution(true);
+    setWordInContextHeadline(removePunctuation(bookmarksToStudy[0].to));
   }
 
   function notifyChoiceSelection(


### PR DESCRIPTION
The translation of the bookmark is now also shown in the headline when the user chooses to show the solution.
<img width="592" alt="Screenshot 2024-10-17 at 13 57 13" src="https://github.com/user-attachments/assets/33776879-72f0-4517-b502-d0d3638fcddf">
