### PR TITLE
Fix error where lastSetter is not set

### DIFF
--- a/src/speech/APIBasedSpeech.js
+++ b/src/speech/APIBasedSpeech.js
@@ -16,7 +16,8 @@ const ZeeguuSpeech = class {
   }
 
   animateSpeechButton(setIsSpeaking, isPlayingSound) {
-    if (typeof setIsSpeaking !== "undefined") setIsSpeaking(isPlayingSound);
+    if (typeof setIsSpeaking !== "undefined" && setIsSpeaking)
+      setIsSpeaking(isPlayingSound);
   }
 
   stopAudio() {


### PR DESCRIPTION
- Since the lastSetter starts as null, then we run into an error where the user might not be able to go to the next exercise.