### PR TITLE
Fixed AlterMenu not showing

### DIFF
--- a/src/AppWithMainNav.sc.js
+++ b/src/AppWithMainNav.sc.js
@@ -12,6 +12,7 @@ const AppWithMainNav = styled.div`
   top: 0;
   height: 100%;
   display: flex;
+  justify-content: space-around;
   flex-direction: ${({ $screenWidth }) =>
     $screenWidth <= MOBILE_WIDTH ? "column" : "row"};
 `;
@@ -20,6 +21,7 @@ const AppContent = styled.section`
   box-sizing: border-box;
   height: 100%;
   width: 100%;
+  position: relative;
   transition: 0.3s ease-in-out;
   padding: 0 1rem 0 1rem;
   overflow-x: hidden;
@@ -44,7 +46,7 @@ const AppContent = styled.section`
     ) {
       return "0";
     } else if ($screenWidth <= MOBILE_WIDTH) {
-      return "4 rem";
+      return "4rem";
     } else {
       return "0";
     }

--- a/src/reader/ArticleReader.sc.js
+++ b/src/reader/ArticleReader.sc.js
@@ -109,6 +109,18 @@ let ArticleImg = styled.img`
   margin-bottom: 1em;
 `;
 
+const ToolbarWrapper = styled.div`
+  margin-top: 25px;
+  display: flex;
+  justify-content: flex-end;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  background: white;
+  z-index: 2000;
+  border-bottom: 1px solid ${veryLightGrey};
+`;
+
 let Toolbar = styled.div`
   padding-top: 0.5rem;
   width: 100%;
@@ -432,4 +444,5 @@ export {
   PlayerControl,
   InvisibleBox,
   CombinedBox,
+  ToolbarWrapper,
 };

--- a/src/reader/TopToolbar.js
+++ b/src/reader/TopToolbar.js
@@ -69,7 +69,7 @@ export default function TopToolbar({
   };
 
   return (
-    <PopupButtonWrapper>
+    <s.ToolbarWrapper>
       <s.Toolbar>
         <s.TopbarButtonsContainer $screenWidth={screenWidth}>
           {screenWidth < MOBILE_WIDTH && <BackArrow noMargin={false} />}
@@ -119,6 +119,6 @@ export default function TopToolbar({
           <progress style={{ margin: "0px" }} value={articleProgress} />
         </div>
       </s.Toolbar>
-    </PopupButtonWrapper>
+    </s.ToolbarWrapper>
   );
 }


### PR DESCRIPTION
- Due to the use of Relative / Absolute positions the current scrollholder was displacing the AlterMenu. To fix this, I made the scroll holder relative.
- Renamed `PopupButtonWrapper` -> `ToolbarWrapper`, and increased the z-index so it overlaps the alter menu.

