### PR TITLE
Fixed Audio Exercise Abruptly

### DIFF
--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -69,10 +69,12 @@ export default function SpellWhatYouHear({
 
   useEffect(() => {
     // Timeout is set so that the page renders before the word is spoken, allowing for the user to gain focus on the page
-    // Changed timeout to be slightly shorter.
-    setTimeout(() => {
-      handleSpeak();
-    }, 300);
+    // Changed timeout to be slightly shorter. The sound should only play if the text
+    // is visible for the user.
+    if (interactiveText && !isButtonSpeaking)
+      setTimeout(() => {
+        handleSpeak();
+      }, 200);
   }, [interactiveText]);
 
   function handleShowSolution(e, message) {

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -66,9 +66,10 @@ export default function TranslateWhatYouHear({
   }, [isBookmarkChanged]);
 
   useEffect(() => {
-    if (SessionStorage.isAudioExercisesEnabled()) {
-      handleSpeak();
-    }
+    if (interactiveText && !isButtonSpeaking)
+      setTimeout(() => {
+        handleSpeak();
+      }, 200);
   }, [interactiveText]);
 
   function handleShowSolution(e, message) {


### PR DESCRIPTION
- After the latest update for the Audio player, the audio exercises would stop the animation abruptly when the exercise started. It seems like the cause for this was that the request to handle speak was being sent twice close together.


## Before:

https://github.com/user-attachments/assets/62b3b0b2-6e45-40b0-8872-d77ab99f1530

## After:

https://github.com/user-attachments/assets/e880d7c0-39df-4781-9995-c21eaacf6f30

