### PR TITLE
Fix AlterMenu not displaying on Exercises

### DIFF
--- a/src/exercises/exerciseTypes/Exercise.sc.js
+++ b/src/exercises/exerciseTypes/Exercise.sc.js
@@ -13,7 +13,7 @@ const Exercise = styled.div`
   flex-direction: column;
   text-align: center;
   transition: all 0.5s;
-  padding-bottom: 1em;
+  padding-bottom: 6.5rem;
 
   .next-nav-feedback {
     display: flex;


### PR DESCRIPTION
- Increased the padding bottom for the exercises to allow sufficient space for the alter translation box.

This only happens to exercises which don't have a lot of bottom space, like the exercise displayed in the result. For example, if there is an input box then the box can be displayed without any issues. 

Note: This will mean that the grey box is slightly larger than it was originally, but I think it's not too noticeable and displaying the alter box takes higher priority. 

| Before | After |
| :-: | :-: |
|  ![{EFCFA44A-6F62-4E0C-92EE-61851ABBBB34}](https://github.com/user-attachments/assets/70f2b224-adae-44e2-91e7-0d3b0cee5ffb)  | ![{F126840D-F2A3-4F7B-B7BE-9D013E6D73DB}](https://github.com/user-attachments/assets/5ca7708d-7c00-448b-bd17-d5770a26976b) |


