### PR TITLE
Fix Contexts having space between all tokens

### DIFF
--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -200,7 +200,10 @@ export default class InteractiveText {
       let count = 0;
       while (count < maxLeftContextLength && currentWord.prev) {
         currentWord = currentWord.prev;
-        contextBuilder = currentWord.word + " " + contextBuilder;
+        contextBuilder =
+          currentWord.word +
+          (currentWord.token.has_space ? " " : "") +
+          contextBuilder;
         if (
           currentWord.token.is_sent_start ||
           currentWord.token.token_i === 0
@@ -229,7 +232,11 @@ export default class InteractiveText {
         ) {
           break;
         }
-        contextBuilder = contextBuilder + " " + currentWord.word;
+
+        contextBuilder =
+          contextBuilder +
+          (currentWord.prev.token.has_space ? " " : "") +
+          currentWord.word;
         if (!wordShouldSkipCount(currentWord))
           // If it's not a punctuation or symbol we count it.
           count++;


### PR DESCRIPTION
- Use the token has_space property to correctly build the context.

| Before | After |
| :-: | :-: |
| ![{A142F734-C370-4114-A965-8FF2BAF6F182}](https://github.com/user-attachments/assets/ea1e4f14-68d0-40ad-9c41-2e17d3b6957f) | ![{E7C8EA3D-F468-4D3E-9BB9-5000CDA0DBA4}](https://github.com/user-attachments/assets/ed4bfa99-eb10-42e4-b9dc-62c309479a6c)   |