### PR TITLE
Fixing Rendering Congratulation Screen Updating after 1st update

### DIFF
--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -29,7 +29,6 @@ export default function Congratulations({
   exerciseSessionTimer,
 }) {
   const [checkpointTime] = useState(exerciseSessionTimer);
-  const exerciseNotification = useContext(ExerciseCountContext);
   const [correctBookmarksToDisplay, setCorrectBookmarksToDisplay] = useState(
     removeArrayDuplicates(correctBookmarks),
   );
@@ -59,7 +58,7 @@ export default function Congratulations({
     api.logUserActivity(api.COMPLETED_EXERCISES, articleID, "", source);
   }, []);
 
-  if (username === undefined) {
+  if (username === undefined || isOutOfWordsToday === undefined) {
     return <LoadingAnimation />;
   }
 

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -161,7 +161,7 @@ export default function Exercises({
   }
 
   function resetExerciseState() {
-    setIsOutOfWordsToday(false);
+    setIsOutOfWordsToday();
     setCountBookmarksToPractice();
     setFullExerciseProgression();
     setCurrentBookmarksToStudy();
@@ -174,7 +174,7 @@ export default function Exercises({
 
   function updateIsOutOfWordsToday() {
     api.getTopBookmarksToStudy((topBookmarks) => {
-      setIsOutOfWordsToday(topBookmarks.length == 0);
+      setIsOutOfWordsToday(topBookmarks.length === 0);
     });
   }
 
@@ -256,8 +256,7 @@ export default function Exercises({
   function moveToNextExercise() {
     LocalStorage.setLastExerciseCompleteDate(new Date().toDateString());
 
-    //ML: To think about: Semantically this is strange; Why don't we set it to null? We don't know if it's correct or not
-    setIsCorrect(false);
+    setIsCorrect(null);
     setShowFeedbackButtons(false);
     const newIndex = currentIndex + 1;
     exerciseNotification.updateReactState();


### PR DESCRIPTION
## Previous Issue

https://github.com/user-attachments/assets/bf1e0d17-3317-41de-8fe7-712acd9a2720

## Changes

- isOutOfWordsToday was being updated after the rendering of the Congratulations page resulting in the button + text changing after the first render, going from Keep Exercising to Back to Reading.
- Instead of setting the value to false on reset, the value is unset and is only  rendered once the API updates it.
- Change setIsCorrect to null rather than false on exercise change.


