### PR TITLE
add back arrow to the OutOfWordsMessage and Congratulations component

### DIFF
--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -10,6 +10,9 @@ import { timeToHumanReadable } from "../utils/misc/readableTime";
 import { ExerciseCountContext } from "./ExerciseCountContext";
 import CollapsablePanel from "../components/CollapsablePanel";
 import Pluralize from "../utils/text/pluralize";
+import BackArrow from "../pages/Settings/settings_pages_shared/BackArrow";
+import useScreenWidth from "../hooks/useScreenWidth";
+import { MOBILE_WIDTH } from "../components/MainNav/screenSize";
 
 export default function Congratulations({
   articleID,
@@ -34,6 +37,8 @@ export default function Congratulations({
     useState(removeArrayDuplicates(incorrectBookmarks));
   const [totalBookmarksReviewed, setTotalBookmarksReviewed] = useState();
   const [username, setUsername] = useState();
+
+  const { screenWidth } = useScreenWidth();
 
   function deleteBookmark(bookmark) {
     setCorrectBookmarksToDisplay(
@@ -76,7 +81,7 @@ export default function Congratulations({
   return (
     <>
       <s.NarrowColumn className="narrowColumn">
-        <br />
+        {screenWidth < MOBILE_WIDTH && <BackArrow />}
         <CenteredColumn className="centeredColumn">
           <h1>
             {strings.goodJob} {username}!

--- a/src/exercises/OutOfWordsMessage.js
+++ b/src/exercises/OutOfWordsMessage.js
@@ -2,14 +2,19 @@ import * as s from "./exerciseTypes/Exercise.sc";
 import * as sc from "../reader/ArticleReader.sc";
 import strings from "../i18n/definitions";
 import Pluralize from "../utils/text/pluralize";
+import useScreenWidth from "../hooks/useScreenWidth";
+import { MOBILE_WIDTH } from "../components/MainNav/screenSize";
+import BackArrow from "../pages/Settings/settings_pages_shared/BackArrow";
 
 export default function OutOfWordsMessage({
   totalInLearning,
   goBackAction,
   keepExercisingAction,
 }) {
+  const { screenWidth } = useScreenWidth();
   return (
     <s.Exercise>
+      {screenWidth < MOBILE_WIDTH && <BackArrow />}
       <div className="contextExample">
         <h2>{strings.noTranslatedWords}</h2>
         <p>


### PR DESCRIPTION
The `<BactArrow/>` is now added to the `<Congratulations/>` and the `<OutOfWordsMessage/>` component. 
In my opinion, it should be a temporary solution, and in the future we need to rethink how we update the content on the `<Exercises/>` page.

Currently, depending on what conditions are met, the whole  `<Exercises/>` component is replaced by `<Congratulations/>` or `<OutOfWordsMessage/>` or loading animation. Instead, we should always return the  `<Exercises/>` component but only modify its inner part. This would allow us to create a more universal solution and avoid having to create back navigation duplicates per each variant of the exercises page (loading, out of words, congratulations, other future variants).

