### PR TITLE
Updated Speech Module

### DIFF
--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -13,6 +13,7 @@ import Feature from "../features/Feature";
 import { MAX_COOLDOWN_INTERVAL } from "./ExerciseConstants";
 import LocalStorage from "../assorted/LocalStorage";
 import { assignBookmarksToExercises } from "./assignBookmarksToExercises";
+import { SpeechContext } from "../contexts/SpeechContext";
 
 import {
   DEFAULT_SEQUENCE,
@@ -72,6 +73,7 @@ export default function Exercises({
     useActivityTimer();
   const activeSessionDurationRef = useShadowRef(activeSessionDuration);
   const exerciseNotification = useContext(ExerciseCountContext);
+  const speech = useContext(SpeechContext);
 
   const { screenWidth } = useScreenWidth();
 
@@ -255,6 +257,7 @@ export default function Exercises({
   }
 
   function moveToNextExercise() {
+    speech.stopAudio();
     LocalStorage.setLastExerciseCompleteDate(new Date().toDateString());
 
     setIsCorrect(null);

--- a/src/exercises/exerciseTypes/SpeakButton.js
+++ b/src/exercises/exerciseTypes/SpeakButton.js
@@ -78,8 +78,6 @@ export default function SpeakButton({
   }, [parentIsSpeakingControl]);
 
   async function handleSpeak() {
-    // If audio is playing don't let other buttons be clicked.
-    if (speech.isCurrentlySpeaking) return;
     try {
       if (isReadContext) {
         await speech.speakOut(bookmarkToStudy.context, setIsSpeaking);

--- a/src/speech/APIBasedSpeech.js
+++ b/src/speech/APIBasedSpeech.js
@@ -8,22 +8,37 @@ const ZeeguuSpeech = class {
     this.pronunciationPlayer = new Audio();
     this.pronunciationPlayer.autoplay = true;
     this.isCurrentlySpeaking = false;
+    this.lastSetter = null;
+  }
+
+  resetClip() {
+    this.pronunciationPlayer.currentTime = 0;
+  }
+
+  animateSpeechButton(setIsSpeaking, isPlayingSound) {
+    if (typeof setIsSpeaking !== "undefined") setIsSpeaking(isPlayingSound);
+  }
+
+  stopAudio() {
+    this.animateSpeechButton(this.lastSetter, false);
+    this.pronunciationPlayer.pause();
+    this.isCurrentlySpeaking = false;
   }
 
   async speakOut(word, setIsSpeaking) {
-    if (this.isCurrentlySpeaking) return;
-    function animateSpeechButton(setIsSpeaking, isPlayingSound) {
-      if (typeof setIsSpeaking !== "undefined") setIsSpeaking(isPlayingSound);
+    if (this.isCurrentlySpeaking) {
+      this.stopAudio();
     }
     this.isCurrentlySpeaking = true;
-    animateSpeechButton(setIsSpeaking, true);
+    this.animateSpeechButton(setIsSpeaking, true);
+    this.lastSetter = setIsSpeaking;
     await this.api
       .fetchLinkToSpeechMp3(word, this.language)
       .then((linkToMp3) => {
         this.pronunciationPlayer.src = linkToMp3;
         this.pronunciationPlayer.addEventListener("ended", (e) => {
           // Only terminate the animation after playing the sound.
-          animateSpeechButton(setIsSpeaking, false);
+          this.animateSpeechButton(setIsSpeaking, false);
           this.isCurrentlySpeaking = false;
         });
 
@@ -34,14 +49,14 @@ const ZeeguuSpeech = class {
               // Autoplay started!
             })
             .catch((error) => {
-              animateSpeechButton(setIsSpeaking, false);
+              this.animateSpeechButton(setIsSpeaking, false);
               this.isCurrentlySpeaking = false;
             });
         }
       })
       .catch(() => {
         // in case anything goes wrong here... we should still deactivate the animation
-        animateSpeechButton(setIsSpeaking, false);
+        this.animateSpeechButton(setIsSpeaking, false);
         this.isCurrentlySpeaking = false;
       });
   }


### PR DESCRIPTION
At the moment, our system would prevent users from playing two sounds at the same time, generally forcing the user to wait to hear out the sound before playing a new sound. 

With this change, the module keeps track of whether its playing and what was the last animation it set. This way whenever a new sound is requested, the module can stop the previous animation and audio and play the new one.