### PR TITLE
Learned turns green when learned

### DIFF
--- a/src/exercises/progressBars/levelIndicator/LevelIndicatorCircles.js
+++ b/src/exercises/progressBars/levelIndicator/LevelIndicatorCircles.js
@@ -19,10 +19,12 @@ export default function LevelIndicatorCircles({
       );
     } else if (index === level - 1 && levelIsBlinking) {
       return "level-circle passed blink";
+    } else if (index === maxLevel && level === maxLevel + 1 && levelCompleted) {
+      // We update the level when the bookmark is correct, so if the level is
+      // equal to maxLevel + 1, then we are at the end of the learning cycle.
+      return "level-circle final learned";
     } else if (index === maxLevel) {
       return "level-circle final";
-    } else if (index === maxLevel && levelCompleted) {
-      return "level-circle final learned";
     } else if (index <= level - 1) {
       return "level-circle passed";
     } else {


### PR DESCRIPTION
- The last indicator was not turning green when the word was learned.

The condition was below a less restrictive condition so it was never rendering. However, the "level" completed is always true whenever the user changes level. We need to check that the level is equal to maxLevel + 1 (since we update the level, when the user is correct). 

![{05A3C1E9-F516-470B-BBBC-734E52D0DAC9}](https://github.com/user-attachments/assets/afd52c1d-9564-4a9c-83ab-94c8610637b4)
