### PR TITLE
Ampersand in Bookmark Context

### DIFF
--- a/src/api/translations.js
+++ b/src/api/translations.js
@@ -1,4 +1,5 @@
 import { Zeeguu_API } from "./classDef";
+import qs from "qs";
 
 Zeeguu_API.prototype.getOneTranslation = function (
   from_lang,
@@ -7,17 +8,20 @@ Zeeguu_API.prototype.getOneTranslation = function (
   context,
   articleUrl,
   articleTitle,
-  articleID
+  articleID,
 ) {
-  let url = this._appendSessionToUrl(
-    `get_one_translation/${from_lang}/${to_lang}`
-  );
+  let payload = {
+    word: word,
+    context: context,
+    url: articleUrl,
+    title: articleTitle,
+    articleID: articleID,
+  };
 
-  return fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: `word=${word}&context=${context}&url=${articleUrl}&title=${articleTitle}&articleID=${articleID}`,
-  });
+  return this._post(
+    `get_one_translation/${from_lang}/${to_lang}`,
+    qs.stringify(payload),
+  );
 };
 
 Zeeguu_API.prototype.getMultipleTranslations = function (
@@ -29,10 +33,10 @@ Zeeguu_API.prototype.getMultipleTranslations = function (
   numberOfResults,
   serviceToExclude,
   translationToExclude,
-  articleID
+  articleID,
 ) {
   let url = this._appendSessionToUrl(
-    `get_multiple_translations/${from_lang}/${to_lang}`
+    `get_multiple_translations/${from_lang}/${to_lang}`,
   );
 
   let body = `word=${word}&context=${context}&url=${pageUrl}&numberOfResults=${numberOfResults}&articleID=${articleID}`;
@@ -59,10 +63,10 @@ Zeeguu_API.prototype.contributeTranslation = function (
   translation,
   context,
   pageUrl,
-  pageTitle
+  pageTitle,
 ) {
   let url = this._appendSessionToUrl(
-    `contribute_translation/${from_lang}/${to_lang}`
+    `contribute_translation/${from_lang}/${to_lang}`,
   );
 
   let body = `word=${word}&translation=${translation}&context=${context}&url=${pageUrl}&pageTitle=${pageTitle}`;
@@ -78,7 +82,7 @@ Zeeguu_API.prototype.updateBookmark = function (
   bookmark_id,
   word,
   translation,
-  context
+  context,
 ) {
   let url = this._appendSessionToUrl(`update_bookmark/${bookmark_id}`);
 


### PR DESCRIPTION
- Update passing parameters on URL, and instead pass it with a payload.

This seems to resolve the issue where in case of an ampersand the context would be cut at the occurrence of this character. This seems to been caused by passing the context through the url parameters, rather than a dictionary. 

| Old | New |
| :-: | :-: |
| ![{141D1162-EC41-4A5B-B2E6-73D54C279FF1}](https://github.com/user-attachments/assets/491839ed-73b5-48db-88db-9547ba77ae0b) | ![{9A166375-F7EF-4B2D-854C-25BF6AA88A94}](https://github.com/user-attachments/assets/435bd4fd-b0e8-410d-aa1d-1ea9811ca4c6) |