### PR TITLE
Added prefixMsg to Feedback and pass the exerciseType + Bookmark ID when in exercise. 

### DIFF
--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -9,6 +9,7 @@ export default function FeedbackButton() {
   return (
     <>
       <FeedbackModal
+        prefixMsg={"Sidebar"}
         open={showFeedbackModal}
         setOpen={() => {
           setShowFeedbackModal(!showFeedbackModal);

--- a/src/components/FeedbackModal.js
+++ b/src/components/FeedbackModal.js
@@ -14,7 +14,12 @@ import Header from "./modal_shared/Header.sc.js";
 import Heading from "./modal_shared/Heading.sc.js";
 import { FEEDBACK_CODES, FEEDBACK_CODES_NAME } from "./FeedbackConstants.js";
 
-export default function FeedbackModal({ open, setOpen, feedbackOptions }) {
+export default function FeedbackModal({
+  open,
+  setOpen,
+  feedbackOptions,
+  prefixMsg,
+}) {
   let api = useContext(APIContext);
   const [feedbackComponentSelected, setFeedbackComponentSelected] =
     useFormField(FEEDBACK_CODES_NAME.OTHER);
@@ -23,7 +28,9 @@ export default function FeedbackModal({ open, setOpen, feedbackOptions }) {
   function onSubmit(e) {
     e.preventDefault();
     let payload = {
-      message: feedbackMessage,
+      message: prefixMsg
+        ? prefixMsg + " - " + feedbackMessage
+        : feedbackMessage,
       feedbackComponentId: feedbackComponentSelected,
       currentUrl: window.location.href,
     };

--- a/src/components/LoadingAnimation.js
+++ b/src/components/LoadingAnimation.js
@@ -32,6 +32,7 @@ export default function LoadingAnimation({
   return (
     <>
       <FeedbackModal
+        prefixMsg={"Loading"}
         open={showFeedbackModal}
         setOpen={() => {
           setShowFeedbackModal(!showFeedbackModal);

--- a/src/exercises/exerciseTypes/NextNavigation.js
+++ b/src/exercises/exerciseTypes/NextNavigation.js
@@ -285,7 +285,7 @@ export default function NextNavigation({
         </s.StyledGreyButton>
       )}
       <SolutionFeedbackLinks
-        api={api}
+        prefixMsg={`${exerciseType}-(${exerciseBookmark.id})`}
         handleShowSolution={handleShowSolution}
         toggleShow={toggleShow}
         isCorrect={isCorrect}

--- a/src/exercises/exerciseTypes/SolutionFeedbackLinks.js
+++ b/src/exercises/exerciseTypes/SolutionFeedbackLinks.js
@@ -5,7 +5,7 @@ import FeedbackModal from "../../components/FeedbackModal";
 import { FEEDBACK_OPTIONS } from "../../components/FeedbackConstants";
 
 export default function SolutionFeedbackLinks({
-  api,
+  prefixMsg,
   handleShowSolution,
   toggleShow,
   isCorrect,
@@ -15,6 +15,7 @@ export default function SolutionFeedbackLinks({
   return (
     <s.CenteredRow>
       <FeedbackModal
+        prefixMsg={prefixMsg}
         open={openFeedback}
         setOpen={setOpenFeedback}
         feedbackOptions={FEEDBACK_OPTIONS.EXERCISE}

--- a/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
+++ b/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
@@ -138,6 +138,7 @@ export default function FindWordInContextCloze({
 
       <NextNavigation
         message={messageToAPI}
+        exerciseType={EXERCISE_TYPE}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}
         moveToNextExercise={moveToNextExercise}

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -153,6 +153,7 @@ export default function MultipleChoice({
         />
       )}
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
+++ b/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
@@ -251,6 +251,7 @@ export default function MultipleChoiceAudio({
         </>
       )}
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -182,6 +182,7 @@ export default function MultipleChoiceContext({
       ))}
 
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
+++ b/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
@@ -142,6 +142,7 @@ export default function MultipleChoiceL2toL1({
         />
       )}
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -1182,6 +1182,7 @@ export default function OrderWords({
           </div>
         )}
         <NextNavigation
+          exerciseType={EXERCISE_TYPE}
           message={messageToAPI}
           api={api}
           // Added an empty bookmark to avoid showing the

--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -179,6 +179,7 @@ export default function SpellWhatYouHear({
         </>
       )}
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         api={api}
         message={messageToAPI}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
+++ b/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
@@ -143,6 +143,7 @@ export default function TranslateL2toL1({
       )}
 
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -179,6 +179,7 @@ export default function TranslateWhatYouHear({
         </>
       )}
       <NextNavigation
+        exerciseType={EXERCISE_TYPE}
         api={api}
         message={messageToAPI}
         exerciseBookmark={bookmarksToStudy[0]}

--- a/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
+++ b/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
@@ -195,6 +195,7 @@ export default function WordInContextExercise({
         />
       )}
       <NextNavigation
+        exerciseType={exerciseType}
         message={messageToAPI}
         api={api}
         exerciseBookmark={bookmarksToStudy[0]}


### PR DESCRIPTION
- When giving feedback we might want to give some prefix to add some information. In this case, when users use the exercise Msg, we would like to know the exercise type and bookmark, and with that we can investigate better the issue they report.
- Removed api, as it isn't used for the feedback.
- Added a prefix message reporting where the feedback is sent from (Loading / Exercise / Sidebar)

Example:

![{EF7A4E7E-9E6F-469D-9F4D-72EFD4EA867C}](https://github.com/user-attachments/assets/c5e1e66a-56f6-45da-b230-91a8a308eb91)

