### PR TITLE
Remove duplicated Message

### DIFF
--- a/src/words/Learning.js
+++ b/src/words/Learning.js
@@ -154,9 +154,6 @@ export default function Learning({ api }) {
           <s.TopMessage>{strings.noToLearnWords}</s.TopMessage>
         ) : (
           <>
-            <s.TopMessage>
-              <div className="top-message-icon">{strings.toLearnMsg}</div>
-            </s.TopMessage>
             {toLearnWords.map((each) => (
               <Word
                 key={each.id}


### PR DESCRIPTION
- One Infobox wasn't removed when updating the strings and handling the exercise / productive words cases.