### PR TITLE
Update Exercises.js

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -91,12 +91,16 @@ export default function Exercises({
       let id = JSON.parse(newlyCreatedDBSessionID).id;
       setDbExerciseSessionId(id);
     });
-    api.logReaderActivity(
-      api.SCHEDULED_EXERCISES_OPEN,
-      null,
-      JSON.stringify({ had_notification: exerciseNotification.hasExercises }),
-      "",
-    );
+
+    if (!articleID)
+      // Only report if it's the tab
+      api.logReaderActivity(
+        api.SCHEDULED_EXERCISES_OPEN,
+        null,
+        JSON.stringify({ had_notification: exerciseNotification.hasExercises }),
+        "",
+      );
+
     setTitle("Exercises");
     startExercising();
     return () => {

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -93,7 +93,8 @@ export default function Exercises({
     });
 
     if (!articleID)
-      // Only report if it's the tab
+      // Only report if it's the scheduled exercises that are opened
+      // and not the article exercises
       api.logReaderActivity(
         api.SCHEDULED_EXERCISES_OPEN,
         null,
@@ -105,7 +106,7 @@ export default function Exercises({
     startExercising();
     return () => {
       if (currentIndexRef.current > 0 || hasKeptExercisingRef.current) {
-        // Do not report if there was no exercises
+        // Do not report if there were no exercises
         // performed
         api.reportExerciseSessionEnd(
           dbExerciseSessionIdRef.current,


### PR DESCRIPTION
- Do not create a schedule activity if there is an articleID (meaning it's a word review).

I realized that this was reporting everytime the user was going to the exercise component, which is not what we want. SCHEDULED_EXERCISES_OPEN should only be written if the tab is clicked, so I now check if an ArticleID is defined. 

We could do an update in the DB to avoid it being confusing?

```
UPDATE user_activity_data
SET event='EXERCISES_OPEN'
WHERE event like 'SCHEDULED_EXERCISES_OPEN';
```
