### PR TITLE
Fixed spacing for article preview

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -148,8 +148,8 @@ export default function ArticlePreview({
       </s.ArticleContent>
 
       <s.BottomContainer>
-        <div>
-          {Feature.new_topics() && showInferredTopic && (
+        {Feature.new_topics() && showInferredTopic && new_topics.length > 0 && (
+          <div>
             <s.UrlTopics>
               {new_topics.map((tuple) => (
                 // Tuple (Topic Title, TopicOriginType)
@@ -179,15 +179,17 @@ export default function ArticlePreview({
                 </span>
               ))}
             </s.UrlTopics>
-          )}
-          {!Feature.new_topics() && (
+          </div>
+        )}
+        {!Feature.new_topics() && topics.length > 0 && (
+          <div>
             <s.Topics>
               {topics.map((topic) => (
                 <span key={topic}>{topic}</span>
               ))}
             </s.Topics>
-          )}
-        </div>
+          </div>
+        )}
         <ArticleStatInfo
           cefr_level={cefr_level}
           articleInfo={article}

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -30,13 +30,11 @@ const ArticleContent = styled.div`
   font-weight: inherit;
   flex-direction: row;
   flex-wrap: wrap;
-  align-content: center;
-  justify-content: space-around;
-  align-items: center;
+
+  gap: 0.5em;
 
   img {
-    margin: 0.5em;
-    margin-left: 0;
+    margin: 0 0.5em;
     max-width: 10em;
     max-height: 10em;
     border-radius: 1em;
@@ -44,9 +42,18 @@ const ArticleContent = styled.div`
     object-fit: cover;
 
     @media (max-width: 990px) {
+      align-content: center;
+      justify-content: space-around;
+      align-items: center;
       max-width: 14em;
       max-height: 10em;
+      margin: 0.5rem;
     }
+  }
+  @media (max-width: 990px) {
+    align-content: center;
+    justify-content: space-around;
+    align-items: center;
   }
 `;
 
@@ -109,8 +116,6 @@ let Summary = styled.div`
   line-height: 1.5em;
   margin-top: 0.36em;
   width: 40em;
-  margin: auto;
-  margin-left: 1em;
   @media (max-width: 990px) {
     width: 100%;
   }
@@ -118,13 +123,13 @@ let Summary = styled.div`
 
 let BottomContainer = styled.div`
   display: flex;
+  flex-direction: row;
   margin-top: 0.5em;
-  align-items: center;
   justify-content: space-between;
-  @media (max-width: 900px) {
-    align-items: flex-start;
+  @media (max-width: 990px) {
     flex-direction: column;
-    gap: 1em;
+    align-items: flex-start;
+    gap: 0.5 rem;
   }
 `;
 

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -176,7 +176,7 @@ let UrlTopics = styled.div`
     margin-bottom: -0.3em;
     margin-right: -0.3em;
   }
-  @media (max-width: 900px) {
+  @media (max-width: 990px) {
     margin-bottom: 1.2em;
   }
 `;

--- a/src/components/ArticleStatInfo.sc.js
+++ b/src/components/ArticleStatInfo.sc.js
@@ -3,6 +3,10 @@ import styled from "styled-components";
 let StatContainer = styled.div`
   display: flex;
   align-items: center;
+  margin-left: auto;
+  @media (max-width: 990px) {
+    margin-left: 0;
+  }
 `;
 
 const Difficulty = styled.div`


### PR DESCRIPTION
- Fixed some spacing issues for the articles

1. Article having a small indentation if there was no image
2. Phone having a lot of vertical space if there was no topics for an article between the stats and summary

## Preview:

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/e3be61b6-4688-4165-a8b0-e6b0d3542035) | ![image](https://github.com/user-attachments/assets/f2e7bd7e-56eb-4830-98b4-40f5eefc89d1) |
| ![image](https://github.com/user-attachments/assets/ed0661c6-02b9-4f80-bede-ab5f6565728e) | ![image](https://github.com/user-attachments/assets/1767ce3d-800c-4e85-9c7c-b76f58e1d2af) |