### PR TITLE
700 add a quick language change option to the sidenav and the bottomnav

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,16 +66,14 @@ function App() {
       api.isValidSession(
         () => {
           console.log("valid sesison... getting user details...");
-          api.getUserDetails((data) => {
-            LocalStorage.setUserInfo(data);
-            api.getUserPreferences((preferences) => {
-              LocalStorage.setUserPreferences(preferences);
-
-              let userDict = {
-                session: getSessionFromCookies(),
-                ...LocalStorage.userInfo(),
-              };
-              console.log("Session: " + api.session);
+          api.getUserDetails((userDetails) => {
+            LocalStorage.setUserInfo(userDetails);
+            console.log("User Details: ");
+            console.log(userDetails);
+            api.getUserPreferences((userPreferences) => {
+              LocalStorage.setUserPreferences(userPreferences);
+              console.log("User Preferences: ");
+              console.log(userPreferences);
 
               if (userHasNotExercisedToday())
                 api.getUserBookmarksToStudy(1, (scheduledBookmaks) => {
@@ -88,8 +86,13 @@ function App() {
                 exerciseNotification.setHasExercises(false);
                 exerciseNotification.updateReactState();
               }
-              setZeeguuSpeech(new ZeeguuSpeech(api, userDict.learned_language));
-              setUserData(userDict);
+              setZeeguuSpeech(
+                new ZeeguuSpeech(api, userDetails.learned_language),
+              );
+              setUserData({
+                userDetails: userDetails,
+                userPreferences: userPreferences,
+              });
             });
           });
         },
@@ -150,7 +153,7 @@ function App() {
     setUser(newUserValue);
 
     /* If a redirect link exists, uses it to redirect the user,
-                            otherwise, uses the location from the function argument. */
+                                                                            otherwise, uses the location from the function argument. */
     handleRedirectLinkOrGoTo("/articles");
   }
 
@@ -165,12 +168,18 @@ function App() {
     <SpeechContext.Provider value={zeeguuSpeech}>
       <BrowserRouter>
         <RoutingContext.Provider value={{ returnPath, setReturnPath }}>
-          <UserContext.Provider value={{ ...userData, logoutMethod: logout }}>
+          <UserContext.Provider
+            value={{
+              userData,
+              setUserData: setUserData,
+              session: getSessionFromCookies(),
+              logoutMethod: logout,
+            }}
+          >
             <ExerciseCountContext.Provider value={exerciseNotification}>
               <APIContext.Provider value={api}>
                 {/* Routing*/}
                 <MainAppRouter
-                  setUser={setUserData}
                   hasExtension={isExtensionAvailable}
                   handleSuccessfulLogIn={handleSuccessfulLogIn}
                 />

--- a/src/App.js
+++ b/src/App.js
@@ -37,20 +37,19 @@ function App() {
 
   useUILanguage();
 
-  const [userData, setUserData] = useState();
+  const [userDetails, setUserDetails] = useState();
+  const [userPreferences, setUserPreferences] = useState();
 
   const [isExtensionAvailable] = useExtensionCommunication();
   const [zeeguuSpeech, setZeeguuSpeech] = useState(false);
   let { handleRedirectLinkOrGoTo } = useRedirectLink();
 
   useEffect(() => {
-    if (userData && userData.userDetails.learned_language) {
-      setZeeguuSpeech(
-        new ZeeguuSpeech(api, userData.userDetails.learned_language),
-      );
+    if (userDetails && userDetails.learned_language) {
+      setZeeguuSpeech(new ZeeguuSpeech(api, userDetails.learned_language));
     }
     // eslint-disable-next-line
-  }, [userData]);
+  }, [userDetails]);
 
   useEffect(() => {
     console.log("Got the API URL:" + API_ENDPOINT);
@@ -88,10 +87,8 @@ function App() {
               setZeeguuSpeech(
                 new ZeeguuSpeech(api, userDetails.learned_language),
               );
-              setUserData({
-                userDetails: userDetails,
-                userPreferences: userPreferences,
-              });
+              setUserDetails(userDetails);
+              setUserPreferences(userPreferences);
             });
           });
         },
@@ -104,7 +101,8 @@ function App() {
     //logs out user on zeeguu.org if they log out of the extension
     const interval = setInterval(() => {
       if (!getSessionFromCookies()) {
-        setUserData({});
+        setUserDetails({});
+        setUserPreferences({});
       }
     }, 1000);
     return () => clearInterval(interval);
@@ -115,7 +113,8 @@ function App() {
   function logout() {
     LocalStorage.deleteUserInfo();
     LocalStorage.deleteUserPreferences();
-    setUserData({});
+    setUserDetails({});
+    setUserPreferences({});
 
     removeUserInfoFromCookies();
   }
@@ -159,7 +158,7 @@ function App() {
   //Setting up the routing context to be able to use the cancel-button in EditText correctly
   const [returnPath, setReturnPath] = useState("");
 
-  if (userData === undefined) {
+  if (userDetails === undefined) {
     return <LoadingAnimation />;
   }
 
@@ -169,8 +168,10 @@ function App() {
         <RoutingContext.Provider value={{ returnPath, setReturnPath }}>
           <UserContext.Provider
             value={{
-              userData,
-              setUserData: setUserData,
+              userDetails,
+              setUserDetails,
+              userPreferences,
+              setUserPreferences,
               session: getSessionFromCookies(),
               logoutMethod: logout,
             }}

--- a/src/App.js
+++ b/src/App.js
@@ -72,8 +72,6 @@ function App() {
             console.log(userDetails);
             api.getUserPreferences((userPreferences) => {
               LocalStorage.setUserPreferences(userPreferences);
-              console.log("User Preferences: ");
-              console.log(userPreferences);
 
               if (userHasNotExercisedToday())
                 api.getUserBookmarksToStudy(1, (scheduledBookmaks) => {

--- a/src/App.js
+++ b/src/App.js
@@ -38,13 +38,16 @@ function App() {
   useUILanguage();
 
   const [userData, setUserData] = useState();
+
   const [isExtensionAvailable] = useExtensionCommunication();
   const [zeeguuSpeech, setZeeguuSpeech] = useState(false);
   let { handleRedirectLinkOrGoTo } = useRedirectLink();
 
   useEffect(() => {
-    if (userData && userData.learned_language) {
-      setZeeguuSpeech(new ZeeguuSpeech(api, userData.learned_language));
+    if (userData && userData.userDetails.learned_language) {
+      setZeeguuSpeech(
+        new ZeeguuSpeech(api, userData.userDetails.learned_language),
+      );
     }
     // eslint-disable-next-line
   }, [userData]);
@@ -68,8 +71,6 @@ function App() {
           console.log("valid sesison... getting user details...");
           api.getUserDetails((userDetails) => {
             LocalStorage.setUserInfo(userDetails);
-            console.log("User Details: ");
-            console.log(userDetails);
             api.getUserPreferences((userPreferences) => {
               LocalStorage.setUserPreferences(userPreferences);
 

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -79,44 +79,30 @@ export default function MainAppRouter({
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/articles"
-        api={api}
         component={ArticlesRouter}
       />
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/exercises"
-        api={api}
         component={ExercisesRouter}
       />
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/words"
-        api={api}
         component={WordsRouter}
       />
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/history"
-        api={api}
         component={ReadingHistory}
       />
       <PrivateRouteWithMainNav
-        path="/account_settings"
         setUser={setUser}
+        path="/account_settings"
         component={SettingsRouter}
       />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/teacher"
-        api={api}
-        component={TeacherRouter}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/read/article"
-        api={api}
-        component={ArticleReader}
-      />
+      <PrivateRouteWithMainNav path="/teacher" component={TeacherRouter} />
+      <PrivateRouteWithMainNav path="/read/article" component={ArticleReader} />
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/user_dashboard"
@@ -125,7 +111,6 @@ export default function MainAppRouter({
       <PrivateRouteWithMainNav
         setUser={setUser}
         path="/search"
-        api={api}
         component={ArticlesRouter}
       />
       <PrivateRouteWithMainNav

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -24,11 +24,7 @@ import SettingsRouter from "./pages/Settings/_SettingsRouter";
 import ExercisesForArticle from "./exercises/ExercisesForArticle";
 import { UMR_SOURCE } from "./reader/ArticleReader";
 
-export default function MainAppRouter({
-  setUser,
-  hasExtension,
-  handleSuccessfulLogIn,
-}) {
+export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
   return (
     <Switch>
       <Route
@@ -39,10 +35,7 @@ export default function MainAppRouter({
       <Route
         path="/account_details"
         render={() => (
-          <CreateAccount
-            handleSuccessfulLogIn={handleSuccessfulLogIn}
-            setUser={setUser}
-          />
+          <CreateAccount handleSuccessfulLogIn={handleSuccessfulLogIn} />
         )}
       />
 
@@ -76,45 +69,22 @@ export default function MainAppRouter({
         component={ExcludeWords}
       />
 
+      <PrivateRouteWithMainNav path="/articles" component={ArticlesRouter} />
+      <PrivateRouteWithMainNav path="/exercises" component={ExercisesRouter} />
+      <PrivateRouteWithMainNav path="/words" component={WordsRouter} />
+      <PrivateRouteWithMainNav path="/history" component={ReadingHistory} />
       <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/articles"
-        component={ArticlesRouter}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/exercises"
-        component={ExercisesRouter}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/words"
-        component={WordsRouter}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/history"
-        component={ReadingHistory}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
         path="/account_settings"
         component={SettingsRouter}
       />
       <PrivateRouteWithMainNav path="/teacher" component={TeacherRouter} />
       <PrivateRouteWithMainNav path="/read/article" component={ArticleReader} />
       <PrivateRouteWithMainNav
-        setUser={setUser}
         path="/user_dashboard"
         component={UserDashboard}
       />
+      <PrivateRouteWithMainNav path="/search" component={ArticlesRouter} />
       <PrivateRouteWithMainNav
-        setUser={setUser}
-        path="/search"
-        component={ArticlesRouter}
-      />
-      <PrivateRouteWithMainNav
-        setUser={setUser}
         path="/articleWordReview/:articleID"
         component={ExercisesForArticle}
         source={UMR_SOURCE}

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -76,30 +76,60 @@ export default function MainAppRouter({
         component={ExcludeWords}
       />
 
-      <PrivateRouteWithMainNav path="/articles" component={ArticlesRouter} />
-
-      <PrivateRouteWithMainNav path="/exercises" component={ExercisesRouter} />
-
-      <PrivateRouteWithMainNav path="/words" component={WordsRouter} />
-
-      <PrivateRouteWithMainNav path="/history" component={ReadingHistory} />
-
+      <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/articles"
+        api={api}
+        component={ArticlesRouter}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/exercises"
+        api={api}
+        component={ExercisesRouter}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/words"
+        api={api}
+        component={WordsRouter}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/history"
+        api={api}
+        component={ReadingHistory}
+      />
       <PrivateRouteWithMainNav
         path="/account_settings"
         setUser={setUser}
         component={SettingsRouter}
       />
-      <PrivateRouteWithMainNav path="/teacher" component={TeacherRouter} />
-
-      <PrivateRouteWithMainNav path="/read/article" component={ArticleReader} />
-
       <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/teacher"
+        api={api}
+        component={TeacherRouter}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/read/article"
+        api={api}
+        component={ArticleReader}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
         path="/user_dashboard"
         component={UserDashboard}
       />
-      <PrivateRouteWithMainNav path="/search" component={ArticlesRouter} />
-
       <PrivateRouteWithMainNav
+        setUser={setUser}
+        path="/search"
+        api={api}
+        component={ArticlesRouter}
+      />
+      <PrivateRouteWithMainNav
+        setUser={setUser}
         path="/articleWordReview/:articleID"
         component={ExercisesForArticle}
         source={UMR_SOURCE}

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -9,8 +9,6 @@ export default function MainNavWithComponent(props) {
   const { children: appContent, setUser } = props;
   const { screenWidth } = useScreenWidth();
 
-  console.log("MainNavWithComponent", { setUser });
-
   const path = useLocation().pathname;
 
   //Initial state and setter passed to the value prop of the MainNavContext.Provider

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -9,8 +9,7 @@ import * as s from "./MainNavWithComponent.sc";
 export default function MainNavWithComponent(props) {
   const { children: appContent } = props;
   const { screenWidth } = useScreenWidth();
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   const path = useLocation().pathname;
 

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -1,13 +1,15 @@
-import * as s from "./MainNavWithComponent.sc";
-import MainNav from "./components/MainNav/MainNav";
-import useScreenWidth from "./hooks/useScreenWidth";
+import { useEffect, useState, useContext } from "react";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { MainNavContext } from "./contexts/MainNavContext";
-import { useEffect, useState } from "react";
+import { UserContext } from "./contexts/UserContext";
+import useScreenWidth from "./hooks/useScreenWidth";
+import MainNav from "./components/MainNav/MainNav";
+import * as s from "./MainNavWithComponent.sc";
 
 export default function MainNavWithComponent(props) {
   const { children: appContent, setUser } = props;
   const { screenWidth } = useScreenWidth();
+  const user = useContext(UserContext);
 
   const path = useLocation().pathname;
 
@@ -34,6 +36,10 @@ export default function MainNavWithComponent(props) {
       <s.MainNavWithComponent $screenWidth={screenWidth}>
         <MainNav setUser={setUser} screenWidth={screenWidth} />
         <s.AppContent
+          // Update the key when the learned_language changes to trigger a re-render
+          // of the app content that needs real-time updates. This is a smoother
+          // alternative to window.location.reload() when switching the practiced language in navigation.
+          key={user.learned_language}
           $currentPath={path}
           $screenWidth={screenWidth}
           id="scrollHolder"

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -9,7 +9,8 @@ import * as s from "./MainNavWithComponent.sc";
 export default function MainNavWithComponent(props) {
   const { children: appContent, setUser } = props;
   const { screenWidth } = useScreenWidth();
-  const userContext = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
 
   const path = useLocation().pathname;
 
@@ -39,7 +40,7 @@ export default function MainNavWithComponent(props) {
           // Update the key when the learned_language changes to trigger a re-render
           // of the app content that needs real-time updates. This is a smoother
           // alternative to window.location.reload() when switching the practiced language in navigation.
-          key={userContext.userData.userDetails.learned_language}
+          key={userDetails.learned_language}
           $currentPath={path}
           $screenWidth={screenWidth}
           id="scrollHolder"

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -6,8 +6,10 @@ import { MainNavContext } from "./contexts/MainNavContext";
 import { useEffect, useState } from "react";
 
 export default function MainNavWithComponent(props) {
-  const { children: appContent } = props;
+  const { children: appContent, setUser } = props;
   const { screenWidth } = useScreenWidth();
+
+  console.log("MainNavWithComponent", { setUser });
 
   const path = useLocation().pathname;
 
@@ -32,7 +34,7 @@ export default function MainNavWithComponent(props) {
       }}
     >
       <s.MainNavWithComponent $screenWidth={screenWidth}>
-        <MainNav screenWidth={screenWidth} />
+        <MainNav setUser={setUser} screenWidth={screenWidth} />
         <s.AppContent
           $currentPath={path}
           $screenWidth={screenWidth}

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -9,7 +9,7 @@ import * as s from "./MainNavWithComponent.sc";
 export default function MainNavWithComponent(props) {
   const { children: appContent, setUser } = props;
   const { screenWidth } = useScreenWidth();
-  const user = useContext(UserContext);
+  const userContext = useContext(UserContext);
 
   const path = useLocation().pathname;
 
@@ -39,7 +39,7 @@ export default function MainNavWithComponent(props) {
           // Update the key when the learned_language changes to trigger a re-render
           // of the app content that needs real-time updates. This is a smoother
           // alternative to window.location.reload() when switching the practiced language in navigation.
-          key={user.learned_language}
+          key={userContext.userData.userDetails.learned_language}
           $currentPath={path}
           $screenWidth={screenWidth}
           id="scrollHolder"

--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -7,7 +7,7 @@ import MainNav from "./components/MainNav/MainNav";
 import * as s from "./MainNavWithComponent.sc";
 
 export default function MainNavWithComponent(props) {
-  const { children: appContent, setUser } = props;
+  const { children: appContent } = props;
   const { screenWidth } = useScreenWidth();
   const { userData } = useContext(UserContext);
   const { userDetails } = userData;
@@ -35,7 +35,7 @@ export default function MainNavWithComponent(props) {
       }}
     >
       <s.MainNavWithComponent $screenWidth={screenWidth}>
-        <MainNav setUser={setUser} screenWidth={screenWidth} />
+        <MainNav screenWidth={screenWidth} />
         <s.AppContent
           // Update the key when the learned_language changes to trigger a re-render
           // of the app content that needs real-time updates. This is a smoother

--- a/src/PrivateRoute.js
+++ b/src/PrivateRoute.js
@@ -10,11 +10,12 @@ import { UserContext } from "./contexts/UserContext";
 //- they cannot access the content of Zeeguu and will be redirected to the login-page
 
 const PrivateRoute = ({ component: Component, ...rest }) => {
-  const user = useContext(UserContext);
+  const { session } = useContext(UserContext);
+
   const isAccountDelition = window.location.href.includes(
     APP_DOMAIN + "account_deletion",
   );
-  if (!user.session) {
+  if (!session) {
     if (isAccountDelition) {
       return (
         <Redirect

--- a/src/PrivateRouteWithMainNav.js
+++ b/src/PrivateRouteWithMainNav.js
@@ -12,6 +12,8 @@ import MainNavWithComponent from "./MainNavWithComponent";
 export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
   const user = useContext(UserContext);
 
+  console.log("Rest", { rest });
+
   if (!user.session) {
     return (
       <Redirect
@@ -26,7 +28,9 @@ export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
     <Route
       {...rest}
       render={() => (
-        <MainNavWithComponent>{<Component {...rest} />}</MainNavWithComponent>
+        <MainNavWithComponent {...rest}>
+          {<Component {...rest} />}
+        </MainNavWithComponent>
       )}
     />
   );

--- a/src/PrivateRouteWithMainNav.js
+++ b/src/PrivateRouteWithMainNav.js
@@ -10,10 +10,9 @@ import MainNavWithComponent from "./MainNavWithComponent";
 //- they cannot access the content of Zeeguu and will be redirected to the login-page
 
 export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
-  const user = useContext(UserContext);
-  //TODO: modify the UserContext so that the setUser function could be accessed here, instead of being drilled
+  const { session } = useContext(UserContext);
 
-  if (!user.session) {
+  if (!session) {
     return (
       <Redirect
         to={{
@@ -27,9 +26,7 @@ export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
     <Route
       {...rest}
       render={() => (
-        <MainNavWithComponent {...rest}>
-          {<Component {...rest} />}
-        </MainNavWithComponent>
+        <MainNavWithComponent>{<Component {...rest} />}</MainNavWithComponent>
       )}
     />
   );

--- a/src/PrivateRouteWithMainNav.js
+++ b/src/PrivateRouteWithMainNav.js
@@ -12,8 +12,6 @@ import MainNavWithComponent from "./MainNavWithComponent";
 export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
   const user = useContext(UserContext);
 
-  console.log("Rest", { rest });
-
   if (!user.session) {
     return (
       <Redirect

--- a/src/PrivateRouteWithMainNav.js
+++ b/src/PrivateRouteWithMainNav.js
@@ -11,6 +11,7 @@ import MainNavWithComponent from "./MainNavWithComponent";
 
 export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
   const user = useContext(UserContext);
+  //TODO: modify the UserContext so that the setUser function could be accessed here, instead of being drilled
 
   if (!user.session) {
     return (

--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import FeedbackModal from "./FeedbackModal";
 import { FEEDBACK_OPTIONS } from "./FeedbackConstants";
+import FeedbackModal from "./FeedbackModal";
 import NavOption from "./MainNav/NavOption";
 import FeedbackRoundedIcon from "@mui/icons-material/FeedbackRounded";
 
@@ -17,6 +17,7 @@ export default function FeedbackButton({ screenWidth }) {
         feedbackOptions={FEEDBACK_OPTIONS.ALL}
       ></FeedbackModal>
       <NavOption
+        ariaHasPopup={"dialog"}
         icon={<FeedbackRoundedIcon />}
         screenWidth={screenWidth}
         text={"Give Feedback"}

--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -20,7 +20,6 @@ export default function FeedbackButton({ screenWidth }) {
         icon={<FeedbackRoundedIcon />}
         screenWidth={screenWidth}
         text={"Give Feedback"}
-        isButton={true}
         onClick={(e) => {
           e.stopPropagation();
           setShowFeedbackModal(!showFeedbackModal);

--- a/src/components/MainNav/BottomNav/BottomNav.js
+++ b/src/components/MainNav/BottomNav/BottomNav.js
@@ -12,7 +12,7 @@ import { fadeIn, fadeOut } from "../../transitions";
 import { slideIn, slideOut } from "../../transitions";
 import * as s from "./BottomNav.sc";
 
-export default function BottomNav({ setUser }) {
+export default function BottomNav() {
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 
@@ -65,9 +65,7 @@ export default function BottomNav({ setUser }) {
           $bottomNavTransition={bottomNavTransition}
         >
           <s.NavList>
-            {isOnStudentSide && (
-              <BottomNavOptionsForStudent setUser={setUser} />
-            )}
+            {isOnStudentSide && <BottomNavOptionsForStudent />}
 
             {!isOnStudentSide && <BottomNavOptionsForTeacher />}
 

--- a/src/components/MainNav/BottomNav/BottomNav.js
+++ b/src/components/MainNav/BottomNav/BottomNav.js
@@ -60,16 +60,22 @@ export default function BottomNav() {
   return (
     <>
       {renderBottomNav && (
-        <s.BottomNav $bottomNavTransition={bottomNavTransition}>
-          {isOnStudentSide && <BottomNavOptionsForStudent />}
+        <s.BottomNav
+          aria-label="Bottom Navigation"
+          $bottomNavTransition={bottomNavTransition}
+        >
+          <s.NavList>
+            {isOnStudentSide && <BottomNavOptionsForStudent />}
 
-          {!isOnStudentSide && <BottomNavOptionsForTeacher />}
+            {!isOnStudentSide && <BottomNavOptionsForTeacher />}
 
-          <BottomNavOption
-            onClick={handleShowMoreOptions}
-            icon={<NavIcon name="more" />}
-            text={strings.more}
-          />
+            <BottomNavOption
+              onClick={handleShowMoreOptions}
+              icon={<NavIcon name="more" />}
+              text={strings.more}
+              ariaHasPopup={"true"}
+            />
+          </s.NavList>
         </s.BottomNav>
       )}
 

--- a/src/components/MainNav/BottomNav/BottomNav.js
+++ b/src/components/MainNav/BottomNav/BottomNav.js
@@ -1,16 +1,16 @@
-import * as s from "./BottomNav.sc";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { useEffect, useState, useRef, useContext } from "react";
+import { MainNavContext } from "../../../contexts/MainNavContext";
+import { PAGES_WITHOUT_BOTTOM_NAV } from "./pagesWithoutBottomNav";
+import strings from "../../../i18n/definitions";
 import NavIcon from "../NavIcon";
 import MoreOptionsPanel from "./MoreOptionsPanel";
 import BottomNavOptionsForStudent from "./BottomNavOptionsForStudent";
 import BottomNavOptionsForTeacher from "./BottomNavOptionsForTeacher";
 import BottomNavOption from "./BottomNavOption";
-import strings from "../../../i18n/definitions";
 import { fadeIn, fadeOut } from "../../transitions";
 import { slideIn, slideOut } from "../../transitions";
-import { MainNavContext } from "../../../contexts/MainNavContext";
-import { PAGES_WITHOUT_BOTTOM_NAV } from "./pagesWithoutBottomNav";
+import * as s from "./BottomNav.sc";
 
 export default function BottomNav() {
   const { mainNavProperties } = useContext(MainNavContext);
@@ -64,13 +64,6 @@ export default function BottomNav() {
           {isOnStudentSide && <BottomNavOptionsForStudent />}
 
           {!isOnStudentSide && <BottomNavOptionsForTeacher />}
-
-          <BottomNavOption
-            linkTo={"/account_settings"}
-            currentPath={path}
-            icon={<NavIcon name="settings" />}
-            text={strings.settings}
-          />
 
           <BottomNavOption
             onClick={handleShowMoreOptions}

--- a/src/components/MainNav/BottomNav/BottomNav.js
+++ b/src/components/MainNav/BottomNav/BottomNav.js
@@ -12,7 +12,7 @@ import { fadeIn, fadeOut } from "../../transitions";
 import { slideIn, slideOut } from "../../transitions";
 import * as s from "./BottomNav.sc";
 
-export default function BottomNav() {
+export default function BottomNav({ setUser }) {
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 
@@ -65,7 +65,9 @@ export default function BottomNav() {
           $bottomNavTransition={bottomNavTransition}
         >
           <s.NavList>
-            {isOnStudentSide && <BottomNavOptionsForStudent />}
+            {isOnStudentSide && (
+              <BottomNavOptionsForStudent setUser={setUser} />
+            )}
 
             {!isOnStudentSide && <BottomNavOptionsForTeacher />}
 

--- a/src/components/MainNav/BottomNav/BottomNav.sc.js
+++ b/src/components/MainNav/BottomNav/BottomNav.sc.js
@@ -3,9 +3,6 @@ import styled from "styled-components";
 const BottomNav = styled.nav`
   box-sizing: border-box;
   width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
   position: fixed;
   bottom: 0;
   padding: 0.5rem 1rem 1rem 1rem;
@@ -16,4 +13,12 @@ const BottomNav = styled.nav`
     ease-in-out forwards;
 `;
 
-export { BottomNav };
+const NavList = styled.ul`
+  all: unset;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+export { BottomNav, NavList };

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { FEEDBACK_OPTIONS } from "../../FeedbackConstants";
 import LanguageModal from "../LanguageModal";
-import BottomNavOption from "../BottomNavOption";
+import BottomNavOption from "./BottomNavOption";
 import NavIcon from "../NavIcon";
 
 export default function BottomNavLanguageOption() {
@@ -10,7 +10,7 @@ export default function BottomNavLanguageOption() {
     <>
       <BottomNavOption
         icon={<NavIcon name="language" />}
-        text={strings.more}
+        text={"Language"}
         onClick={(e) => {
           e.stopPropagation();
           setShowLanguageModal(!showLanguageModal);

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -7,8 +7,7 @@ import navLanguages from "../navLanguages";
 
 export default function BottomNavLanguageOption() {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   const currentLearnedLanguage = useMemo(() => {
     const languageCode = userDetails.learned_language;

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -5,15 +5,19 @@ import BottomNavOption from "./BottomNavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 
-export default function BottomNavLanguageOption({ setUser }) {
+export default function BottomNavLanguageOption() {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const user = useContext(UserContext);
+  const userContext = useContext(UserContext);
 
   const currentLearnedLanguage = useMemo(() => {
-    const languageCode = user.learned_language;
+    const languageCode = userContext.userData.userDetails.learned_language;
+    console.log(
+      "Language Code: Inside bottom nav language option: ",
+      languageCode,
+    );
     const languageName = navLanguages[languageCode];
     return languageName || "Language";
-  }, [user.learned_language]);
+  }, [userContext]);
 
   const languageDisplayed = currentLearnedLanguage || "Language";
   return (
@@ -29,7 +33,6 @@ export default function BottomNavLanguageOption({ setUser }) {
         }}
       />
       <LanguageModal
-        setUser={setUser}
         prefixMsg={"Sidebar"}
         open={showLanguageModal}
         setOpen={() => {

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -10,14 +10,8 @@ export default function BottomNavLanguageOption() {
   const { userData } = useContext(UserContext);
   const { userDetails } = userData;
 
-  console.log("User data", userData);
-
   const currentLearnedLanguage = useMemo(() => {
     const languageCode = userDetails.learned_language;
-    console.log(
-      "Language Code: Inside bottom nav language option: ",
-      languageCode,
-    );
     const languageName = navLanguages[languageCode];
     return languageName || "Language";
   }, [userDetails.learned_language]);

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { FEEDBACK_OPTIONS } from "../../FeedbackConstants";
 import LanguageModal from "../LanguageModal";
 import BottomNavOption from "./BottomNavOption";
 import NavIcon from "../NavIcon";
@@ -9,6 +8,7 @@ export default function BottomNavLanguageOption() {
   return (
     <>
       <BottomNavOption
+        ariaHasPopup={"dialog"}
         icon={<NavIcon name="language" />}
         text={"Language"}
         onClick={(e) => {
@@ -22,7 +22,6 @@ export default function BottomNavLanguageOption() {
         setOpen={() => {
           setShowLanguageModal(!showLanguageModal);
         }}
-        feedbackOptions={FEEDBACK_OPTIONS.ALL}
       ></LanguageModal>
     </>
   );

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -5,7 +5,7 @@ import BottomNavOption from "./BottomNavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 
-export default function BottomNavLanguageOption() {
+export default function BottomNavLanguageOption({ setUser }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
   const user = useContext(UserContext);
 
@@ -29,6 +29,7 @@ export default function BottomNavLanguageOption() {
         }}
       />
       <LanguageModal
+        setUser={setUser}
         prefixMsg={"Sidebar"}
         open={showLanguageModal}
         setOpen={() => {

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -1,16 +1,28 @@
-import { useState } from "react";
+import { useState, useMemo, useContext } from "react";
+import { UserContext } from "../../../contexts/UserContext";
 import LanguageModal from "../LanguageModal";
 import BottomNavOption from "./BottomNavOption";
 import NavIcon from "../NavIcon";
+import navLanguages from "../navLanguages";
 
 export default function BottomNavLanguageOption() {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
+  const user = useContext(UserContext);
+
+  const currentLearnedLanguage = useMemo(() => {
+    const languageCode = user.learned_language;
+    const languageName = navLanguages[languageCode];
+    return languageName || "Language";
+  }, [user.learned_language]);
+
+  const languageDisplayed = currentLearnedLanguage || "Language";
   return (
     <>
       <BottomNavOption
         ariaHasPopup={"dialog"}
+        ariaLabel={`Change language (currently: ${languageDisplayed})`}
         icon={<NavIcon name="language" />}
-        text={"Language"}
+        text={languageDisplayed}
         onClick={(e) => {
           e.stopPropagation();
           setShowLanguageModal(!showLanguageModal);

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -7,17 +7,20 @@ import navLanguages from "../navLanguages";
 
 export default function BottomNavLanguageOption() {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const userContext = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
+
+  console.log("User data", userData);
 
   const currentLearnedLanguage = useMemo(() => {
-    const languageCode = userContext.userData.userDetails.learned_language;
+    const languageCode = userDetails.learned_language;
     console.log(
       "Language Code: Inside bottom nav language option: ",
       languageCode,
     );
     const languageName = navLanguages[languageCode];
     return languageName || "Language";
-  }, [userContext]);
+  }, [userDetails.learned_language]);
 
   const languageDisplayed = currentLearnedLanguage || "Language";
   return (

--- a/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavLanguageOption.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { FEEDBACK_OPTIONS } from "../../FeedbackConstants";
+import LanguageModal from "../LanguageModal";
+import BottomNavOption from "../BottomNavOption";
+import NavIcon from "../NavIcon";
+
+export default function BottomNavLanguageOption() {
+  const [showLanguageModal, setShowLanguageModal] = useState(false);
+  return (
+    <>
+      <BottomNavOption
+        icon={<NavIcon name="language" />}
+        text={strings.more}
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowLanguageModal(!showLanguageModal);
+        }}
+      />
+      <LanguageModal
+        prefixMsg={"Sidebar"}
+        open={showLanguageModal}
+        setOpen={() => {
+          setShowLanguageModal(!showLanguageModal);
+        }}
+        feedbackOptions={FEEDBACK_OPTIONS.ALL}
+      ></LanguageModal>
+    </>
+  );
+}

--- a/src/components/MainNav/BottomNav/BottomNavOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavOption.js
@@ -8,13 +8,19 @@ export default function BottomNavOption({
   text,
   notification,
   ariaHasPopup,
+  ariaLabel,
 }) {
   const Component = linkTo ? s.StyledLink : s.StyledButton;
   const isActive = currentPath?.includes(linkTo);
 
   return (
     <s.BottomNavOption>
-      <Component to={linkTo} onClick={onClick} aria-haspopup={ariaHasPopup}>
+      <Component
+        to={linkTo}
+        onClick={onClick}
+        aria-haspopup={ariaHasPopup}
+        aria-label={ariaLabel}
+      >
         {notification}
         <s.IconSpan isActive={isActive}>{icon}</s.IconSpan>
         {text}

--- a/src/components/MainNav/BottomNav/BottomNavOption.js
+++ b/src/components/MainNav/BottomNav/BottomNavOption.js
@@ -7,13 +7,14 @@ export default function BottomNavOption({
   icon,
   text,
   notification,
+  ariaHasPopup,
 }) {
   const Component = linkTo ? s.StyledLink : s.StyledButton;
   const isActive = currentPath?.includes(linkTo);
 
   return (
     <s.BottomNavOption>
-      <Component to={linkTo && linkTo} onClick={onClick}>
+      <Component to={linkTo} onClick={onClick} aria-haspopup={ariaHasPopup}>
         {notification}
         <s.IconSpan isActive={isActive}>{icon}</s.IconSpan>
         {text}

--- a/src/components/MainNav/BottomNav/BottomNavOption.sc.js
+++ b/src/components/MainNav/BottomNav/BottomNavOption.sc.js
@@ -10,6 +10,8 @@ const OptionShared = css`
   width: 4rem;
   height: 3rem;
   gap: 0.2rem;
+  font-weight: 700;
+  font-size: 0.7rem;
   white-space: nowrap;
   user-select: none;
   position: relative;
@@ -20,8 +22,6 @@ const OptionShared = css`
 const BottomNavOption = styled.li`
   box-sizing: border-box;
   list-style: none;
-  font-weight: 700;
-  font-size: 0.7rem;
   position: relative;
 `;
 
@@ -30,7 +30,6 @@ const StyledLink = styled(Link)`
 `;
 
 const StyledButton = styled.button`
-  font: inherit;
   border: inherit;
   padding: inherit;
   margin: inherit;

--- a/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
+++ b/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
@@ -5,7 +5,7 @@ import BottomNavOption from "./BottomNavOption";
 import NavigationOptions from "../navigationOptions";
 import BottomNavLanguageOption from "./BottomNavLanguageOption";
 
-export default function BottomNavOptionsForStudent() {
+export default function BottomNavOptionsForStudent({ setUser }) {
   const path = useLocation().pathname;
   const { hasExerciseNotification, notificationMsg } =
     useExerciseNotification();
@@ -26,7 +26,7 @@ export default function BottomNavOptionsForStudent() {
         }
       />
       <BottomNavOption {...NavigationOptions.words} currentPath={path} />
-      <BottomNavLanguageOption />
+      <BottomNavLanguageOption setUser={setUser} />
     </>
   );
 }

--- a/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
+++ b/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
@@ -5,7 +5,7 @@ import BottomNavOption from "./BottomNavOption";
 import NavigationOptions from "../navigationOptions";
 import BottomNavLanguageOption from "./BottomNavLanguageOption";
 
-export default function BottomNavOptionsForStudent({ setUser }) {
+export default function BottomNavOptionsForStudent() {
   const path = useLocation().pathname;
   const { hasExerciseNotification, notificationMsg } =
     useExerciseNotification();
@@ -26,7 +26,7 @@ export default function BottomNavOptionsForStudent({ setUser }) {
         }
       />
       <BottomNavOption {...NavigationOptions.words} currentPath={path} />
-      <BottomNavLanguageOption setUser={setUser} />
+      <BottomNavLanguageOption />
     </>
   );
 }

--- a/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
+++ b/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
@@ -3,6 +3,7 @@ import NotificationIcon from "../../NotificationIcon";
 import useExerciseNotification from "../../../hooks/useExerciseNotification";
 import BottomNavOption from "./BottomNavOption";
 import NavigationOptions from "../navigationOptions";
+import BottomNavLanguageOption from "./BottomNavLanguageOption";
 
 export default function BottomNavOptionsForStudent() {
   const path = useLocation().pathname;
@@ -12,7 +13,6 @@ export default function BottomNavOptionsForStudent() {
   return (
     <>
       <BottomNavOption {...NavigationOptions.articles} currentPath={path} />
-
       <BottomNavOption
         {...NavigationOptions.exercises}
         currentPath={path}
@@ -25,8 +25,8 @@ export default function BottomNavOptionsForStudent() {
           )
         }
       />
-
       <BottomNavOption {...NavigationOptions.words} currentPath={path} />
+      <BottomNavLanguageOption />
     </>
   );
 }

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.js
@@ -1,11 +1,12 @@
-import * as s from "./MoreOptionsPanel.sc";
 import { useContext } from "react";
 import { UserContext } from "../../../contexts/UserContext";
+import { MainNavContext } from "../../../contexts/MainNavContext";
+import { useLocation } from "react-router-dom/cjs/react-router-dom";
+import NavigationOptions from "../navigationOptions";
 import FeedbackButton from "../../FeedbackButton";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import NavOption from "../NavOption";
-import NavigationOptions from "../navigationOptions";
-import { MainNavContext } from "../../../contexts/MainNavContext";
+import * as s from "./MoreOptionsPanel.sc";
 
 export default function MoreOptionsPanel({
   overlayTransition,
@@ -17,6 +18,7 @@ export default function MoreOptionsPanel({
   const { is_teacher: isTeacher } = useContext(UserContext);
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
+  const path = useLocation().pathname;
 
   return (
     <s.MoreOptionsWrapper
@@ -68,6 +70,12 @@ export default function MoreOptionsPanel({
             onClick={handleHideMoreOptions}
           />
         )}
+
+        <NavOption
+          {...NavigationOptions.settings}
+          currentPath={path}
+          onClick={handleHideMoreOptions}
+        />
 
         <FeedbackButton />
       </s.MoreOptionsPanel>

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.js
@@ -15,7 +15,9 @@ export default function MoreOptionsPanel({
   currentPath,
   renderMoreOptions,
 }) {
-  const { is_teacher: isTeacher } = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
+
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
   const path = useLocation().pathname;
@@ -58,7 +60,7 @@ export default function MoreOptionsPanel({
                 onClick={handleHideMoreOptions}
               />
 
-              {isTeacher && (
+              {userDetails.is_teacher && (
                 <NavOption
                   {...NavigationOptions.teacherSite}
                   currentPath={currentPath}

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.js
@@ -15,8 +15,7 @@ export default function MoreOptionsPanel({
   currentPath,
   renderMoreOptions,
 }) {
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.js
@@ -27,6 +27,7 @@ export default function MoreOptionsPanel({
       onClick={handleHideMoreOptions}
     >
       <s.MoreOptionsPanel
+        aria-label="More Options Menu panel"
         $renderMoreOptions={renderMoreOptions}
         $moreOptionsTransition={moreOptionsTransition}
         onClick={(e) => {
@@ -34,50 +35,55 @@ export default function MoreOptionsPanel({
         }}
       >
         <s.CloseSection>
-          <s.CloseButton onClick={handleHideMoreOptions}>
+          <s.CloseButton
+            aria-label="Close More Options panel"
+            onClick={handleHideMoreOptions}
+          >
             <CloseRoundedIcon fontSize="small" />
           </s.CloseButton>
         </s.CloseSection>
 
-        {isOnStudentSide && (
-          <>
-            <NavOption
-              {...NavigationOptions.statistics}
-              currentPath={currentPath}
-              onClick={handleHideMoreOptions}
-            />
-
-            <NavOption
-              {...NavigationOptions.history}
-              currentPath={currentPath}
-              onClick={handleHideMoreOptions}
-            />
-
-            {isTeacher && (
+        <s.MoreOptionsList>
+          {isOnStudentSide && (
+            <>
               <NavOption
-                {...NavigationOptions.teacherSite}
+                {...NavigationOptions.statistics}
                 currentPath={currentPath}
                 onClick={handleHideMoreOptions}
               />
-            )}
-          </>
-        )}
 
-        {!isOnStudentSide && (
+              <NavOption
+                {...NavigationOptions.history}
+                currentPath={currentPath}
+                onClick={handleHideMoreOptions}
+              />
+
+              {isTeacher && (
+                <NavOption
+                  {...NavigationOptions.teacherSite}
+                  currentPath={currentPath}
+                  onClick={handleHideMoreOptions}
+                />
+              )}
+            </>
+          )}
+
+          {!isOnStudentSide && (
+            <NavOption
+              {...NavigationOptions.studentSite}
+              currentPath={currentPath}
+              onClick={handleHideMoreOptions}
+            />
+          )}
+
           <NavOption
-            {...NavigationOptions.studentSite}
-            currentPath={currentPath}
+            {...NavigationOptions.settings}
+            currentPath={path}
             onClick={handleHideMoreOptions}
           />
-        )}
 
-        <NavOption
-          {...NavigationOptions.settings}
-          currentPath={path}
-          onClick={handleHideMoreOptions}
-        />
-
-        <FeedbackButton />
+          <FeedbackButton />
+        </s.MoreOptionsList>
       </s.MoreOptionsPanel>
     </s.MoreOptionsWrapper>
   );

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.sc.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.sc.js
@@ -18,13 +18,18 @@ const MoreOptionsPanel = styled.nav`
   position: fixed;
   bottom: 0;
   z-index: 2;
-  display: flex;
-  flex-direction: column;
   border-radius: 1rem 1rem 0 0;
   padding: 1rem 1rem 2rem 1rem;
   box-shadow: 0 -0.25rem 1.25rem rgba(0, 0, 0, 0.1);
   animation: ${({ $moreOptionsTransition }) => $moreOptionsTransition} 0.3s
     ease-in-out forwards;
+`;
+
+const MoreOptionsList = styled.ul`
+  all: unset;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 `;
 
 const CloseSection = styled.div`
@@ -41,4 +46,10 @@ const CloseButton = styled.button`
   cursor: pointer;
 `;
 
-export { MoreOptionsWrapper, MoreOptionsPanel, CloseSection, CloseButton };
+export {
+  MoreOptionsWrapper,
+  MoreOptionsPanel,
+  MoreOptionsList,
+  CloseSection,
+  CloseButton,
+};

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -63,7 +63,7 @@ export default function FeedbackModal({ open, setOpen }) {
         <Form onSubmit={onSubmit}>
           <FormSection>
             <RadioGroup
-              legend="Select your active language:"
+              radioGroupLabel="Choose your current language:"
               name="active-language"
               options={activeLanguages}
               selectedValue={currentLearnedLanguage}

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -39,28 +39,28 @@ export default function LanguageModal({ open, setOpen, setUser }) {
       setUserDetails(undefined);
       setCurrentLearnedLanguage(undefined);
     };
-  }, [open, api, user.session, user.learned_language]);
+  }, [open, api, user.session]);
 
-  console.log("User details underneath useeffect:", userDetails);
-  console.log("user context underneath useeffect:", user);
-
-  //Note to myself: This one is working
   function updateLearnedLanguage(lang_code) {
     setCurrentLearnedLanguage(lang_code);
     const newUserDetails = { ...userDetails, learned_language: lang_code };
     setUserDetails(newUserDetails);
   }
 
+  function updateUserInfo(info) {
+    LocalStorage.setUserInfo(info);
+    setUser({
+      ...user,
+      learned_language: info.learned_language,
+    });
+
+    saveUserInfoIntoCookies(info);
+  }
+
   function handleSave(e) {
     e.preventDefault();
     api.saveUserDetails(userDetails, setErrorMessage, () => {
-      LocalStorage.setUserInfo(userDetails);
-      setUser({
-        ...user,
-        learned_language: userDetails.learned_language,
-      });
-
-      saveUserInfoIntoCookies(userDetails);
+      updateUserInfo(userDetails);
       setOpen(false);
     });
   }

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -104,7 +104,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
         <Form>
           <FormSection>
             <RadioGroup
-              radioGroupLabel="Choose your current language:"
+              radioGroupLabel="Select the language you want to practice:"
               name="active-language"
               options={reorderedLanguages}
               selectedValue={currentLearnedLanguage}

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -54,10 +54,10 @@ export default function FeedbackModal({ open, setOpen }) {
         setOpen(false);
       }}
     >
+      <Header withoutLogo>
+        <Heading>Your Active Languages:</Heading>
+      </Header>
       <Main>
-        <Header withoutLogo>
-          <Heading>Your Active Languages:</Heading>
-        </Header>
         <Form onSubmit={onSubmit}>
           <FormSection>
             <RadioGroup

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect, useContext } from "react";
+import { APIContext } from "../../contexts/APIContext.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
@@ -17,8 +18,25 @@ const options = [
 ];
 
 export default function FeedbackModal({ open, setOpen }) {
-  const [selectedLanguage, setSelectedLanguage] = useState("german");
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeLanguages, setActiveLanguages] = useState(undefined);
+  const [selectedLanguage, setSelectedLanguage] = useState();
   const [reorderedOptions, setReorderedOptions] = useState(options);
+  const api = useContext(APIContext);
+  // const { getUserLanguages } = api;
+
+  // console.log("Api:", getUserLanguages);
+
+  useEffect(() => {
+    if (open) {
+      setIsLoading(true);
+      api.getUserLanguages((data) => {
+        console.log("Languages:", data);
+        setActiveLanguages(data);
+        setIsLoading(false);
+      });
+    }
+  }, [open, api]);
 
   const handleLanguageChange = (event) => {
     setSelectedLanguage(event.target.value);
@@ -44,15 +62,17 @@ export default function FeedbackModal({ open, setOpen }) {
         <Header withoutLogo>
           <Heading>Your Active Languages:</Heading>
         </Header>
-        <Form action={onSubmit}>
+        <Form onSubmit={onSubmit}>
           <FormSection>
-            <RadioGroup
-              legend="Select your active languages:"
-              name="active-language"
-              options={reorderedOptions}
-              selectedValue={selectedLanguage}
-              onChange={handleLanguageChange}
-            />
+            {!isLoading && (
+              <RadioGroup
+                legend="Select your active languages:"
+                name="active-language"
+                options={activeLanguages}
+                selectedValue={selectedLanguage}
+                onChange={handleLanguageChange}
+              />
+            )}
           </FormSection>
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
             <Button

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -78,7 +78,6 @@ export default function LanguageModal({ open, setOpen }) {
       saveUserInfoIntoCookies(newUserDetails);
 
       setOpen(false);
-      console.log("success in updating userDetails");
     });
   }
 

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext } from "react";
 import { APIContext } from "../../contexts/APIContext.js";
+import { UserContext } from "../../contexts/UserContext.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
@@ -11,10 +12,12 @@ import Heading from "../modal_shared/Heading.sc.js";
 import RadioGroup from "./RadioGroup.js";
 
 export default function FeedbackModal({ open, setOpen }) {
-  const [isLoading, setIsLoading] = useState(false);
-  const [activeLanguages, setActiveLanguages] = useState(undefined);
-  const [selectedLanguage, setSelectedLanguage] = useState("de");
   const api = useContext(APIContext);
+  const user = useContext(UserContext);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentLearnedLanguage, setCurrentLearnedLanguage] =
+    useState(undefined);
+  const [activeLanguages, setActiveLanguages] = useState(undefined);
 
   useEffect(() => {
     let isMounted = true;
@@ -35,15 +38,18 @@ export default function FeedbackModal({ open, setOpen }) {
         setIsLoading(false);
       };
     }
-  }, [open, api]);
+  }, [open, api, user.session]);
+
+  useEffect(() => {
+    setCurrentLearnedLanguage(user.learned_language);
+  }, [user.learned_language]);
 
   const handleLanguageChange = (event) => {
-    setSelectedLanguage(event.target.value);
+    setCurrentLearnedLanguage(event.target.value);
   };
 
   function onSubmit(e) {
     e.preventDefault();
-    console.log("Selected a new language");
     setOpen(false);
   }
 
@@ -64,7 +70,7 @@ export default function FeedbackModal({ open, setOpen }) {
               legend="Select your active language:"
               name="active-language"
               options={activeLanguages}
-              selectedValue={selectedLanguage}
+              selectedValue={currentLearnedLanguage}
               onChange={handleLanguageChange}
               optionLabel={(e) => e.language}
               optionValue={(e) => e.code}
@@ -78,7 +84,7 @@ export default function FeedbackModal({ open, setOpen }) {
                 onSubmit(e);
               }}
             >
-              Submit
+              Save
             </Button>
           </ButtonContainer>
         </Form>

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -42,7 +42,7 @@ export default function FeedbackModal({ open, setOpen }) {
 
   useEffect(() => {
     setCurrentLearnedLanguage(user.learned_language);
-  }, [user.learned_language]);
+  }, [user.learned_language, open]);
 
   const handleLanguageChange = (event) => {
     setCurrentLearnedLanguage(event.target.value);

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -17,8 +17,7 @@ import AddRoundedIcon from "@mui/icons-material/AddRounded";
 
 export default function LanguageModal({ open, setOpen }) {
   const api = useContext(APIContext);
-  const { userData, setUserData, session } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails, setUserDetails, session } = useContext(UserContext);
   const [, setErrorMessage] = useState("");
 
   const [learnedLanguageCode, setLearnedLanguageCode] = useState(null);
@@ -69,10 +68,7 @@ export default function LanguageModal({ open, setOpen }) {
     };
 
     api.saveUserDetails(newUserDetails, setErrorMessage, () => {
-      setUserData({
-        ...userData,
-        userDetails: newUserDetails,
-      });
+      setUserDetails(newUserDetails);
 
       LocalStorage.setUserInfo(newUserDetails);
       saveUserInfoIntoCookies(newUserDetails);

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -2,7 +2,6 @@ import { useState, useEffect, useContext } from "react";
 import { APIContext } from "../../contexts/APIContext.js";
 import { UserContext } from "../../contexts/UserContext.js";
 import { saveUserInfoIntoCookies } from "../../utils/cookies/userInfo.js";
-import { Link } from "react-router-dom";
 import LocalStorage from "../../assorted/LocalStorage.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
@@ -13,11 +12,13 @@ import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
 import Heading from "../modal_shared/Heading.sc.js";
 import RadioGroup from "./RadioGroup.js";
+import ReactLink from "../ReactLink.sc.js";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
 
 export default function LanguageModal({ open, setOpen, setUser }) {
   const api = useContext(APIContext);
   const user = useContext(UserContext);
-  const [errorMessage, setErrorMessage] = useState("");
+  const [, setErrorMessage] = useState("");
   const [userDetails, setUserDetails] = useState(undefined);
   const [currentLearnedLanguage, setCurrentLearnedLanguage] =
     useState(undefined);
@@ -36,14 +37,14 @@ export default function LanguageModal({ open, setOpen, setUser }) {
 
   useEffect(() => {
     if (open) {
-      api.getUserLanguages((data) => {
-        setActiveLanguages(data);
-      });
-
       api.getUserDetails((data) => {
         setUserDetails(data);
         setCEFRlevel(data); //the api won't update without it (bug to fix)
         setCurrentLearnedLanguage(data.learned_language);
+      });
+
+      api.getUserLanguages((data) => {
+        setActiveLanguages(data);
       });
     }
     return () => {
@@ -113,12 +114,13 @@ export default function LanguageModal({ open, setOpen, setUser }) {
             <Button onClick={handleSave} type={"submit"}>
               Save
             </Button>
-            <Link
+            <ReactLink
+              className="small"
               onClick={() => setOpen(false)}
               to="/account_settings/language_settings"
             >
-              Add a new language
-            </Link>
+              <AddRoundedIcon /> Add a new language
+            </ReactLink>
           </ButtonContainer>
         </Form>
       </Main>

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,16 +1,35 @@
+import { useState } from "react";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
 import Button from "../../pages/_pages_shared/Button.sc.js";
-import Selector from "../Selector.js";
 import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
 import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
 import Heading from "../modal_shared/Heading.sc.js";
+import RadioGroup from "./RadioGroup.js";
+
+//to be replaced with actual languages
+const options = [
+  { value: "german", label: "German" },
+  { value: "danish", label: "Danish" },
+  { value: "french", label: "French" },
+];
 
 export default function FeedbackModal({ open, setOpen }) {
+  const [selectedLanguage, setSelectedLanguage] = useState("german");
+  const [reorderedOptions, setReorderedOptions] = useState(options);
+
+  const handleLanguageChange = (event) => {
+    setSelectedLanguage(event.target.value);
+  };
+
   function onSubmit(e) {
     e.preventDefault();
+    setReorderedOptions([
+      ...options.filter((option) => option.value === selectedLanguage),
+      ...options.filter((option) => option.value !== selectedLanguage),
+    ]);
     setOpen(false);
   }
 
@@ -27,7 +46,13 @@ export default function FeedbackModal({ open, setOpen }) {
         </Header>
         <Form action={onSubmit}>
           <FormSection>
-            <Selector />
+            <RadioGroup
+              legend="Select your active languages:"
+              name="active-language"
+              options={reorderedOptions}
+              selectedValue={selectedLanguage}
+              onChange={handleLanguageChange}
+            />
           </FormSection>
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
             <Button

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -14,7 +14,6 @@ import RadioGroup from "./RadioGroup.js";
 export default function FeedbackModal({ open, setOpen }) {
   const api = useContext(APIContext);
   const user = useContext(UserContext);
-  const [isLoading, setIsLoading] = useState(false);
   const [currentLearnedLanguage, setCurrentLearnedLanguage] =
     useState(undefined);
   const [activeLanguages, setActiveLanguages] = useState(undefined);
@@ -23,19 +22,16 @@ export default function FeedbackModal({ open, setOpen }) {
     let isMounted = true;
 
     if (open) {
-      setIsLoading(true);
       api.getUserLanguages((data) => {
         if (isMounted) {
           console.log("Languages:", data);
           setActiveLanguages(data);
-          setIsLoading(false);
         }
       });
 
       return () => {
         isMounted = false;
         setActiveLanguages(undefined);
-        setIsLoading(false);
       };
     }
   }, [open, api, user.session]);

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,0 +1,94 @@
+import { toast } from "react-toastify";
+import { useContext } from "react";
+import useFormField from "../../hooks/useFormField.js";
+import { APIContext } from "../../contexts/APIContext.js";
+import Modal from "../modal_shared/Modal.js";
+import Form from "../../pages/_pages_shared/Form.sc.js";
+import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
+import Button from "../../pages/_pages_shared/Button.sc.js";
+import Selector from "../Selector.js";
+import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
+import TextField from "../TextField.js";
+import Main from "../modal_shared/Main.sc.js";
+import Header from "../modal_shared/Header.sc.js";
+import Heading from "../modal_shared/Heading.sc.js";
+import { FEEDBACK_CODES, FEEDBACK_CODES_NAME } from "./FeedbackConstants.js";
+
+export default function FeedbackModal({
+  open,
+  setOpen,
+  feedbackOptions,
+  prefixMsg,
+}) {
+  let api = useContext(APIContext);
+  const [feedbackComponentSelected, setFeedbackComponentSelected] =
+    useFormField(FEEDBACK_CODES_NAME.OTHER);
+  const [feedbackMessage, feedbackMessageChange] = useFormField("");
+
+  function onSubmit(e) {
+    e.preventDefault();
+    let payload = {
+      message: prefixMsg
+        ? prefixMsg + " - " + feedbackMessage
+        : feedbackMessage,
+      feedbackComponentId: feedbackComponentSelected,
+      currentUrl: window.location.href,
+    };
+    api.sendFeedback(
+      payload,
+      () => {
+        toast.success("Feedback sent!");
+      },
+      () => {
+        toast.error("There was an error sending your message.");
+      },
+    );
+    setOpen(false);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => {
+        setOpen(false);
+      }}
+    >
+      <Main>
+        <Header withoutLogo>
+          <Heading>Provide Feedback</Heading>
+        </Header>
+        <Form action={onSubmit}>
+          <FormSection>
+            <Selector
+              options={feedbackOptions}
+              optionLabel={(v) => FEEDBACK_CODES[v]}
+              optionValue={(v) => v}
+              selectedValue={feedbackComponentSelected}
+              onChange={(e) => setFeedbackComponentSelected(e.target.value)}
+              label={"Which component do you want to give feedback on?"}
+              placeholder={"Select component to give feedback on"}
+              id={"feedback-option"}
+            />
+          </FormSection>
+          <FormSection>
+            <TextField
+              label={"Let us know what happened"}
+              onChange={(e) => feedbackMessageChange(e.target.value)}
+            />
+          </FormSection>
+
+          <ButtonContainer className={"adaptive-alignment-horizontal"}>
+            <Button
+              type={"submit"}
+              onClick={(e) => {
+                onSubmit(e);
+              }}
+            >
+              Submit
+            </Button>
+          </ButtonContainer>
+        </Form>
+      </Main>
+    </Modal>
+  );
+}

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -2,12 +2,12 @@ import { useState, useEffect, useContext } from "react";
 import { APIContext } from "../../contexts/APIContext.js";
 import { UserContext } from "../../contexts/UserContext.js";
 import { saveUserInfoIntoCookies } from "../../utils/cookies/userInfo.js";
+import { Link } from "react-router-dom";
 import LocalStorage from "../../assorted/LocalStorage.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
 import Button from "../../pages/_pages_shared/Button.sc.js";
-import { Link } from "react-router-dom";
 import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
 import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
@@ -22,6 +22,17 @@ export default function LanguageModal({ open, setOpen, setUser }) {
   const [currentLearnedLanguage, setCurrentLearnedLanguage] =
     useState(undefined);
   const [activeLanguages, setActiveLanguages] = useState(undefined);
+  const [CEFR, setCEFR] = useState("");
+
+  function setCEFRlevel(data) {
+    const levelKey = data.learned_language + "_cefr_level";
+    const levelNumber = data[levelKey];
+    setCEFR("" + levelNumber);
+    setUserDetails({
+      ...data,
+      cefr_level: levelNumber,
+    });
+  }
 
   useEffect(() => {
     if (open) {
@@ -31,6 +42,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
 
       api.getUserDetails((data) => {
         setUserDetails(data);
+        setCEFRlevel(data); //the api won't update without it (bug to fix)
         setCurrentLearnedLanguage(data.learned_language);
       });
     }
@@ -43,7 +55,11 @@ export default function LanguageModal({ open, setOpen, setUser }) {
 
   function updateLearnedLanguage(lang_code) {
     setCurrentLearnedLanguage(lang_code);
-    const newUserDetails = { ...userDetails, learned_language: lang_code };
+    const newUserDetails = {
+      ...userDetails,
+      learned_language: lang_code,
+      cefr_level: CEFR,
+    };
     setUserDetails(newUserDetails);
   }
 
@@ -52,6 +68,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
     setUser({
       ...user,
       learned_language: info.learned_language,
+      cefr_level: CEFR,
     });
 
     saveUserInfoIntoCookies(info);
@@ -61,6 +78,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
     e.preventDefault();
     api.saveUserDetails(userDetails, setErrorMessage, () => {
       updateUserInfo(userDetails);
+      window.location.reload();
       setOpen(false);
     });
   }

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,48 +1,16 @@
-import { toast } from "react-toastify";
-import { useContext } from "react";
-import useFormField from "../../hooks/useFormField.js";
-import { APIContext } from "../../contexts/APIContext.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
 import Button from "../../pages/_pages_shared/Button.sc.js";
 import Selector from "../Selector.js";
 import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
-import TextField from "../TextField.js";
 import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
 import Heading from "../modal_shared/Heading.sc.js";
-import { FEEDBACK_CODES, FEEDBACK_CODES_NAME } from "./FeedbackConstants.js";
 
-export default function FeedbackModal({
-  open,
-  setOpen,
-  feedbackOptions,
-  prefixMsg,
-}) {
-  let api = useContext(APIContext);
-  const [feedbackComponentSelected, setFeedbackComponentSelected] =
-    useFormField(FEEDBACK_CODES_NAME.OTHER);
-  const [feedbackMessage, feedbackMessageChange] = useFormField("");
-
+export default function FeedbackModal({ open, setOpen }) {
   function onSubmit(e) {
     e.preventDefault();
-    let payload = {
-      message: prefixMsg
-        ? prefixMsg + " - " + feedbackMessage
-        : feedbackMessage,
-      feedbackComponentId: feedbackComponentSelected,
-      currentUrl: window.location.href,
-    };
-    api.sendFeedback(
-      payload,
-      () => {
-        toast.success("Feedback sent!");
-      },
-      () => {
-        toast.error("There was an error sending your message.");
-      },
-    );
     setOpen(false);
   }
 
@@ -55,28 +23,12 @@ export default function FeedbackModal({
     >
       <Main>
         <Header withoutLogo>
-          <Heading>Provide Feedback</Heading>
+          <Heading>Your Active Languages:</Heading>
         </Header>
         <Form action={onSubmit}>
           <FormSection>
-            <Selector
-              options={feedbackOptions}
-              optionLabel={(v) => FEEDBACK_CODES[v]}
-              optionValue={(v) => v}
-              selectedValue={feedbackComponentSelected}
-              onChange={(e) => setFeedbackComponentSelected(e.target.value)}
-              label={"Which component do you want to give feedback on?"}
-              placeholder={"Select component to give feedback on"}
-              id={"feedback-option"}
-            />
+            <Selector />
           </FormSection>
-          <FormSection>
-            <TextField
-              label={"Let us know what happened"}
-              onChange={(e) => feedbackMessageChange(e.target.value)}
-            />
-          </FormSection>
-
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
             <Button
               type={"submit"}

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -39,7 +39,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
     if (open) {
       api.getUserDetails((data) => {
         setUserDetails(data);
-        setCEFRlevel(data); //the api won't update without it (bug to fix)
+        setCEFRlevel(data); //the api won't update without CEFR (bug to fix)
         setCurrentLearnedLanguage(data.learned_language);
       });
 
@@ -53,6 +53,12 @@ export default function LanguageModal({ open, setOpen, setUser }) {
       setCurrentLearnedLanguage(undefined);
     };
   }, [open, api, user.session]);
+
+  const reorderedLanguages = activeLanguages?.sort((a, b) => {
+    if (a.code === user.learned_language) return -1;
+    if (b.code === user.learned_language) return 1;
+    return 0;
+  });
 
   function updateLearnedLanguage(lang_code) {
     setCurrentLearnedLanguage(lang_code);
@@ -100,7 +106,7 @@ export default function LanguageModal({ open, setOpen, setUser }) {
             <RadioGroup
               radioGroupLabel="Choose your current language:"
               name="active-language"
-              options={activeLanguages}
+              options={reorderedLanguages}
               selectedValue={currentLearnedLanguage}
               onChange={(e) => {
                 updateLearnedLanguage(e.target.value);

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -85,7 +85,6 @@ export default function LanguageModal({ open, setOpen, setUser }) {
     e.preventDefault();
     api.saveUserDetails(userDetails, setErrorMessage, () => {
       updateUserInfo(userDetails);
-      window.location.reload();
       setOpen(false);
     });
   }

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -1,12 +1,13 @@
 import { useState, useEffect, useContext } from "react";
 import { APIContext } from "../../contexts/APIContext.js";
 import { UserContext } from "../../contexts/UserContext.js";
-import LocalStorage from "../../assorted/LocalStorage.js";
 import { saveUserInfoIntoCookies } from "../../utils/cookies/userInfo.js";
+import LocalStorage from "../../assorted/LocalStorage.js";
 import Modal from "../modal_shared/Modal.js";
 import Form from "../../pages/_pages_shared/Form.sc.js";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
 import Button from "../../pages/_pages_shared/Button.sc.js";
+import { Link } from "react-router-dom";
 import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
 import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
@@ -29,11 +30,15 @@ export default function LanguageModal({ open, setOpen, setUser }) {
       });
 
       api.getUserDetails((data) => {
-        console.log("User details from api:", data);
         setUserDetails(data);
         setCurrentLearnedLanguage(data.learned_language);
       });
     }
+    return () => {
+      setActiveLanguages(undefined);
+      setUserDetails(undefined);
+      setCurrentLearnedLanguage(undefined);
+    };
   }, [open, api, user.session, user.learned_language]);
 
   console.log("User details underneath useeffect:", userDetails);
@@ -41,19 +46,14 @@ export default function LanguageModal({ open, setOpen, setUser }) {
 
   //Note to myself: This one is working
   function updateLearnedLanguage(lang_code) {
-    console.log("language code in updateLearnedLanguage");
-    console.log(lang_code);
     setCurrentLearnedLanguage(lang_code);
     const newUserDetails = { ...userDetails, learned_language: lang_code };
     setUserDetails(newUserDetails);
-
-    console.log("User details from the live update:", newUserDetails);
   }
 
   function handleSave(e) {
     e.preventDefault();
     api.saveUserDetails(userDetails, setErrorMessage, () => {
-      console.log("User Details from onSubmit:", userDetails);
       LocalStorage.setUserInfo(userDetails);
       setUser({
         ...user,
@@ -95,6 +95,12 @@ export default function LanguageModal({ open, setOpen, setUser }) {
             <Button onClick={handleSave} type={"submit"}>
               Save
             </Button>
+            <Link
+              onClick={() => setOpen(false)}
+              to="/account_settings/language_settings"
+            >
+              Add a new language
+            </Link>
           </ButtonContainer>
         </Form>
       </Main>

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -18,6 +18,7 @@ import AddRoundedIcon from "@mui/icons-material/AddRounded";
 export default function LanguageModal({ open, setOpen }) {
   const api = useContext(APIContext);
   const { userData, setUserData, session } = useContext(UserContext);
+  const { userDetails } = userData;
   const [, setErrorMessage] = useState("");
 
   const [learnedLanguageCode, setLearnedLanguageCode] = useState(null);
@@ -25,7 +26,7 @@ export default function LanguageModal({ open, setOpen }) {
 
   useEffect(() => {
     if (open) {
-      setLearnedLanguageCode(userData.userDetails.learned_language);
+      setLearnedLanguageCode(userDetails.learned_language);
 
       api.getUserLanguages((data) => {
         setActiveLanguages(data);
@@ -33,7 +34,6 @@ export default function LanguageModal({ open, setOpen }) {
     }
     return () => {
       setActiveLanguages(undefined);
-
       setLearnedLanguageCode(undefined);
     };
   }, [open, api, session]);
@@ -41,20 +41,19 @@ export default function LanguageModal({ open, setOpen }) {
   const reorderedLanguages = useMemo(() => {
     if (!activeLanguages) return [];
 
-    // Filter out the user's translation language
     const filteredLanguages = activeLanguages.filter(
-      (lang) => lang.code !== userData.native_language,
+      (lang) => lang.code !== userDetails.native_language,
     );
 
     return filteredLanguages.sort((a, b) => {
-      if (a.code === userData.userDetails.learned_language) return -1;
-      if (b.code === userData.userDetails.learned_language) return 1;
+      if (a.code === userDetails.learned_language) return -1;
+      if (b.code === userDetails.learned_language) return 1;
       return 0;
     });
   }, [
     activeLanguages,
-    userData.userDetails.native_language,
-    userData.userDetails.learned_language,
+    userDetails.native_language,
+    userDetails.learned_language,
   ]);
 
   function updateLearnedLanguage(lang_code) {
@@ -65,7 +64,7 @@ export default function LanguageModal({ open, setOpen }) {
     e.preventDefault();
 
     const newUserDetails = {
-      ...userData.userDetails,
+      ...userDetails,
       learned_language: learnedLanguageCode,
     };
 

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -10,31 +10,30 @@ import Header from "../modal_shared/Header.sc.js";
 import Heading from "../modal_shared/Heading.sc.js";
 import RadioGroup from "./RadioGroup.js";
 
-//to be replaced with actual languages
-const options = [
-  { value: "german", label: "German" },
-  { value: "danish", label: "Danish" },
-  { value: "french", label: "French" },
-];
-
 export default function FeedbackModal({ open, setOpen }) {
   const [isLoading, setIsLoading] = useState(false);
   const [activeLanguages, setActiveLanguages] = useState(undefined);
-  const [selectedLanguage, setSelectedLanguage] = useState();
-  const [reorderedOptions, setReorderedOptions] = useState(options);
+  const [selectedLanguage, setSelectedLanguage] = useState("de");
   const api = useContext(APIContext);
-  // const { getUserLanguages } = api;
-
-  // console.log("Api:", getUserLanguages);
 
   useEffect(() => {
+    let isMounted = true;
+
     if (open) {
       setIsLoading(true);
       api.getUserLanguages((data) => {
-        console.log("Languages:", data);
-        setActiveLanguages(data);
-        setIsLoading(false);
+        if (isMounted) {
+          console.log("Languages:", data);
+          setActiveLanguages(data);
+          setIsLoading(false);
+        }
       });
+
+      return () => {
+        isMounted = false;
+        setActiveLanguages(undefined);
+        setIsLoading(false);
+      };
     }
   }, [open, api]);
 
@@ -44,10 +43,7 @@ export default function FeedbackModal({ open, setOpen }) {
 
   function onSubmit(e) {
     e.preventDefault();
-    setReorderedOptions([
-      ...options.filter((option) => option.value === selectedLanguage),
-      ...options.filter((option) => option.value !== selectedLanguage),
-    ]);
+    console.log("Selected a new language");
     setOpen(false);
   }
 
@@ -64,15 +60,16 @@ export default function FeedbackModal({ open, setOpen }) {
         </Header>
         <Form onSubmit={onSubmit}>
           <FormSection>
-            {!isLoading && (
-              <RadioGroup
-                legend="Select your active languages:"
-                name="active-language"
-                options={activeLanguages}
-                selectedValue={selectedLanguage}
-                onChange={handleLanguageChange}
-              />
-            )}
+            <RadioGroup
+              legend="Select your active language:"
+              name="active-language"
+              options={activeLanguages}
+              selectedValue={selectedLanguage}
+              onChange={handleLanguageChange}
+              optionLabel={(e) => e.language}
+              optionValue={(e) => e.code}
+              optionId={(e) => e.id}
+            />
           </FormSection>
           <ButtonContainer className={"adaptive-alignment-horizontal"}>
             <Button

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -6,7 +6,7 @@ import { ThemeProvider } from "styled-components";
 import { mainNavTheme } from "./mainNavTheme";
 import { MainNavContext } from "../../contexts/MainNavContext";
 
-export default function MainNav({ screenWidth, setUser }) {
+export default function MainNav({ screenWidth }) {
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 
@@ -16,9 +16,9 @@ export default function MainNav({ screenWidth, setUser }) {
       theme={isOnStudentSide ? mainNavTheme.student : mainNavTheme.teacher}
     >
       {screenWidth <= MOBILE_WIDTH ? (
-        <BottomNav setUser={setUser} />
+        <BottomNav />
       ) : (
-        <SideNav setUser={setUser} screenWidth={screenWidth} />
+        <SideNav screenWidth={screenWidth} />
       )}
     </ThemeProvider>
   );

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -6,7 +6,7 @@ import { ThemeProvider } from "styled-components";
 import { mainNavTheme } from "./mainNavTheme";
 import { MainNavContext } from "../../contexts/MainNavContext";
 
-export default function MainNav({ screenWidth }) {
+export default function MainNav({ screenWidth, setUser }) {
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 
@@ -16,9 +16,9 @@ export default function MainNav({ screenWidth }) {
       theme={isOnStudentSide ? mainNavTheme.student : mainNavTheme.teacher}
     >
       {screenWidth <= MOBILE_WIDTH ? (
-        <BottomNav />
+        <BottomNav setUser={setUser} />
       ) : (
-        <SideNav screenWidth={screenWidth} />
+        <SideNav setUser={setUser} screenWidth={screenWidth} />
       )}
     </ThemeProvider>
   );

--- a/src/components/MainNav/NavIcon.js
+++ b/src/components/MainNav/NavIcon.js
@@ -11,6 +11,7 @@ import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
 import DonutSmallRoundedIcon from "@mui/icons-material/DonutSmallRounded";
 import DoubleArrowRight from "@mui/icons-material/KeyboardDoubleArrowRightOutlined";
 import DoubleArrowLeft from "@mui/icons-material/KeyboardDoubleArrowLeftOutlined";
+import LanguageRoundedIcon from "@mui/icons-material/LanguageRounded";
 
 export default function NavIcon({ name }) {
   const navIcons = {
@@ -27,6 +28,7 @@ export default function NavIcon({ name }) {
     myTexts: <ChromeReaderModeRoundedIcon />,
     studentSite: <SchoolRoundedIcon />,
     more: <MoreHorizRoundedIcon />,
+    language: <LanguageRoundedIcon />,
   };
   return navIcons[name] || "";
 }

--- a/src/components/MainNav/NavOption.js
+++ b/src/components/MainNav/NavOption.js
@@ -12,6 +12,7 @@ export default function NavOption({
   className,
   screenWidth,
   ariaHasPopup,
+  ariaLabel,
 }) {
   const Component = linkTo ? s.RouterLink : s.OptionButton;
   const isActive = currentPath?.includes(linkTo);
@@ -31,6 +32,7 @@ export default function NavOption({
         to={linkTo}
         title={elementTitle}
         aria-haspopup={ariaHasPopup}
+        aria-label={ariaLabel}
       >
         <s.OptionContentWrapper $screenWidth={screenWidth}>
           <s.IconContainer>{icon}</s.IconContainer>

--- a/src/components/MainNav/NavOption.js
+++ b/src/components/MainNav/NavOption.js
@@ -11,6 +11,7 @@ export default function NavOption({
   currentPath,
   className,
   screenWidth,
+  ariaHasPopup,
 }) {
   const Component = linkTo ? s.RouterLink : s.OptionButton;
   const isActive = currentPath?.includes(linkTo);
@@ -27,8 +28,9 @@ export default function NavOption({
         $isActive={isActive}
         className={className}
         onClick={onClick}
-        to={linkTo && linkTo}
+        to={linkTo}
         title={elementTitle}
+        aria-haspopup={ariaHasPopup}
       >
         <s.OptionContentWrapper $screenWidth={screenWidth}>
           <s.IconContainer>{icon}</s.IconContainer>

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -17,9 +17,8 @@ export default function RadioGroup({
           {radioGroupLabel}
         </s.RadioGroupLabel>
         {options?.map((option) => (
-          <>
+          <div key={optionId(option)}>
             <s.StyledInput
-              key={optionId(option)}
               type="radio"
               id={optionId(option)}
               name={name}
@@ -30,7 +29,7 @@ export default function RadioGroup({
             <s.OptionLabel htmlFor={optionId(option)}>
               {optionLabel(option)}
             </s.OptionLabel>
-          </>
+          </div>
         ))}
       </s.StyledRadioGroup>
     </>

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -23,7 +23,7 @@ export default function RadioGroup({
             checked={selectedValue === optionValue(option)}
             onChange={onChange}
           />
-          <s.StyledLabel htmlFor={optionValue(option)}>
+          <s.StyledLabel htmlFor={optionId(option)}>
             {optionLabel(option)}
           </s.StyledLabel>
         </s.StyledDiv>

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -11,27 +11,25 @@ export default function RadioGroup({
   optionId,
 }) {
   return (
-    <>
-      <s.StyledRadioGroup role="radiogroup" aria-labelledby={`${name}-label`}>
-        <s.RadioGroupLabel id={`${name}-label`}>
-          {radioGroupLabel}
-        </s.RadioGroupLabel>
-        {options?.map((option) => (
-          <div key={optionId(option)}>
-            <s.StyledInput
-              type="radio"
-              id={optionId(option)}
-              name={name}
-              value={optionValue(option)}
-              onChange={onChange}
-              checked={selectedValue === optionValue(option)}
-            />
-            <s.OptionLabel htmlFor={optionId(option)}>
-              {optionLabel(option)}
-            </s.OptionLabel>
-          </div>
-        ))}
-      </s.StyledRadioGroup>
-    </>
+    <s.StyledRadioGroup role="radiogroup" aria-labelledby={`${name}-label`}>
+      <s.RadioGroupLabel id={`${name}-label`}>
+        {radioGroupLabel}
+      </s.RadioGroupLabel>
+      {options?.map((option) => (
+        <div key={optionId(option)}>
+          <s.StyledInput
+            type="radio"
+            id={optionId(option)}
+            name={name}
+            value={optionValue(option)}
+            onChange={onChange}
+            checked={selectedValue === optionValue(option)}
+          />
+          <s.OptionLabel htmlFor={optionId(option)}>
+            {optionLabel(option)}
+          </s.OptionLabel>
+        </div>
+      ))}
+    </s.StyledRadioGroup>
   );
 }

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -1,7 +1,7 @@
 import * as s from "./RadioGroup.sc";
 
 export default function RadioGroup({
-  legend,
+  radioGroupLabel,
   name,
   options,
   selectedValue,
@@ -11,24 +11,28 @@ export default function RadioGroup({
   optionId,
 }) {
   return (
-    <s.StyledFieldset>
-      <s.StyledLegend id={`${name}-label`}>{legend}</s.StyledLegend>
-      {options?.map((option) => (
-        <>
-          <s.StyledInput
-            key={optionId(option)}
-            type="radio"
-            id={optionId(option)}
-            name={name}
-            value={optionValue(option)}
-            onChange={onChange}
-            checked={selectedValue === optionValue(option)}
-          />
-          <s.StyledLabel htmlFor={optionId(option)}>
-            {optionLabel(option)}
-          </s.StyledLabel>
-        </>
-      ))}
-    </s.StyledFieldset>
+    <>
+      <s.StyledRadioGroup role="radiogroup" aria-labelledby={`${name}-label`}>
+        <s.RadioGroupLabel id={`${name}-label`}>
+          {radioGroupLabel}
+        </s.RadioGroupLabel>
+        {options?.map((option) => (
+          <>
+            <s.StyledInput
+              key={optionId(option)}
+              type="radio"
+              id={optionId(option)}
+              name={name}
+              value={optionValue(option)}
+              onChange={onChange}
+              checked={selectedValue === optionValue(option)}
+            />
+            <s.OptionLabel htmlFor={optionId(option)}>
+              {optionLabel(option)}
+            </s.OptionLabel>
+          </>
+        ))}
+      </s.StyledRadioGroup>
+    </>
   );
 }

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -6,22 +6,25 @@ export default function RadioGroup({
   options,
   selectedValue,
   onChange,
+  optionLabel,
+  optionValue,
+  optionId,
 }) {
   return (
     <s.StyledFieldset>
       <s.StyledLegend id={`${name}-label`}>{legend}</s.StyledLegend>
       {options?.map((option) => (
-        <s.StyledDiv key={option.id}>
+        <s.StyledDiv key={optionId(option)}>
           <s.StyledInput
             type="radio"
-            id={option.id}
+            id={optionId(option)}
             name={name}
-            value={option.language}
-            checked={selectedValue === option.language}
+            value={optionValue(option)}
+            checked={selectedValue === optionValue(option)}
             onChange={onChange}
           />
-          <s.StyledLabel htmlFor={option.language}>
-            {option.language}
+          <s.StyledLabel htmlFor={optionValue(option)}>
+            {optionLabel(option)}
           </s.StyledLabel>
         </s.StyledDiv>
       ))}

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -21,8 +21,8 @@ export default function RadioGroup({
             id={optionId(option)}
             name={name}
             value={optionValue(option)}
-            checked={selectedValue === optionValue(option)}
             onChange={onChange}
+            checked={selectedValue === optionValue(option)}
           />
           <s.StyledLabel htmlFor={optionId(option)}>
             {optionLabel(option)}

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -14,8 +14,9 @@ export default function RadioGroup({
     <s.StyledFieldset>
       <s.StyledLegend id={`${name}-label`}>{legend}</s.StyledLegend>
       {options?.map((option) => (
-        <s.StyledDiv key={optionId(option)}>
+        <>
           <s.StyledInput
+            key={optionId(option)}
             type="radio"
             id={optionId(option)}
             name={name}
@@ -26,7 +27,7 @@ export default function RadioGroup({
           <s.StyledLabel htmlFor={optionId(option)}>
             {optionLabel(option)}
           </s.StyledLabel>
-        </s.StyledDiv>
+        </>
       ))}
     </s.StyledFieldset>
   );

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -10,17 +10,19 @@ export default function RadioGroup({
   return (
     <s.StyledFieldset>
       <s.StyledLegend id={`${name}-label`}>{legend}</s.StyledLegend>
-      {options.map((option) => (
-        <s.StyledDiv key={option.value}>
+      {options?.map((option) => (
+        <s.StyledDiv key={option.id}>
           <s.StyledInput
             type="radio"
-            id={option.value}
+            id={option.id}
             name={name}
-            value={option.value}
-            checked={selectedValue === option.value}
+            value={option.language}
+            checked={selectedValue === option.language}
             onChange={onChange}
           />
-          <s.StyledLabel htmlFor={option.value}>{option.label}</s.StyledLabel>
+          <s.StyledLabel htmlFor={option.language}>
+            {option.language}
+          </s.StyledLabel>
         </s.StyledDiv>
       ))}
     </s.StyledFieldset>

--- a/src/components/MainNav/RadioGroup.js
+++ b/src/components/MainNav/RadioGroup.js
@@ -1,0 +1,28 @@
+import * as s from "./RadioGroup.sc";
+
+export default function RadioGroup({
+  legend,
+  name,
+  options,
+  selectedValue,
+  onChange,
+}) {
+  return (
+    <s.StyledFieldset>
+      <s.StyledLegend id={`${name}-label`}>{legend}</s.StyledLegend>
+      {options.map((option) => (
+        <s.StyledDiv key={option.value}>
+          <s.StyledInput
+            type="radio"
+            id={option.value}
+            name={name}
+            value={option.value}
+            checked={selectedValue === option.value}
+            onChange={onChange}
+          />
+          <s.StyledLabel htmlFor={option.value}>{option.label}</s.StyledLabel>
+        </s.StyledDiv>
+      ))}
+    </s.StyledFieldset>
+  );
+}

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -61,8 +61,8 @@ const OptionLabel = styled.label`
     color: ${blue900};
   }
 
-  //more about :is() https://developer.mozilla.org/en-US/docs/Web/CSS/:is
-  &:is(:active, ${StyledInput}:checked + &:active) {
+  &:active,
+  ${StyledInput}:checked + &:active {
     box-shadow: none;
     transform: translateY(0.1em);
     transition: all ease-in 0.08s;

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -5,6 +5,7 @@ const StyledFieldset = styled.fieldset`
   all: unset;
   box-sizing: border-box;
   overflow-y: scroll;
+  overflow-x: hidden;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -1,32 +1,21 @@
 import styled from "styled-components";
+import { blue100, blue700, blue900, lightGrey, veryLightGrey } from "../colors";
 
 const StyledFieldset = styled.fieldset`
   all: unset;
   box-sizing: border-box;
   overflow-y: scroll;
-  height: 24rem;
-
-  ::-webkit-scrollbar {
-    width: 0.25rem;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: darkgray;
-    border-radius: 1rem;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: lightgray;
-    border-radius: 1rem;
-  }
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 0.5rem;
+  padding: 1rem 0 0 0;
+  max-height: 24rem;
 `;
 
 const StyledLegend = styled.legend`
   margin: 0 0 0.5rem 0;
-`;
-
-const StyledDiv = styled.div`
-  margin: 0.5rem 0;
 `;
 
 const StyledInput = styled.input`
@@ -36,25 +25,45 @@ const StyledInput = styled.input`
 `;
 
 const StyledLabel = styled.label`
-  box-sizing: border-box;
   cursor: pointer;
-  padding: 0.5rem;
-  border: 2px solid transparent;
-  display: inline-block;
-  width: 100%;
+  color: black;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  border-radius: 2rem;
+  border: solid 0.1rem ${lightGrey};
+  box-shadow: 0px 0.1rem ${lightGrey};
+  white-space: nowrap;
   transition: all 300ms ease-in-out;
-  user-select: none;
-  font-weight: bold;
-  border-radius: 0.3rem;
-  border: solid 0.1rem transparent;
+  margin-bottom: 0.2rem;
 
   &:hover {
-    border-color: #007bff;
+    background-color: ${veryLightGrey};
+  }
+
+  ${StyledInput}:checked + &:hover {
+    background-color: ${blue100};
   }
 
   ${StyledInput}:checked + & {
-    border-color: #007bff;
+    background-color: ${blue100};
+    border-color: ${blue700};
+    box-shadow: 0px 0.1rem ${blue700};
+    color: ${blue900};
+  }
+
+  //more about :is() https://developer.mozilla.org/en-US/docs/Web/CSS/:is
+  &:is(:active, ${StyledInput}:checked + &:active) {
+    box-shadow: none;
+    transform: translateY(0.1em);
+    transition: all ease-in 0.08s;
   }
 `;
 
-export { StyledFieldset, StyledLegend, StyledDiv, StyledInput, StyledLabel };
+export { StyledFieldset, StyledLegend, StyledInput, StyledLabel };

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -4,7 +4,7 @@ const StyledFieldset = styled.fieldset`
   all: unset;
   box-sizing: border-box;
   overflow-y: scroll;
-  max-height: 300px;
+  max-height: 500px;
 `;
 
 const StyledLegend = styled.legend`

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { blue100, blue700, blue900, lightGrey, veryLightGrey } from "../colors";
 
-const StyledFieldset = styled.fieldset`
+const StyledRadioGroup = styled.div`
   all: unset;
   box-sizing: border-box;
   overflow-y: scroll;
@@ -11,12 +11,14 @@ const StyledFieldset = styled.fieldset`
   flex-wrap: wrap;
   align-content: flex-start;
   gap: 0.5rem;
-  padding: 1rem 0 0 0;
+  padding: 0;
   max-height: 24rem;
 `;
 
-const StyledLegend = styled.legend`
-  margin: 0 0 0.5rem 0;
+const RadioGroupLabel = styled.div`
+  margin: 0 0 1rem 0;
+  display: block;
+  width: 100%;
 `;
 
 const StyledInput = styled.input`
@@ -25,7 +27,7 @@ const StyledInput = styled.input`
   opacity: 0;
 `;
 
-const StyledLabel = styled.label`
+const OptionLabel = styled.label`
   cursor: pointer;
   color: black;
   margin: 0;
@@ -67,4 +69,4 @@ const StyledLabel = styled.label`
   }
 `;
 
-export { StyledFieldset, StyledLegend, StyledInput, StyledLabel };
+export { StyledRadioGroup, RadioGroupLabel, StyledInput, OptionLabel };

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+
+const StyledFieldset = styled.fieldset`
+  all: unset;
+  box-sizing: border-box;
+  overflow-y: scroll;
+  max-height: 300px;
+`;
+
+const StyledLegend = styled.legend`
+  margin: 0 0 0.5rem 0;
+`;
+
+const StyledDiv = styled.div`
+  margin: 0.5rem 0;
+`;
+
+const StyledInput = styled.input`
+  appearance: none;
+  position: absolute;
+  opacity: 0;
+`;
+
+const StyledLabel = styled.label`
+  box-sizing: border-box;
+  cursor: pointer;
+  padding: 0.5rem;
+  border: 2px solid transparent;
+  display: inline-block;
+  width: 100%;
+  transition: all 300ms ease-in-out;
+  user-select: none;
+  font-weight: bold;
+  border-radius: 0.3rem;
+  border: solid 0.1rem transparent;
+
+  &:hover {
+    border-color: #007bff;
+  }
+
+  ${StyledInput}:checked + & {
+    border-color: #007bff;
+  }
+`;
+
+export { StyledFieldset, StyledLegend, StyledDiv, StyledInput, StyledLabel };

--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -4,7 +4,21 @@ const StyledFieldset = styled.fieldset`
   all: unset;
   box-sizing: border-box;
   overflow-y: scroll;
-  max-height: 500px;
+  height: 24rem;
+
+  ::-webkit-scrollbar {
+    width: 0.25rem;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: darkgray;
+    border-radius: 1rem;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: lightgray;
+    border-radius: 1rem;
+  }
 `;
 
 const StyledLegend = styled.legend`

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -11,8 +11,7 @@ import SideNavLanguageOption from "./SideNavLanguageOption";
 import * as s from "./SideNav.sc";
 
 export default function SideNav({ screenWidth }) {
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -24,9 +24,11 @@ export default function SideNav({ screenWidth }) {
         <NavOption
           className={"logo"}
           linkTo={defaultPage}
-          icon={<img alt="" src="../static/images/zeeguuWhiteLogo.svg"></img>}
+          icon={
+            <img alt="Zeeguu" src="../static/images/zeeguuWhiteLogo.svg"></img>
+          }
           text={"Zeeguu"}
-          ariaLabel={"Go to Zeeguu homepage"}
+          ariaLabel="Zeeguu homepage"
         ></NavOption>
 
         {isOnStudentSide && (

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -10,7 +10,7 @@ import NavigationOptions from "../navigationOptions";
 import SideNavLanguageOption from "./SideNavLanguageOption";
 import * as s from "./SideNav.sc";
 
-export default function SideNav({ screenWidth }) {
+export default function SideNav({ screenWidth, setUser }) {
   const { is_teacher: isTeacher } = useContext(UserContext);
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
@@ -41,7 +41,10 @@ export default function SideNav({ screenWidth }) {
       <s.BottomSection $screenWidth={screenWidth}>
         <s.NavList>
           {isOnStudentSide && (
-            <SideNavLanguageOption screenWidth={screenWidth} />
+            <SideNavLanguageOption
+              setUser={setUser}
+              screenWidth={screenWidth}
+            />
           )}
           <NavOption
             {...NavigationOptions.settings}

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -28,7 +28,7 @@ export default function SideNav({ screenWidth }) {
             <img alt="Zeeguu" src="../static/images/zeeguuWhiteLogo.svg"></img>
           }
           text={"Zeeguu"}
-          ariaLabel="Zeeguu homepage"
+          ariaLabel="Zeeguu"
         ></NavOption>
 
         {isOnStudentSide && (

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -19,33 +19,33 @@ export default function SideNav({ screenWidth }) {
 
   return (
     <s.SideNav $screenWidth={screenWidth} role="navigation">
-      <NavOption
-        className={"logo"}
-        linkTo={defaultPage}
-        icon={
-          <img
-            alt="Zeeguu logo - the elephant"
-            src="../static/images/zeeguuWhiteLogo.svg"
-          ></img>
-        }
-        text={"Zeeguu"}
-      ></NavOption>
+      <s.NavList>
+        <NavOption
+          className={"logo"}
+          linkTo={defaultPage}
+          icon={<img alt="" src="../static/images/zeeguuWhiteLogo.svg"></img>}
+          text={"Zeeguu"}
+          ariaLabel={"Go to Zeeguu homepage"}
+        ></NavOption>
 
-      {isOnStudentSide && (
-        <SideNavOptionsForStudent screenWidth={screenWidth} />
-      )}
+        {isOnStudentSide && (
+          <SideNavOptionsForStudent screenWidth={screenWidth} />
+        )}
 
-      {!isOnStudentSide && (
-        <SideNavOptionsForTeacher screenWidth={screenWidth} />
-      )}
+        {!isOnStudentSide && (
+          <SideNavOptionsForTeacher screenWidth={screenWidth} />
+        )}
+      </s.NavList>
 
       <s.BottomSection $screenWidth={screenWidth}>
-        <NavOption
-          {...NavigationOptions.settings}
-          currentPath={path}
-          screenWidth={screenWidth}
-        />
-        <FeedbackButton screenWidth={screenWidth} />
+        <s.NavList>
+          <NavOption
+            {...NavigationOptions.settings}
+            currentPath={path}
+            screenWidth={screenWidth}
+          />
+          <FeedbackButton screenWidth={screenWidth} />
+        </s.NavList>
       </s.BottomSection>
     </s.SideNav>
   );

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -10,13 +10,14 @@ import NavigationOptions from "../navigationOptions";
 import SideNavLanguageOption from "./SideNavLanguageOption";
 import * as s from "./SideNav.sc";
 
-export default function SideNav({ screenWidth, setUser }) {
-  const { is_teacher: isTeacher } = useContext(UserContext);
+export default function SideNav({ screenWidth }) {
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
 
   const path = useLocation().pathname;
-  const defaultPage = isTeacher ? "/teacher/classes" : "/articles";
+  const defaultPage = userDetails.is_teacher ? "/teacher/classes" : "/articles";
 
   return (
     <s.SideNav $screenWidth={screenWidth} role="navigation">
@@ -41,10 +42,7 @@ export default function SideNav({ screenWidth, setUser }) {
       <s.BottomSection $screenWidth={screenWidth}>
         <s.NavList>
           {isOnStudentSide && !path?.includes("/read") && (
-            <SideNavLanguageOption
-              setUser={setUser}
-              screenWidth={screenWidth}
-            />
+            <SideNavLanguageOption screenWidth={screenWidth} />
           )}
           <NavOption
             {...NavigationOptions.settings}

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -1,13 +1,14 @@
 import { useContext } from "react";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { UserContext } from "../../../contexts/UserContext";
+import { MainNavContext } from "../../../contexts/MainNavContext";
 import SideNavOptionsForStudent from "./SideNavOptionsForStudent";
 import SideNavOptionsForTeacher from "./SideNavOptionsForTeacher";
-import * as s from "./SideNav.sc";
 import NavOption from "../NavOption";
 import FeedbackButton from "../../FeedbackButton";
 import NavigationOptions from "../navigationOptions";
-import { MainNavContext } from "../../../contexts/MainNavContext";
+import SideNavLanguageOption from "./SideNavLanguageOption";
+import * as s from "./SideNav.sc";
 
 export default function SideNav({ screenWidth }) {
   const { is_teacher: isTeacher } = useContext(UserContext);
@@ -39,6 +40,9 @@ export default function SideNav({ screenWidth }) {
 
       <s.BottomSection $screenWidth={screenWidth}>
         <s.NavList>
+          {isOnStudentSide && (
+            <SideNavLanguageOption screenWidth={screenWidth} />
+          )}
           <NavOption
             {...NavigationOptions.settings}
             currentPath={path}

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -24,11 +24,8 @@ export default function SideNav({ screenWidth }) {
         <NavOption
           className={"logo"}
           linkTo={defaultPage}
-          icon={
-            <img alt="Zeeguu" src="../static/images/zeeguuWhiteLogo.svg"></img>
-          }
+          icon={<img alt="" src="../static/images/zeeguuWhiteLogo.svg"></img>}
           text={"Zeeguu"}
-          ariaLabel="Zeeguu"
         ></NavOption>
 
         {isOnStudentSide && (

--- a/src/components/MainNav/SideNav/SideNav.js
+++ b/src/components/MainNav/SideNav/SideNav.js
@@ -40,7 +40,7 @@ export default function SideNav({ screenWidth, setUser }) {
 
       <s.BottomSection $screenWidth={screenWidth}>
         <s.NavList>
-          {isOnStudentSide && (
+          {isOnStudentSide && !path?.includes("/read") && (
             <SideNavLanguageOption
               setUser={setUser}
               screenWidth={screenWidth}

--- a/src/components/MainNav/SideNav/SideNav.sc.js
+++ b/src/components/MainNav/SideNav/SideNav.sc.js
@@ -25,6 +25,7 @@ const SideNav = styled.nav`
   top: 0;
   padding: 0.5rem 0.5rem 11rem 0.5rem;
   overflow-y: scroll;
+  z-index: 2;
 
   ${sharedSideNavStyling}
   &::-webkit-scrollbar {

--- a/src/components/MainNav/SideNav/SideNav.sc.js
+++ b/src/components/MainNav/SideNav/SideNav.sc.js
@@ -32,10 +32,20 @@ const SideNav = styled.nav`
   }
 `;
 
+const NavList = styled.ul`
+  all: unset;
+`;
+
 const BottomSection = styled.div`
   bottom: 0;
   padding: 1rem 0.5rem 1rem 0.5rem;
   ${sharedSideNavStyling}
 `;
 
-export { SideNav, BottomSection, sideNavExpandedWidth, sideNavCollapsedWidth };
+export {
+  SideNav,
+  NavList,
+  BottomSection,
+  sideNavExpandedWidth,
+  sideNavCollapsedWidth,
+};

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -5,15 +5,16 @@ import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 
-export default function SideNavLanguageOption({ screenWidth, setUser }) {
+export default function SideNavLanguageOption({ screenWidth }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const userContext = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
 
   const currentLearnedLanguage = useMemo(() => {
-    const languageCode = userContext.userData.userDetails.learned_language;
+    const languageCode = userDetails.learned_language;
     const languageName = navLanguages[languageCode];
     return languageName || "Language";
-  }, [userContext.userData.userDetails.learned_language]);
+  }, [userDetails.learned_language]);
 
   const languageDisplayed = currentLearnedLanguage || "Language not set";
   return (
@@ -31,7 +32,6 @@ export default function SideNavLanguageOption({ screenWidth, setUser }) {
         }}
       />
       <LanguageModal
-        setUser={setUser}
         prefixMsg={"Sidebar"}
         open={showLanguageModal}
         setOpen={() => {

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -5,7 +5,7 @@ import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 
-export default function SideNavLanguageOption({ screenWidth }) {
+export default function SideNavLanguageOption({ screenWidth, setUser }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
   const user = useContext(UserContext);
 
@@ -31,6 +31,7 @@ export default function SideNavLanguageOption({ screenWidth }) {
         }}
       />
       <LanguageModal
+        setUser={setUser}
         prefixMsg={"Sidebar"}
         open={showLanguageModal}
         setOpen={() => {

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -7,8 +7,7 @@ import navLanguages from "../navLanguages";
 
 export default function SideNavLanguageOption({ screenWidth }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   const currentLearnedLanguage = useMemo(() => {
     const languageCode = userDetails.learned_language;

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { FEEDBACK_OPTIONS } from "../../FeedbackConstants";
 import LanguageModal from "../LanguageModal";
 import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
@@ -9,6 +8,7 @@ export default function SideNavLanguageOption() {
   return (
     <>
       <NavOption
+        ariaHasPopup={"dialog"}
         icon={<NavIcon name={"language"} />}
         text={"Language"}
         onClick={(e) => {
@@ -22,7 +22,6 @@ export default function SideNavLanguageOption() {
         setOpen={() => {
           setShowLanguageModal(!showLanguageModal);
         }}
-        feedbackOptions={FEEDBACK_OPTIONS.ALL}
       ></LanguageModal>
     </>
   );

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { FEEDBACK_OPTIONS } from "../../FeedbackConstants";
+import LanguageModal from "../LanguageModal";
+import NavOption from "../NavOption";
+import NavIcon from "../NavIcon";
+
+export default function SideNavLanguageOption() {
+  const [showLanguageModal, setShowLanguageModal] = useState(false);
+  return (
+    <>
+      <NavOption
+        icon={<NavIcon name={"language"} />}
+        text={"Current Language"}
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowLanguageModal(!showLanguageModal);
+        }}
+      />
+      <LanguageModal
+        prefixMsg={"Sidebar"}
+        open={showFeedbackModal}
+        setOpen={() => {
+          setShowLanguageModal(!showFeedbackModal);
+        }}
+        feedbackOptions={FEEDBACK_OPTIONS.ALL}
+      ></LanguageModal>
+    </>
+  );
+}

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -10,7 +10,7 @@ export default function SideNavLanguageOption() {
     <>
       <NavOption
         icon={<NavIcon name={"language"} />}
-        text={"Current Language"}
+        text={"Language"}
         onClick={(e) => {
           e.stopPropagation();
           setShowLanguageModal(!showLanguageModal);
@@ -18,9 +18,9 @@ export default function SideNavLanguageOption() {
       />
       <LanguageModal
         prefixMsg={"Sidebar"}
-        open={showFeedbackModal}
+        open={showLanguageModal}
         setOpen={() => {
-          setShowLanguageModal(!showFeedbackModal);
+          setShowLanguageModal(!showLanguageModal);
         }}
         feedbackOptions={FEEDBACK_OPTIONS.ALL}
       ></LanguageModal>

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -7,13 +7,13 @@ import navLanguages from "../navLanguages";
 
 export default function SideNavLanguageOption({ screenWidth, setUser }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
-  const user = useContext(UserContext);
+  const userContext = useContext(UserContext);
 
   const currentLearnedLanguage = useMemo(() => {
-    const languageCode = user.learned_language;
+    const languageCode = userContext.userData.userDetails.learned_language;
     const languageName = navLanguages[languageCode];
     return languageName || "Language";
-  }, [user.learned_language]);
+  }, [userContext.userData.userDetails.learned_language]);
 
   const languageDisplayed = currentLearnedLanguage || "Language not set";
   return (

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -5,7 +5,7 @@ import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 
-export default function SideNavLanguageOption() {
+export default function SideNavLanguageOption({ screenWidth }) {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
   const user = useContext(UserContext);
 
@@ -23,6 +23,8 @@ export default function SideNavLanguageOption() {
         ariaLabel={`Change language (currently: ${languageDisplayed})`}
         icon={<NavIcon name={"language"} />}
         text={languageDisplayed}
+        title={languageDisplayed}
+        screenWidth={screenWidth}
         onClick={(e) => {
           e.stopPropagation();
           setShowLanguageModal(!showLanguageModal);

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -1,16 +1,28 @@
-import { useState } from "react";
+import { useState, useContext, useMemo } from "react";
+import { UserContext } from "../../../contexts/UserContext";
 import LanguageModal from "../LanguageModal";
 import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
+import navLanguages from "../navLanguages";
 
 export default function SideNavLanguageOption() {
   const [showLanguageModal, setShowLanguageModal] = useState(false);
+  const user = useContext(UserContext);
+
+  const currentLearnedLanguage = useMemo(() => {
+    const languageCode = user.learned_language;
+    const languageName = navLanguages[languageCode];
+    return languageName || "Language";
+  }, [user.learned_language]);
+
+  const languageDisplayed = currentLearnedLanguage || "Language not set";
   return (
     <>
       <NavOption
         ariaHasPopup={"dialog"}
+        ariaLabel={`Change language (currently: ${languageDisplayed})`}
         icon={<NavIcon name={"language"} />}
-        text={"Language"}
+        text={languageDisplayed}
         onClick={(e) => {
           e.stopPropagation();
           setShowLanguageModal(!showLanguageModal);

--- a/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
+++ b/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
@@ -2,10 +2,9 @@ import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { useContext } from "react";
 import { UserContext } from "../../../contexts/UserContext";
 import useExerciseNotification from "../../../hooks/useExerciseNotification";
-import NotificationIcon from "../../NotificationIcon";
 import NavOption from "../NavOption";
 import NavigationOptions from "../navigationOptions";
-import SideNavLanguageOption from "./SideNavLanguageOption";
+import NotificationIcon from "../../NotificationIcon";
 
 export default function SideNavOptionsForStudent({ screenWidth }) {
   const { is_teacher: isTeacher } = useContext(UserContext);
@@ -53,8 +52,6 @@ export default function SideNavOptionsForStudent({ screenWidth }) {
         currentPath={path}
         screenWidth={screenWidth}
       />
-
-      <SideNavLanguageOption screenWidth={screenWidth} />
 
       {isTeacher && (
         <NavOption

--- a/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
+++ b/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
@@ -7,8 +7,7 @@ import NavigationOptions from "../navigationOptions";
 import NotificationIcon from "../../NotificationIcon";
 
 export default function SideNavOptionsForStudent({ screenWidth }) {
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   const path = useLocation().pathname;
   const { hasExerciseNotification, notificationMsg } =

--- a/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
+++ b/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
@@ -7,9 +7,10 @@ import NavigationOptions from "../navigationOptions";
 import NotificationIcon from "../../NotificationIcon";
 
 export default function SideNavOptionsForStudent({ screenWidth }) {
-  const { is_teacher: isTeacher } = useContext(UserContext);
-  const path = useLocation().pathname;
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
 
+  const path = useLocation().pathname;
   const { hasExerciseNotification, notificationMsg } =
     useExerciseNotification();
 
@@ -53,7 +54,7 @@ export default function SideNavOptionsForStudent({ screenWidth }) {
         screenWidth={screenWidth}
       />
 
-      {isTeacher && (
+      {userDetails.is_teacher && (
         <NavOption
           {...NavigationOptions.teacherSite}
           currentPath={path}

--- a/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
+++ b/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
@@ -54,7 +54,7 @@ export default function SideNavOptionsForStudent({ screenWidth }) {
         screenWidth={screenWidth}
       />
 
-      <SideNavLanguageOption />
+      <SideNavLanguageOption screenWidth={screenWidth} />
 
       {isTeacher && (
         <NavOption

--- a/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
+++ b/src/components/MainNav/SideNav/SideNavOptionsForStudent.js
@@ -5,6 +5,7 @@ import useExerciseNotification from "../../../hooks/useExerciseNotification";
 import NotificationIcon from "../../NotificationIcon";
 import NavOption from "../NavOption";
 import NavigationOptions from "../navigationOptions";
+import SideNavLanguageOption from "./SideNavLanguageOption";
 
 export default function SideNavOptionsForStudent({ screenWidth }) {
   const { is_teacher: isTeacher } = useContext(UserContext);
@@ -52,6 +53,8 @@ export default function SideNavOptionsForStudent({ screenWidth }) {
         currentPath={path}
         screenWidth={screenWidth}
       />
+
+      <SideNavLanguageOption />
 
       {isTeacher && (
         <NavOption

--- a/src/components/MainNav/navLanguages.js
+++ b/src/components/MainNav/navLanguages.js
@@ -1,0 +1,18 @@
+const navLanguages = {
+  da: "Danish",
+  nl: "Dutch",
+  en: "English",
+  fr: "French",
+  de: "German",
+  hu: "Hungarian",
+  it: "Italian",
+  no: "Norwegian",
+  pl: "Polish",
+  pt: "Portuguese",
+  ro: "Romanian",
+  ru: "Russian",
+  es: "Spanish",
+  sv: "Swedish",
+};
+
+export default navLanguages;

--- a/src/components/ReactLink.sc.js
+++ b/src/components/ReactLink.sc.js
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { orange700, orange800 } from "./colors";
+
+const ReactLink = styled(Link)`
+  display: flex;
+  font-size: 1.2rem;
+  font-weight: 600;
+  gap: 0.25rem;
+  align-items: center;
+  text-underline-offset: 0.2em;
+  color: ${orange700};
+  transition: all 0.3s ease-in-out;
+  padding: 0.5rem 0;
+
+  &:hover {
+    color: ${orange800};
+  }
+
+  &.small {
+    font-size: 1rem;
+  }
+`;
+
+export default ReactLink;

--- a/src/components/modal_shared/ButtonContainer.sc.js
+++ b/src/components/modal_shared/ButtonContainer.sc.js
@@ -7,6 +7,7 @@ const ButtonContainer = styled.div`
   gap: 1.5rem;
   flex-direction: row-reverse;
   justify-content: space-between;
+  align-items: center;
 
   ${(props) =>
     props.buttonCountNum === 1 &&

--- a/src/components/modal_shared/Heading.sc.js
+++ b/src/components/modal_shared/Heading.sc.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const Heading = styled.h1`
+const Heading = styled.h2`
   font-size: 1.3rem;
   line-height: 150%;
   text-align: center;

--- a/src/components/modal_shared/Modal.js
+++ b/src/components/modal_shared/Modal.js
@@ -7,7 +7,7 @@ export default function Modal({ children, open, onClose }) {
     <ModalMui open={open} onClose={onClose}>
       <s.ModalWrapper>
         {children}
-        <s.CloseButton role="button" onClick={onClose}>
+        <s.CloseButton aria-label="Close Modal" onClick={onClose}>
           <CloseRoundedIcon fontSize="medium" />
         </s.CloseButton>
       </s.ModalWrapper>

--- a/src/components/modal_shared/Modal.sc.js
+++ b/src/components/modal_shared/Modal.sc.js
@@ -70,12 +70,14 @@ const Strong = styled.span`
   font-weight: 700;
 `;
 
-const CloseButton = styled.div`
+const CloseButton = styled.button`
   cursor: pointer;
   padding: 1px;
   text-align: right;
   position: absolute;
   float: right;
+  border: none;
+  background-color: inherit;
   right: 16px;
   margin-top: -16px;
   @media (max-width: 576px) {

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -10,15 +10,7 @@ const UserContext = React.createContext({
   // - logoutMethod
 });
 
-// who uses what from userContext
-// - learned_language: SideNavLanguageOption: learned_language
-// - session
-// - is_teacher: SideNav.js
-// - native_language
 
-// In LanguageModal we call setUser ...
 export {
   UserContext, // Export it so it can be used by other Components
 };
-
-// https://www.digitalocean.com/community/tutorials/react-manage-user-login-react-context

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -1,6 +1,20 @@
 import React from "react";
-const UserContext = React.createContext({}); // Create a context object
 
+const UserContext = React.createContext({
+  // What we have in a user context:
+  // - userData {userDetails: {}, userPreferences: {}}
+  // - setUserData:
+  // - session
+  // - logoutMethod
+});
+
+// who uses what from userContext
+// - learned_language: SideNavLanguageOption: learned_language
+// - session
+// - is_teacher: SideNav.js
+// - native_language
+
+// In LanguageModal we call setUser ...
 export {
   UserContext, // Export it so it can be used by other Components
 };

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -2,8 +2,10 @@ import React from "react";
 
 const UserContext = React.createContext({
   // What we have in a user context:
-  // - userData {userDetails: {}, userPreferences: {}}
-  // - setUserData:
+  // - userDetails: {}
+  // - setUserDetails
+  // - userPreferences: {}
+  // - setUserPreferences
   // - session
   // - logoutMethod
 });

--- a/src/pages/DeleteAccount/DeleteAccount.js
+++ b/src/pages/DeleteAccount/DeleteAccount.js
@@ -22,7 +22,7 @@ const DeletionStatus = Object.freeze({
 
 export default function DeleteAccount() {
   const api = useContext(APIContext);
-  const user = useContext(UserContext);
+  const { logoutMethod } = useContext(UserContext);
   const [headingMsg, setHeadingMsg] = useState("We are deleting your account");
   const [currentStatus, setCurrentStatus] = useState(DeletionStatus.UNDEFINED);
 
@@ -35,7 +35,7 @@ export default function DeleteAccount() {
           setHeadingMsg("✅ Your account has been successfully deleted!");
           setCurrentStatus(DeletionStatus.OK);
           setTimeout(() => {
-            user.logoutMethod();
+            logoutMethod();
           }, TIME_BEFORE_REDIRECT);
         },
         () => {

--- a/src/pages/Settings/ExerciseTypePreferences.js
+++ b/src/pages/Settings/ExerciseTypePreferences.js
@@ -20,7 +20,7 @@ import { APIContext } from "../../contexts/APIContext";
 
 export default function ExerciseTypePreferences() {
   const api = useContext(APIContext);
-  const user = useContext(UserContext);
+  const { session } = useContext(UserContext);
   const history = useHistory();
 
   const [audioExercises, setAudioExercises] = useState(true);
@@ -43,7 +43,7 @@ export default function ExerciseTypePreferences() {
           SessionStorage.isAudioExercisesEnabled(),
       );
     });
-  }, [user.session, api]);
+  }, [session, api]);
 
   function handleAudioExercisesChange(e) {
     setAudioExercises((state) => !state);

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -129,7 +129,10 @@ export default function LanguageSettings() {
     else
       api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
         updateUserInfo(tempUserDetails);
-        history.goBack();
+        setTimeout(() => {
+          //timeout to prevent unmounting to early
+          history.goBack();
+        }, 400);
       });
   }
 

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -1,5 +1,5 @@
 import { useHistory } from "react-router-dom";
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useRef } from "react";
 import { UserContext } from "../../contexts/UserContext";
 import { saveUserInfoIntoCookies } from "../../utils/cookies/userInfo";
 import { CEFR_LEVELS } from "../../assorted/cefrLevels";
@@ -57,6 +57,7 @@ export default function LanguageSettings() {
     }, "Your Translation language needs to be different than your learned language."),
   ]);
   const history = useHistory();
+  const isPageMounted = useRef(true);
 
   function setCEFRlevel(data) {
     const levelKey = data.learned_language + "_cefr_level";
@@ -72,16 +73,25 @@ export default function LanguageSettings() {
   }, []);
 
   useEffect(() => {
+    isPageMounted.current = true;
     api.getUserDetails((data) => {
-      setTempUserDetails(data);
-      setCEFRlevel(data);
-      setLearnedLanguage(data.learned_language);
-      setNativeLanguage(data.native_language);
+      if (isPageMounted.current) {
+        setTempUserDetails(data);
+        setCEFRlevel(data);
+        setLearnedLanguage(data.learned_language);
+        setNativeLanguage(data.native_language);
+      }
     });
 
     api.getSystemLanguages((systemLanguages) => {
-      setLanguages(systemLanguages);
+      if (isPageMounted.current) {
+        setLanguages(systemLanguages);
+      }
     });
+
+    return () => {
+      isPageMounted.current = false;
+    };
     // eslint-disable-next-line
   }, [session, api]);
 
@@ -129,10 +139,7 @@ export default function LanguageSettings() {
     else
       api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
         updateUserInfo(tempUserDetails);
-        setTimeout(() => {
-          //timeout to prevent unmounting to early
-          history.goBack();
-        }, 400);
+        history.goBack();
       });
   }
 

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -29,7 +29,7 @@ import { scrollToTop } from "../../utils/misc/scrollToTop";
 import validateRules from "../../assorted/validateRules";
 import { APIContext } from "../../contexts/APIContext";
 
-export default function LanguageSettings({ setUser }) {
+export default function LanguageSettings() {
   const api = useContext(APIContext);
   const [errorMessage, setErrorMessage] = useState("");
   const [userDetails, setUserDetails] = useState(null);
@@ -56,7 +56,7 @@ export default function LanguageSettings({ setUser }) {
     }, "Your Translation language needs to be different than your learned language."),
   ]);
 
-  const user = useContext(UserContext);
+  const userContext = useContext(UserContext);
   const history = useHistory();
 
   function setCEFRlevel(data) {
@@ -84,14 +84,18 @@ export default function LanguageSettings({ setUser }) {
       setLanguages(systemLanguages);
     });
     // eslint-disable-next-line
-  }, [user.session, api]);
+  }, [userContext.session, api]);
 
   function updateUserInfo(info) {
     LocalStorage.setUserInfo(info);
-    setUser({
-      ...user,
-      learned_language: info.learned_language,
-      native_language: info.native_language,
+
+    userContext.setUserData({
+      ...userContext.userData,
+      userDetails: {
+        ...userContext.userData.userDetails,
+        learned_language: info.learned_language,
+        native_language: info.native_language,
+      },
     });
 
     saveUserInfoIntoCookies(info);

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -31,8 +31,7 @@ import { APIContext } from "../../contexts/APIContext";
 
 export default function LanguageSettings() {
   const api = useContext(APIContext);
-  const { userData, setUserData, session } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails, setUserDetails, session } = useContext(UserContext);
   const [errorMessage, setErrorMessage] = useState("");
   const [tempUserDetails, setTempUserDetails] = useState(null);
   const [languages, setLanguages] = useState();
@@ -94,12 +93,7 @@ export default function LanguageSettings() {
       learned_language: info.learned_language,
       native_language: info.native_language,
     };
-
-    setUserData({
-      ...userData,
-      userDetails: newUserDetails,
-    });
-
+    setUserDetails(newUserDetails);
     saveUserInfoIntoCookies(info);
   }
 

--- a/src/pages/Settings/LogOutButton.js
+++ b/src/pages/Settings/LogOutButton.js
@@ -5,11 +5,11 @@ import { useContext } from "react";
 import { UserContext } from "../../contexts/UserContext";
 
 export default function LogOutButton() {
-  const user = useContext(UserContext);
+  const { logoutMethod } = useContext(UserContext);
   return (
     <LogOutButtonStyle
       onClick={() => {
-        user.logoutMethod();
+        logoutMethod();
       }}
     >
       Log Out{" "}

--- a/src/pages/Settings/MyClassrooms/MyClassrooms.js
+++ b/src/pages/Settings/MyClassrooms/MyClassrooms.js
@@ -24,7 +24,7 @@ import { APIContext } from "../../../contexts/APIContext";
 
 export default function MyClassrooms() {
   const api = useContext(APIContext);
-  const user = useContext(UserContext);
+  const { session } = useContext(UserContext);
 
   const [isLoading, setIsLoading] = useState(true);
   const [
@@ -55,7 +55,7 @@ export default function MyClassrooms() {
   useEffect(() => {
     updateValues();
     // eslint-disable-next-line
-  }, [user.session, api]);
+  }, [session, api]);
 
   function handleOpenLeaveClassroomModal(classroom) {
     setCurrentClassroom(classroom);

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -85,7 +85,6 @@ export default function ProfileDetails() {
     if (!validateRules([validateUserName, validateEmail])) return;
     api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
       updateUserInfo(tempUserDetails);
-      console.log("User details saved", userDetails);
       setTimeout(() => {
         //timeout to prevent unmounting to early
         history.goBack();

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -25,7 +25,6 @@ import {
   NonEmptyValidator,
 } from "../../utils/ValidatorRule/Validator";
 import validateRules from "../../assorted/validateRules";
-import { is } from "date-fns/locale";
 
 export default function ProfileDetails() {
   const api = useContext(APIContext);

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -89,10 +89,7 @@ export default function ProfileDetails() {
     if (!validateRules([validateUserName, validateEmail])) return;
     api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
       updateUserInfo(tempUserDetails);
-      // setTimeout(() => {
-      //timeout to prevent unmounting to early
       history.goBack();
-      // }, 400);
     });
   }
 

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -1,5 +1,5 @@
 import { useHistory } from "react-router-dom";
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useRef } from "react";
 import { UserContext } from "../../contexts/UserContext";
 import { saveUserInfoIntoCookies } from "../../utils/cookies/userInfo";
 import { setTitle } from "../../assorted/setTitle";
@@ -25,12 +25,14 @@ import {
   NonEmptyValidator,
 } from "../../utils/ValidatorRule/Validator";
 import validateRules from "../../assorted/validateRules";
+import { is } from "date-fns/locale";
 
 export default function ProfileDetails() {
   const api = useContext(APIContext);
   const [errorMessage, setErrorMessage] = useState("");
   const { userDetails, setUserDetails } = useContext(UserContext);
   const history = useHistory();
+  const isPageMounted = useRef(true);
 
   const [tempUserDetails, setTempUserDetails] = useState("");
   const [
@@ -56,11 +58,18 @@ export default function ProfileDetails() {
   }, []);
 
   useEffect(() => {
+    isPageMounted.current = true;
     api.getUserDetails((data) => {
-      setTempUserDetails(data);
-      setUserEmail(data.email);
-      setUserName(data.name);
+      if (isPageMounted.current) {
+        setTempUserDetails(data);
+        setUserEmail(data.email);
+        setUserName(data.name);
+      }
     });
+
+    return () => {
+      isPageMounted.current = false;
+    };
     // eslint-disable-next-line
   }, [userDetails, api]);
 
@@ -80,10 +89,10 @@ export default function ProfileDetails() {
     if (!validateRules([validateUserName, validateEmail])) return;
     api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
       updateUserInfo(tempUserDetails);
-      setTimeout(() => {
-        //timeout to prevent unmounting to early
-        history.goBack();
-      }, 400);
+      // setTimeout(() => {
+      //timeout to prevent unmounting to early
+      history.goBack();
+      // }, 400);
     });
   }
 

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -29,8 +29,7 @@ import validateRules from "../../assorted/validateRules";
 export default function ProfileDetails() {
   const api = useContext(APIContext);
   const [errorMessage, setErrorMessage] = useState("");
-  const { userData, setUserData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails, setUserDetails } = useContext(UserContext);
   const history = useHistory();
 
   const [tempUserDetails, setTempUserDetails] = useState("");
@@ -70,12 +69,8 @@ export default function ProfileDetails() {
       ...userDetails,
       name: info.name,
     };
-
+    setUserDetails(newUserDetails);
     LocalStorage.setUserInfo(info);
-    setUserData({
-      ...userData,
-      userDetails: newUserDetails,
-    });
     saveUserInfoIntoCookies(info);
   }
 

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -62,7 +62,7 @@ export default function ProfileDetails() {
       setUserName(data.name);
     });
     // eslint-disable-next-line
-  }, [userData, api]);
+  }, [userDetails, api]);
 
   function updateUserInfo(info) {
     const newUserDetails = {

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -9,8 +9,7 @@ import ListOfSettingsItems from "./settings_pages_shared/ListOfSettingsItems";
 import * as s from "./Settings.sc";
 
 export default function Settings() {
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
 
   useEffect(() => {
     setTitle(strings.settings);

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -9,7 +9,8 @@ import ListOfSettingsItems from "./settings_pages_shared/ListOfSettingsItems";
 import * as s from "./Settings.sc";
 
 export default function Settings() {
-  const user = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
 
   useEffect(() => {
     setTitle(strings.settings);
@@ -27,7 +28,7 @@ export default function Settings() {
           {strings.languageSettings}
         </SettingsItem>
 
-        {!user.is_teacher && (
+        {!userDetails.is_teacher && (
           <SettingsItem path={"/account_settings/my_classrooms"}>
             {strings.myClassrooms}
           </SettingsItem>

--- a/src/pages/_pages_shared/Button.sc.js
+++ b/src/pages/_pages_shared/Button.sc.js
@@ -3,6 +3,9 @@ import {
   zeeguuDarkOrange,
   zeeguuOrange,
   zeeguuRed,
+  orange600,
+  orange500,
+  orange800,
 } from "../../components/colors";
 
 const Button = styled.button`
@@ -18,13 +21,17 @@ const Button = styled.button`
   font-size: 1.2rem;
   padding: 1rem 2.8rem;
   border-radius: 4em;
-  background-color: ${zeeguuOrange};
   font-weight: 600;
-  box-shadow: 0px 0.2rem ${zeeguuDarkOrange};
+  background-color: ${orange500};
+  box-shadow: 0px 0.2rem ${orange800};
   transition: all ease-in 0.08s;
   overflow: hidden;
   white-space: nowrap;
   margin-bottom: 0.2em;
+
+  &:hover {
+    background-color: ${orange600};
+  }
 
   &.small {
     padding: 0.7em 2em;

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -37,8 +37,7 @@ import { APIContext } from "../../contexts/APIContext";
 
 export default function CreateAccount({ handleSuccessfulLogIn }) {
   const api = useContext(APIContext);
-  const { userData, setUserData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails, setUserDetails } = useContext(UserContext);
 
   const learnedLanguage = LocalStorage.getLearnedLanguage();
   const nativeLanguage = LocalStorage.getNativeLanguage();
@@ -160,7 +159,7 @@ export default function CreateAccount({ handleSuccessfulLogIn }) {
       (session) => {
         api.getUserDetails((user) => {
           handleSuccessfulLogIn(user, session);
-          setUserData({ ...userData, userDetails: userInfo });
+          setUserDetails(userInfo);
           saveUserInfoIntoCookies(userInfo);
           redirect("/select_interests");
         });

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -35,9 +35,10 @@ import {
 import { setTitle } from "../../assorted/setTitle";
 import { APIContext } from "../../contexts/APIContext";
 
-export default function CreateAccount({ handleSuccessfulLogIn, setUser }) {
+export default function CreateAccount({ handleSuccessfulLogIn }) {
   const api = useContext(APIContext);
-  const user = useContext(UserContext);
+  const { userData, setUserData } = useContext(UserContext);
+  const { userDetails } = userData;
 
   const learnedLanguage = LocalStorage.getLearnedLanguage();
   const nativeLanguage = LocalStorage.getNativeLanguage();
@@ -144,7 +145,7 @@ export default function CreateAccount({ handleSuccessfulLogIn, setUser }) {
     }
 
     let userInfo = {
-      ...user,
+      ...userDetails,
       name: name,
       email: email,
       learned_language: learnedLanguage,
@@ -159,7 +160,7 @@ export default function CreateAccount({ handleSuccessfulLogIn, setUser }) {
       (session) => {
         api.getUserDetails((user) => {
           handleSuccessfulLogIn(user, session);
-          setUser(userInfo);
+          setUserData({ ...userData, userDetails: userInfo });
           saveUserInfoIntoCookies(userInfo);
           redirect("/select_interests");
         });

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -74,7 +74,8 @@ export default function ArticleReader({ teacherArticleID }) {
   const [clickedOnReviewVocab, setClickedOnReviewVocab] = useState(false);
   const [viewPortSettings, setViewPortSettings] = useState("");
 
-  const user = useContext(UserContext);
+  const { userData } = useContext(UserContext);
+  const { userDetails } = userData;
   const history = useHistory();
   const speech = useContext(SpeechContext);
   const [activityTimer, isTimerActive] = useActivityTimer(uploadActivity);
@@ -296,7 +297,7 @@ export default function ArticleReader({ teacherArticleID }) {
   return (
     <>
       <TopToolbar
-        user={user}
+        user={userDetails}
         teacherArticleID={teacherArticleID}
         articleID={articleID}
         interactiveText={interactiveText}

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -74,8 +74,7 @@ export default function ArticleReader({ teacherArticleID }) {
   const [clickedOnReviewVocab, setClickedOnReviewVocab] = useState(false);
   const [viewPortSettings, setViewPortSettings] = useState("");
 
-  const { userData } = useContext(UserContext);
-  const { userDetails } = userData;
+  const { userDetails } = useContext(UserContext);
   const history = useHistory();
   const speech = useContext(SpeechContext);
   const [activityTimer, isTimerActive] = useActivityTimer(uploadActivity);

--- a/src/teacher/_routing/_TeacherRouter.js
+++ b/src/teacher/_routing/_TeacherRouter.js
@@ -3,7 +3,7 @@ import CohortsRouter from "./_CohortsRouter";
 import Tutorials from "../helpPage/Tutorials";
 import TeacherTextsRouter from "./_TeacherTextsRouter";
 
-export default function TeacherRouter({ api }) {
+export default function TeacherRouter() {
   return (
     <>
       <PrivateRoute path="/teacher/classes" component={CohortsRouter} />


### PR DESCRIPTION
## A quick language change is now available in the MainNav

The fast language change in the main navigation has now been implemented. You can read more details about this implementation in this issue: https://github.com/zeeguu/web/issues/700  

### Additional changes implemented as a part of this PR:
- Web accessibility has been slightly improved.
- The structure of the user context has been modified, and all the necessary changes have been applied across the dependent files.
```
const UserContext = React.createContext({
  // What we have in a user context:
  // - userDetails: {}
  // - setUserDetails
  // - userPreferences: {}
  // - setUserPreferences
  // - session
  // - logoutMethod
});

```
- The `LanguageSettings` page now relies on the `userDetails` state from the `UserContext` for user data retrieval (`learned_language`) and updating the API. 


## Screen recordings

https://github.com/user-attachments/assets/58888d11-792e-49de-9433-27837c9136e4

https://github.com/user-attachments/assets/f553569b-ad83-4e91-b6d3-756baf2c1eb0

https://github.com/user-attachments/assets/9c2310e1-c08e-4b17-af98-1bb5dd16e453