### PR TITLE
Added validation similiar to password

### DIFF
--- a/src/components/LanguageSelector.js
+++ b/src/components/LanguageSelector.js
@@ -5,6 +5,8 @@ export default function LanguageSelector({
   languages,
   selected,
   onChange,
+  errorMessage,
+  isError,
   label,
   id,
 }) {
@@ -19,19 +21,17 @@ export default function LanguageSelector({
     return language.code;
   }
 
-  function getLanguageCodeFromDOMEvent(e) {
-    return e.target.value;
-  }
-
   return (
     <Selector
       options={languages}
       optionLabel={languageLabel}
       optionValue={languageCode}
       selectedValue={selected}
-      onChange={(e) => onChange(getLanguageCodeFromDOMEvent(e))}
+      onChange={onChange}
       label={label}
       placeholder={"Select language"}
+      errorMessage={errorMessage}
+      isError={isError}
       id={id}
     />
   );

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -19,6 +19,14 @@ import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
 import BackArrow from "./settings_pages_shared/BackArrow";
 import Selector from "../../components/Selector";
 import { setTitle } from "../../assorted/setTitle";
+import useFormField from "../../hooks/useFormField";
+import {
+  NonEmptyValidator,
+  Validator,
+} from "../../utils/ValidatorRule/Validator";
+import useShadowRef from "../../hooks/useShadowRef";
+import { scrollToTop } from "../../utils/misc/scrollToTop";
+import validateRules from "../../assorted/validateRules";
 
 export default function LanguageSettings({ api, setUser }) {
   const [errorMessage, setErrorMessage] = useState("");
@@ -26,6 +34,27 @@ export default function LanguageSettings({ api, setUser }) {
   const [languages, setLanguages] = useState();
   // TODO: not used; see if you can remove
   const [cefr, setCEFR] = useState("");
+  const [
+    learnedLanguage,
+    setLearnedLanguage,
+    validateLearnedLanguage,
+    isLearnedLanguageValid,
+    learnedLanguageMsg,
+  ] = useFormField("", NonEmptyValidator("Please select a language."));
+
+  const learnedLanguageRef = useShadowRef(learnedLanguage);
+  const [
+    nativeLanguage,
+    setNativeLanguage,
+    validateNativeLanguage,
+    isNativeLanguageValid,
+    nativeLanguageMsg,
+  ] = useFormField("en", [
+    NonEmptyValidator("Please select a language."),
+    new Validator((v) => {
+      return v !== learnedLanguageRef.current;
+    }, "Your Translation language needs to be different than your learned language."),
+  ]);
 
   const user = useContext(UserContext);
   const history = useHistory();
@@ -48,6 +77,8 @@ export default function LanguageSettings({ api, setUser }) {
     api.getUserDetails((data) => {
       setUserDetails(data);
       setCEFRlevel(data);
+      setLearnedLanguage(data.learned_language);
+      setNativeLanguage(data.native_language);
     });
 
     api.getSystemLanguages((systemLanguages) => {
@@ -67,6 +98,7 @@ export default function LanguageSettings({ api, setUser }) {
   }
 
   function updateNativeLanguage(lang_code) {
+    setNativeLanguage(lang_code);
     setUserDetails({
       ...userDetails,
       native_language: lang_code,
@@ -82,6 +114,7 @@ export default function LanguageSettings({ api, setUser }) {
 
   function updateLearnedLanguage(lang_code) {
     console.log("language code in updateLearnedLanguage");
+    setLearnedLanguage(lang_code);
     console.log(lang_code);
     setUserDetails({
       ...userDetails,
@@ -91,10 +124,13 @@ export default function LanguageSettings({ api, setUser }) {
 
   function handleSave(e) {
     e.preventDefault();
-    api.saveUserDetails(userDetails, setErrorMessage, () => {
-      updateUserInfo(userDetails);
-      history.goBack();
-    });
+    if (!validateRules([validateLearnedLanguage, validateNativeLanguage]))
+      scrollToTop();
+    else
+      api.saveUserDetails(userDetails, setErrorMessage, () => {
+        updateUserInfo(userDetails);
+        history.goBack();
+      });
   }
 
   if (!userDetails || !languages) {
@@ -119,10 +155,12 @@ export default function LanguageSettings({ api, setUser }) {
               id={"practiced-language-selector"}
               label={strings.learnedLanguage}
               languages={languages.learnable_languages}
-              selected={userDetails.learned_language}
-              onChange={(languageCode) => {
-                updateLearnedLanguage(languageCode);
+              selected={learnedLanguage}
+              onChange={(e) => {
+                updateLearnedLanguage(e.target.value);
               }}
+              isError={!isLearnedLanguageValid}
+              errorMessage={learnedLanguageMsg}
             />
 
             <Selector
@@ -142,9 +180,11 @@ export default function LanguageSettings({ api, setUser }) {
               id={"translation-language-selector"}
               label={strings.baseLanguage}
               languages={languages.native_languages}
-              selected={userDetails.native_language}
-              onChange={(languageCode) => {
-                updateNativeLanguage(languageCode);
+              selected={nativeLanguage}
+              isError={!isNativeLanguageValid}
+              errorMessage={nativeLanguageMsg}
+              onChange={(e) => {
+                updateNativeLanguage(e.target.value);
               }}
             />
           </FormSection>

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -25,6 +25,8 @@ import { CEFR_LEVELS } from "../../assorted/cefrLevels";
 import { setTitle } from "../../assorted/setTitle";
 
 import { scrollToTop } from "../../utils/misc/scrollToTop";
+import { Validator } from "../../utils/ValidatorRule/Validator";
+import useShadowRef from "../../hooks/useShadowRef";
 
 export default function LanguagePreferences({ api }) {
   const [
@@ -34,13 +36,20 @@ export default function LanguagePreferences({ api }) {
     isLearnedLanguageValid,
     learnedLanguageMsg,
   ] = useFormField("", NonEmptyValidator("Please select a language."));
+
+  const learnedLanguageRef = useShadowRef(learnedLanguage);
   const [
     nativeLanguage,
     setNativeLanguage,
     validateNativeLanguage,
     isNativeLanguageValid,
     nativeLanguageMsg,
-  ] = useFormField("en", NonEmptyValidator("Please select a language."));
+  ] = useFormField("en", [
+    NonEmptyValidator("Please select a language."),
+    new Validator((v) => {
+      return v !== learnedLanguageRef.current;
+    }, "Your Translation language needs to be different than your learned language."),
+  ]);
   const [
     learnedCEFRLevel,
     setLearnedCEFRLevel,


### PR DESCRIPTION
- Ensures user doesn't select the same Native + Learned language pair.

![{035C580D-C724-4C3E-8FBA-9493834CF40C}](https://github.com/user-attachments/assets/9d2ca80d-c5b9-4eec-8c3e-d6396c6bffee)

This also works on onboarding:

![{5CB64F2E-7A12-4B3B-875E-CCF40FEFE896}](https://github.com/user-attachments/assets/2582dbe3-4b89-42f4-980f-378df9aa4cfe)
