### PR TITLE
Update Bookmark with API data

### DIFF
--- a/src/api/translations.js
+++ b/src/api/translations.js
@@ -96,6 +96,7 @@ Zeeguu_API.prototype.updateBookmark = function (
   word,
   translation,
   context,
+  callback,
 ) {
   let payload = {
     word: word,
@@ -103,7 +104,15 @@ Zeeguu_API.prototype.updateBookmark = function (
     context: context,
   };
 
-  return this._post(`update_bookmark/${bookmark_id}`, qs.stringify(payload));
+  return this._post(
+    `update_bookmark/${bookmark_id}`,
+    qs.stringify(payload),
+    callback,
+    (error) => {
+      console.error(error);
+    },
+    true,
+  );
 };
 
 Zeeguu_API.prototype.basicTranlsate = function (from_lang, to_lang, phrase) {

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -93,28 +93,40 @@ export default function EditBookmarkButton({
     bookmark.context = newContext;
     bookmark.fit_for_study = newFitForStudy;
 
-    api.updateBookmark(bookmark.id, newWord, newTranslation, newContext);
-    if (newFitForStudy) {
-      api.userSetForExercises(bookmark.id);
-      api.logReaderActivity(
-        api.USER_SET_WORD_PREFERRED,
-        bookmark.article_id,
-        bookmark.from,
-        SOURCE_FOR_API_USER_PREFERENCE,
-      );
-    } else {
-      api.userSetNotForExercises(bookmark.id);
-      api.logReaderActivity(
-        api.USER_SET_NOT_WORD_PREFERED,
-        bookmark.article_id,
-        bookmark.from,
-        SOURCE_FOR_API_USER_PREFERENCE,
-      );
-    }
-    if (setReload) setReload(!reload);
-    if (notifyWordChange) notifyWordChange(bookmark.id);
-    toast.success("Thank you for the contribution!");
-    handleClose();
+    api.updateBookmark(
+      bookmark.id,
+      newWord,
+      newTranslation,
+      newContext,
+      (newBookmark) => {
+        bookmark.context_tokenized = newBookmark.context_tokenized;
+        bookmark.context_in_content = newBookmark.context_in_content;
+        bookmark.left_ellipsis = newBookmark.left_ellipsis;
+        bookmark.right_ellipsis = newBookmark.right_ellipsis;
+
+        if (newFitForStudy) {
+          api.userSetForExercises(newBookmark.id);
+          api.logReaderActivity(
+            api.USER_SET_WORD_PREFERRED,
+            newBookmark.article_id,
+            newBookmark.from,
+            SOURCE_FOR_API_USER_PREFERENCE,
+          );
+        } else {
+          api.userSetNotForExercises(newBookmark.id);
+          api.logReaderActivity(
+            api.USER_SET_NOT_WORD_PREFERED,
+            newBookmark.article_id,
+            newBookmark.from,
+            SOURCE_FOR_API_USER_PREFERENCE,
+          );
+        }
+        if (setReload) setReload(!reload);
+        if (notifyWordChange) notifyWordChange(bookmark.id);
+        toast.success("Thank you for the contribution!");
+        handleClose();
+      },
+    );
   }
   const isPhoneScreen = window.innerWidth < 800;
   return (

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -103,9 +103,10 @@ export default function EditBookmarkButton({
         bookmark.context_in_content = newBookmark.context_in_content;
         bookmark.left_ellipsis = newBookmark.left_ellipsis;
         bookmark.right_ellipsis = newBookmark.right_ellipsis;
+        bookmark.id = newBookmark.id;
 
         if (newFitForStudy) {
-          api.userSetForExercises(newBookmark.id);
+          api.userSetForExercises(bookmark.id);
           api.logReaderActivity(
             api.USER_SET_WORD_PREFERRED,
             newBookmark.article_id,
@@ -113,7 +114,7 @@ export default function EditBookmarkButton({
             SOURCE_FOR_API_USER_PREFERENCE,
           );
         } else {
-          api.userSetNotForExercises(newBookmark.id);
+          api.userSetNotForExercises(bookmark.id);
           api.logReaderActivity(
             api.USER_SET_NOT_WORD_PREFERED,
             newBookmark.article_id,


### PR DESCRIPTION
- API should update context after saving.

We now rely on the API to tokenize the contents, so after updating the bookmark we need to send the updated tokens to the frontend.

To do this, I extended the bookmark endpoint to send the bookmark details rather than just the ID.

This requires the following PR from the backend: https://github.com/zeeguu/api/pull/334

| Before | After |
| :-: | :-: |
| ![{FD38308A-7504-4035-A944-93BF3A455E05}](https://github.com/user-attachments/assets/cb0b1541-b9aa-4f5a-8f4d-d70d289c9faa)  | ![{021B0203-8F7D-4B27-B636-8CD976FEC591}](https://github.com/user-attachments/assets/9658f8c2-7c87-4c98-8414-8466e594acea) |