### PR TITLE
A prop wasn't deleted during refactoring

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -68,7 +68,6 @@ export default function FindArticles({
     noMoreArticlesToShow,
     resetPagination,
   ] = useArticlePagination(
-    api,
     articleList,
     setArticleList,
     searchQuery ? "Article Search" : strings.titleHome,


### PR DESCRIPTION
- An extra prop was being passed to the ArticlePagination hook that wasn't needed.