### PR TITLE
Start context from the word, not the word after.

### DIFF
--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -171,11 +171,7 @@ export default class InteractiveText {
     }
 
     let context =
-      getLeftContext(word.prev, 32) +
-      " " +
-      word.word +
-      " " +
-      getRightContext(word.next, 32);
+      getLeftContext(word.prev, 32) + " " + getRightContext(word, 32);
 
     // console.log("context is: " + context);
     return context;


### PR DESCRIPTION
- Avoid situation where the context would contain two sentences when the word translated terminated the sentence.

## Example:

### German:

![{77CF09EF-E9E1-4E24-B55F-0A1FFDE8043B}](https://github.com/user-attachments/assets/1516dc09-2d59-458c-8602-3809bcc41f82)

| Old Context | New Context |
| -- | -- |
| Nichts erinnert mehr an das etwas heruntergekommene Gebäude mit dem blassgelben Anstrich, das sich dort früher einmal **befand**. Tatsächlich steht das klassische Mietshaus mit 30 Kleinstwohnungen aus der Nachkriegszeit aber immer noch  |  Nichts erinnert mehr an das etwas heruntergekommene Gebäude mit dem blassgelben Anstrich, das sich dort früher einmal **befand**. |

### Danish:

![{04B0ACA4-3CFE-4C33-B656-E65F1EDCC18B}](https://github.com/user-attachments/assets/d8f2909e-1d9a-4833-971c-627e08cb9427)

| Old Context | New Context |
| -- | -- |
| Den har en mild og cremet smag, der passer perfekt til både salater, stegeretter og **supper**. Kinakålen kan fint spises rå, hvor den tilfører en frisk og knasende tekstur.  |  Den har en mild og cremet smag, der passer perfekt til både salater, stegeretter og **supper**.   |

