### PR TITLE
Update ArticlePreview.js

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -153,8 +153,8 @@ export default function ArticlePreview({
       </s.ArticleContent>
 
       <s.BottomContainer>
-        {showInferredTopic && topics.length > 0 && (
-          <div>
+        <div>
+          {showInferredTopic && topics.length > 0 && (
             <s.UrlTopics>
               {topics.map((tuple) => (
                 // Tuple (Topic Title, TopicOriginType)
@@ -184,8 +184,8 @@ export default function ArticlePreview({
                 </span>
               ))}
             </s.UrlTopics>
-          </div>
-        )}
+          )}
+        </div>
         <ArticleStatInfo articleInfo={article}></ArticleStatInfo>
       </s.BottomContainer>
       {article.video ? (


### PR DESCRIPTION
- Render the div outside to display the Difficulty / Reading time always on the left when on desktop.

| Before | After |
| :-: | :-: |
| ![{7A6C5502-0500-44BB-9EA6-ACA2C035A1AE}](https://github.com/user-attachments/assets/bc0fb54b-a8d3-47e8-8757-600405cade80)  |  ![{89623A0C-4DD2-4098-AF8A-A1BA2A20D455}](https://github.com/user-attachments/assets/7b510faf-c1f3-45e3-98a1-03d28548edd2) |