### PR TITLE
Reduce z-index of Reader top bar

### DIFF
--- a/src/reader/ArticleReader.sc.js
+++ b/src/reader/ArticleReader.sc.js
@@ -115,7 +115,7 @@ const ToolbarWrapper = styled.div`
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  z-index: 2000;
+  z-index: 1000;
   background-color: white;
   padding-top: 0.5rem;
 `;


### PR DESCRIPTION
- The z-index is too high for dimming, reducing it to 1000 fixes the issue.

| Before | After |
| :-: | :-: |
|  ![image](https://github.com/user-attachments/assets/efb63cbf-a363-4040-99b4-0bc386655bf5)  |  ![{A1E65BA1-16B2-4D46-828F-6EFBD9188EC0}](https://github.com/user-attachments/assets/0361d198-09e5-49a2-a1c9-5a38967e2261)  |



