### PR TITLE
added context to TranslateWhatYouHear and removed extra hint from exercise

### DIFF
--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -12,10 +12,7 @@ export const EXERCISE_TYPES = {
   findWordInContext: "Recognize_L1W_in_L2T",
 
   isTranslationExercise: function (exerciseType) {
-    return (
-      exerciseType === this.translateWhatYouHear ||
-      exerciseType === this.multipleChoice
-    );
+    return exerciseType === this.multipleChoice;
   },
 
   isMultiBookmarkExercise: function (exerciseType) {

--- a/src/exercises/ExerciseTypeConstants.js
+++ b/src/exercises/ExerciseTypeConstants.js
@@ -11,10 +11,6 @@ export const EXERCISE_TYPES = {
   clickWordInContext: "Click_L1W_in_L2T",
   findWordInContext: "Recognize_L1W_in_L2T",
 
-  isTranslationExercise: function (exerciseType) {
-    return exerciseType === this.multipleChoice;
-  },
-
   isMultiBookmarkExercise: function (exerciseType) {
     return [
       this.multipleChoice,

--- a/src/exercises/exerciseTypes/BottomInput.js
+++ b/src/exercises/exerciseTypes/BottomInput.js
@@ -17,7 +17,6 @@ export default function BottomInput({
   messageToAPI,
   setMessageToAPI,
   isL1Answer,
-  onHintUsed,
   exerciseType,
 }) {
   const [currentInput, setCurrentInput] = useState("");
@@ -44,7 +43,12 @@ export default function BottomInput({
   function handleHint() {
     setUsedHint(true);
     let hint;
-    if (currentInput === targetWord.substring(0, currentInput.length)) {
+    const lowerCurrentInput = currentInput.toLowerCase();
+    const lowerTargetWord = targetWord.toLowerCase();
+    if (
+      lowerCurrentInput ===
+      lowerTargetWord.substring(0, lowerCurrentInput.length)
+    ) {
       hint = targetWord.substring(0, currentInput.length + 1);
     } else {
       hint = targetWord.substring(0, 1);

--- a/src/exercises/exerciseTypes/BottomInput.js
+++ b/src/exercises/exerciseTypes/BottomInput.js
@@ -29,7 +29,6 @@ export default function BottomInput({
   const [isInputWrongLanguage, setIsInputWrongLanguage] = useState(false);
   const [isOneWordCorrect, setIsOneWordCorrect] = useState(false);
   const [feedbackMessage, setFeedbackMessage] = useState("");
-  const [firstHint, setFirstHint] = useState(true);
   const levenshtein = require("fast-levenshtein");
 
   const normalizedLearningWord = normalizeAnswer(bookmarksToStudy[0].from);
@@ -43,20 +42,15 @@ export default function BottomInput({
     : bookmarksToStudy[0].from_lang;
 
   function handleHint() {
-    if (exerciseType === EXERCISE_TYPES.translateWhatYouHear && firstHint) {
-      setFirstHint(false);
-      onHintUsed();
+    setUsedHint(true);
+    let hint;
+    if (currentInput === targetWord.substring(0, currentInput.length)) {
+      hint = targetWord.substring(0, currentInput.length + 1);
     } else {
-      setUsedHint(true);
-      let hint;
-      if (currentInput === targetWord.substring(0, currentInput.length)) {
-        hint = targetWord.substring(0, currentInput.length + 1);
-      } else {
-        hint = targetWord.substring(0, 1);
-      }
-      setCurrentInput(hint);
-      setMessageToAPI(messageToAPI + "H");
+      hint = targetWord.substring(0, 1);
     }
+    setCurrentInput(hint);
+    setMessageToAPI(messageToAPI + "H");
   }
 
   // Update the feedback message

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -136,6 +136,7 @@ export default function MultipleChoice({
           translating={true}
           pronouncing={false}
           bookmarkToStudy={bookmarksToStudy[0].from}
+          exerciseType={EXERCISE_TYPE}
         />
       </div>
 

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -14,7 +14,7 @@ import DisableAudioSession from "../DisableAudioSession.js";
 import useSubSessionTimer from "../../../hooks/useSubSessionTimer.js";
 import LearningCycleIndicator from "../../LearningCycleIndicator.js";
 
-// The user has to translate the word they hear into their L1. A L2 context with the word is shown when clicking the Hint button.
+// The user has to translate the word they hear into their L1.
 // This tests the user's passive knowledge.
 
 const EXERCISE_TYPE = EXERCISE_TYPES.translateWhatYouHear;
@@ -138,18 +138,16 @@ export default function TranslateWhatYouHear({
               parentIsSpeakingControl={isButtonSpeaking}
             />
           </s.CenteredRowTall>
-          {showHintText && (
-            <div className="contextExample">
-              <TranslatableText
-                isCorrect={isCorrect}
-                interactiveText={interactiveText}
-                translating={true}
-                pronouncing={false}
-                bookmarkToStudy={bookmarksToStudy[0].from}
-                exerciseType={EXERCISE_TYPE}
-              />
-            </div>
-          )}
+          <div className="contextExample">
+            <TranslatableText
+              isCorrect={isCorrect}
+              interactiveText={interactiveText}
+              translating={true}
+              pronouncing={false}
+              bookmarkToStudy={bookmarksToStudy[0].from}
+              exerciseType={EXERCISE_TYPE}
+            />
+          </div>
           <BottomInput
             handleCorrectAnswer={handleCorrectAnswer}
             handleIncorrectAnswer={handleIncorrectAnswer}

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -41,7 +41,6 @@ export default function TranslateWhatYouHear({
   const [getCurrentSubSessionDuration] = useSubSessionTimer(
     activeSessionDuration,
   );
-  const [showHintText, setShowHintText] = useState(false);
   const [isBookmarkChanged, setIsBookmarkChanged] = useState(false);
 
   async function handleSpeak() {
@@ -156,7 +155,6 @@ export default function TranslateWhatYouHear({
             setMessageToAPI={setMessageToAPI}
             isL1Answer={true}
             exerciseType={EXERCISE_TYPE}
-            onHintUsed={() => setShowHintText(true)}
           />
         </>
       )}

--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -156,16 +156,13 @@ export function TranslatableText({
         );
       }
 
-      const translationExercise =
-        EXERCISE_TYPES.isTranslationExercise(exerciseType);
-
-      if (foundInstances[0] === word.id && !translationExercise) {
+      if (foundInstances[0] === word.id) {
         // If we want, we can render it according to words size.
         // "_".repeat(word.word.length) + " ";
         return "_______ ";
       }
 
-      if (disableTranslation && !translationExercise) {
+      if (disableTranslation) {
         return "";
       }
 


### PR DESCRIPTION
I have added the context with the bookmark omitted to the Translate What You Hear exercise and removed the logic that previously allowed users to get two hints for this specific exercise.

<img width="602" alt="Screenshot 2024-10-23 at 10 02 47" src="https://github.com/user-attachments/assets/7b4318e5-7312-4b07-97e0-2b31747dc0fd">
<img width="593" alt="Screenshot 2024-10-23 at 10 03 00" src="https://github.com/user-attachments/assets/dee82497-c951-4be7-a555-fcaf3217efaf">
