### PR TITLE
Show URLs when article doesn't come from a feed

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -136,11 +136,16 @@ export default function ArticlePreview({
       />
 
       <s.Title>{titleLink(article)}</s.Title>
-      <ArticleSourceInfo
-        articleInfo={article}
-        dontShowPublishingTime={dontShowPublishingTime}
-        dontShowSourceIcon={dontShowSourceIcon}
-      ></ArticleSourceInfo>
+      {article.feed_id ? (
+        <ArticleSourceInfo
+          articleInfo={article}
+          dontShowPublishingTime={dontShowPublishingTime}
+          dontShowSourceIcon={dontShowSourceIcon}
+        ></ArticleSourceInfo>
+      ) : (
+        <span>{article.url}</span>
+      )}
+
       <s.ArticleContent>
         {article.img_url && <img alt="" src={article.img_url} />}
         <s.Summary>{article.summary}...</s.Summary>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -14,6 +14,7 @@ import { toast } from "react-toastify";
 import { darkBlue } from "../components/colors";
 import ExplainTopicsModal from "../pages/ExplainTopicsModal";
 import { TopicOriginType } from "../appConstants";
+import extractDomain from "../utils/web/extractDomain";
 
 export default function ArticlePreview({
   article,
@@ -143,7 +144,8 @@ export default function ArticlePreview({
           dontShowSourceIcon={dontShowSourceIcon}
         ></ArticleSourceInfo>
       ) : (
-        <span>{article.url}</span>
+        !dontShowSourceIcon &&
+        article.url && <s.UrlSource>{extractDomain(article.url)}</s.UrlSource>
       )}
 
       <s.ArticleContent>

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -83,6 +83,12 @@ const Title = styled.div`
   width: 100%;
 `;
 
+const UrlSource = styled.span`
+  font-size: 0.8em;
+  font-style: italic;
+  font-weight: 500;
+`;
+
 const UnfinishedArticleContainer = styled.div`
   margin-top: 0.5em;
   display: flex;
@@ -183,6 +189,7 @@ let UrlTopics = styled.div`
 
 export {
   Title,
+  UrlSource,
   ArticlePreview,
   UnfinishedArticleContainer,
   UnfinishedArticleStats,

--- a/src/utils/web/extractDomain.js
+++ b/src/utils/web/extractDomain.js
@@ -1,0 +1,7 @@
+export default function extractDomain(url) {
+  let parsedDomain = url.replace("http://", "https://");
+  parsedDomain = url.replace("https://", "");
+  parsedDomain = parsedDomain.split("/")[0];
+  parsedDomain = parsedDomain.replace("www.", "");
+  return parsedDomain;
+}


### PR DESCRIPTION
When users add articles that aren't from a feed, they would show a broken icon.

Now, they show the link where the article was found - only the initial domain in shown, rather than the entire URL.


## Preview:

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/863c960b-e262-4be1-b014-208521d331a1) | ![{63462F27-E2FE-4C1C-B746-F927D9071B43}](https://github.com/user-attachments/assets/e1a6e6cf-0070-41e2-b9e4-fa658a31c9f3) |