### PR TITLE
Updated NLP calls from Web

### DIFF
--- a/src/api/Zeeguu_API.js
+++ b/src/api/Zeeguu_API.js
@@ -16,5 +16,6 @@ import "./ownTexts";
 import "./student";
 import "./teacher";
 import "./studentStatsForTeachers";
+import "./nlp";
 
 export default Zeeguu_API;

--- a/src/api/nlp.js
+++ b/src/api/nlp.js
@@ -10,7 +10,13 @@ Zeeguu_API.prototype.tokenizeText = function (text, language, callback) {
     text: text,
     language: language,
   };
-  return this._post(`/tokenize_text`, qs.stringify(payload), callback);
+  return this._post(
+    `/tokenize_text`,
+    qs.stringify(payload),
+    callback,
+    (error) => console.log(error),
+    true,
+  );
 };
 
 Zeeguu_API.prototype.getSents = function (text, language, callback) {
@@ -21,7 +27,13 @@ Zeeguu_API.prototype.getSents = function (text, language, callback) {
     text: text,
     language: language,
   };
-  return this._post(`/tokenize_sents`, qs.stringify(payload), callback);
+  return this._post(
+    `/tokenize_sents`,
+    qs.stringify(payload),
+    callback,
+    (error) => console.log(error),
+    true,
+  );
 };
 
 Zeeguu_API.prototype.getParagraphs = function (text, language, callback) {
@@ -31,5 +43,11 @@ Zeeguu_API.prototype.getParagraphs = function (text, language, callback) {
   let payload = {
     text: text,
   };
-  return this._post(`/get_paragraphs`, qs.stringify(payload), callback);
+  return this._post(
+    `/get_paragraphs`,
+    qs.stringify(payload),
+    callback,
+    (error) => console.log(error),
+    true,
+  );
 };


### PR DESCRIPTION
- The calls from the web were not setup needing an import and to parse the json received.

This change is mostly to allow the Extension students to be able to prototype the ArticleID.