### PR TITLE
Add the requirement that all bookmarks require distinct translations

### DIFF
--- a/src/exercises/assignBookmarksToExercises.js
+++ b/src/exercises/assignBookmarksToExercises.js
@@ -81,6 +81,14 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
     return distinctContextsCount === potentialBookmarkContexts.length;
   }
 
+  function _distinctTranslations(potentialBookmarks) {
+    let potentialBookmarkContexts = potentialBookmarks.map(
+      (bookmark) => bookmark.to,
+    );
+    let distinctContextsCount = new Set(potentialBookmarkContexts).size;
+    return distinctContextsCount === potentialBookmarkContexts.length;
+  }
+
   let exerciseSequence = [];
 
   let exercisesByCycleTask = getElementsByCycleTask(
@@ -109,7 +117,12 @@ function assignBookmarksWithLearningCycle(bookmarks, exerciseTypesList) {
           let availableBookmarks = currentBookmarkList.length;
           if (
             requiredBookmarks <= availableBookmarks &&
-            _distinctContexts(currentBookmarkList.slice(0, requiredBookmarks))
+            _distinctContexts(
+              currentBookmarkList.slice(0, requiredBookmarks),
+            ) &&
+            _distinctTranslations(
+              currentBookmarkList.slice(0, requiredBookmarks),
+            )
           ) {
             let testedBookmarks = popNElementsFromList(
               currentBookmarkList,


### PR DESCRIPTION
## Issue

In case a word has the same translation as a different word, the match exercise will expect the user to match one of the specific target boxes, which can be frustrating. 

![image](https://github.com/user-attachments/assets/fc76ae67-4283-4060-a5e1-7d46d0ba0153)

## Fix

- Added the requirement that for an exercise with multiple words, they need to have different translations on top of having different contexts.

In an extreme example we could have three different words with the same example:

![{39129F41-668D-4EBE-B598-0CBEBF762C5A}](https://github.com/user-attachments/assets/ac1dea38-590d-4e94-aaf9-7faa8a207309)

(This is in the dev environment, so I manually changed the 3 words to have the same translation)



