### PR TITLE
Update useActivityTimer.js

### DIFF
--- a/src/hooks/useActivityTimer.js
+++ b/src/hooks/useActivityTimer.js
@@ -5,12 +5,13 @@ export default function useActivityTimer(activityUploaderFunction) {
   const [activityTimer, setActivityTimer] = useState(0);
 
   const [isTimerActive, setIsTimerActive] = useState(true);
+  const [isFocused, setIsFocused] = useState(true);
 
   const [isActivityOver, setIsActivityOver] = useState(false);
 
   useIdleTimer({
-    onIdle,
     onActive,
+    onIdle,
     timeout: 30_000,
     eventsThrottle: 500,
     events: [
@@ -23,7 +24,6 @@ export default function useActivityTimer(activityUploaderFunction) {
       "touchmove",
       "MSPointerDown",
       "MSPointerMove",
-      "focus",
     ],
   });
   function onIdle() {
@@ -34,7 +34,7 @@ export default function useActivityTimer(activityUploaderFunction) {
   }
 
   function onActive() {
-    setIsTimerActive(true);
+    if (isFocused) setIsTimerActive(true);
   }
 
   useEffect(() => {
@@ -59,6 +59,7 @@ export default function useActivityTimer(activityUploaderFunction) {
       if (!isActivityOver) {
         setIsTimerActive(true);
       }
+      setIsFocused(true);
     };
 
     const handleBlur = () => {
@@ -66,6 +67,7 @@ export default function useActivityTimer(activityUploaderFunction) {
         activityUploaderFunction();
       }
       setIsTimerActive(false);
+      setIsFocused(false);
     };
 
     window.addEventListener("focus", handleFocus);
@@ -76,17 +78,6 @@ export default function useActivityTimer(activityUploaderFunction) {
       window.removeEventListener("blur", handleBlur);
     };
   }, []);
-
-  function onIdle() {
-    if (isTimerActive && activityUploaderFunction) {
-      activityUploaderFunction();
-    }
-    setIsTimerActive(false);
-  }
-
-  function onActive() {
-    setIsTimerActive(true);
-  }
 
   // active session duration is measured in seconds
   return [activityTimer, isTimerActive, setIsActivityOver];

--- a/src/hooks/useActivityTimer.js
+++ b/src/hooks/useActivityTimer.js
@@ -8,6 +8,35 @@ export default function useActivityTimer(activityUploaderFunction) {
 
   const [isActivityOver, setIsActivityOver] = useState(false);
 
+  useIdleTimer({
+    onIdle,
+    onActive,
+    timeout: 30_000,
+    eventsThrottle: 500,
+    events: [
+      "keydown",
+      "wheel",
+      "DOMMouseScroll",
+      "mousewheel",
+      "mousedown",
+      "touchstart",
+      "touchmove",
+      "MSPointerDown",
+      "MSPointerMove",
+      "focus",
+    ],
+  });
+  function onIdle() {
+    if (isTimerActive && activityUploaderFunction) {
+      activityUploaderFunction();
+    }
+    setIsTimerActive(false);
+  }
+
+  function onActive() {
+    setIsTimerActive(true);
+  }
+
   useEffect(() => {
     const interval = setInterval(() => {
       let newValue =
@@ -24,13 +53,6 @@ export default function useActivityTimer(activityUploaderFunction) {
       clearInterval(interval);
     };
   }, [activityTimer, isTimerActive]);
-
-  useIdleTimer({
-    onIdle,
-    onActive,
-    timeout: 30_000,
-    throttle: 500,
-  });
 
   useEffect(() => {
     const handleFocus = () => {


### PR DESCRIPTION
- Update the useIdleTimer props.

I believe that the reason we see very long sessions might have to do with the fact that the idleTimer doesn't stop once a user has left the webpage. It's hard to identify the culprit as there are multiple interactions at play, but I have seen this be alt+tabing and seeing that the counter keeps ticking. To address this I propose the following:

- We specify exactly which elements should "activate" the timer. By default, mouseMove + vibilityChange are included, but I have noted that visibilityChange is only turned off if the window is hidden completely from view. This could be the reason why sometimes the timer doesn't activate the onIdle.
- I also remove onMouseMove, as I think a timeout of 30 seconds between a mouse clicking/scroll is enough of a bandwidth to allow users to interact with the content
- throttle was unsued. That function is called onAction which we do not use. Instead I enabled eventsThrottle, to save CPU time from checking all the events from every 200ms to every 500ms
- Better control over the call of onActive, by checking the window is focused before setting the time to active.

I am hoping these changes might fix the issue of very long time sessions, but I still think they will be a bit difficult to fully capture.