### PR TITLE
737 user settings send updates to the api directly from the user context

### DIFF
--- a/src/components/MainNav/RadioGroup.sc.js
+++ b/src/components/MainNav/RadioGroup.sc.js
@@ -13,6 +13,9 @@ const StyledRadioGroup = styled.div`
   gap: 0.5rem;
   padding: 0;
   max-height: 24rem;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const RadioGroupLabel = styled.div`

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -70,7 +70,6 @@ export default function LanguageSettings() {
   }, []);
 
   useEffect(() => {
-    const startTime = performance.now();
     isPageMounted.current = true;
 
     if (isPageMounted.current) {
@@ -82,10 +81,6 @@ export default function LanguageSettings() {
     api.getSystemLanguages((systemLanguages) => {
       if (isPageMounted.current) {
         setLanguages(systemLanguages);
-        const endTime = performance.now();
-        console.log(
-          `LanguageSettings component loaded in ${endTime - startTime} milliseconds.`,
-        );
       }
     });
 

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -87,20 +87,9 @@ export default function LanguageSettings() {
     return () => {
       isPageMounted.current = false;
     };
-    // eslint-disable-next-line
+    // eslint-disable-next
+    // -line
   }, [session, api]);
-
-  function updateNativeLanguage(lang_code) {
-    setNativeLanguage(lang_code);
-  }
-
-  function updateCEFRLevel(level) {
-    setCEFR(parseInt(level));
-  }
-
-  function updateLearnedLanguage(lang_code) {
-    setLearnedLanguage(lang_code);
-  }
 
   function handleSave(e) {
     e.preventDefault();
@@ -150,7 +139,7 @@ export default function LanguageSettings() {
               languages={languages.learnable_languages}
               selected={learnedLanguage}
               onChange={(e) => {
-                updateLearnedLanguage(e.target.value);
+                setLearnedLanguage(e.target.value);
               }}
               isError={!isLearnedLanguageValid}
               errorMessage={learnedLanguageErrorMsg}
@@ -162,7 +151,7 @@ export default function LanguageSettings() {
               optionLabel={(e) => e.label}
               optionValue={(e) => e.value}
               onChange={(e) => {
-                updateCEFRLevel(e.target.value);
+                setCEFR(parseInt(e.target.value));
               }}
               selectedValue={CEFR}
             />
@@ -177,7 +166,7 @@ export default function LanguageSettings() {
               isError={!isNativeLanguageValid}
               errorMessage={nativeLanguageMsg}
               onChange={(e) => {
-                updateNativeLanguage(e.target.value);
+                setNativeLanguage(e.target.value);
               }}
             />
           </FormSection>

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -59,7 +59,7 @@ export default function LanguageSettings() {
   const history = useHistory();
   const isPageMounted = useRef(true);
 
-  function handleSetCEFRlevelFromUserData(data) {
+  function setCEFRlevelFromUserContext(data) {
     const levelKey = data.learned_language + "_cefr_level";
     const levelNumber = data[levelKey];
     setCEFR(levelNumber);
@@ -73,7 +73,7 @@ export default function LanguageSettings() {
     isPageMounted.current = true;
 
     if (isPageMounted.current) {
-      handleSetCEFRlevelFromUserData(userDetails);
+      setCEFRlevelFromUserContext(userDetails);
       setLearnedLanguage(userDetails.learned_language);
       setNativeLanguage(userDetails.native_language);
     }
@@ -87,8 +87,7 @@ export default function LanguageSettings() {
     return () => {
       isPageMounted.current = false;
     };
-    // eslint-disable-next
-    // -line
+    // eslint-disable-next-line
   }, [session, api]);
 
   function handleSave(e) {

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -59,7 +59,7 @@ export default function LanguageSettings() {
   const history = useHistory();
   const isPageMounted = useRef(true);
 
-  function setCEFRlevelFromUserContext(data) {
+  function setCEFRLevelFromUserContext(data) {
     const levelKey = data.learned_language + "_cefr_level";
     const levelNumber = data[levelKey];
     setCEFR(levelNumber);
@@ -73,7 +73,7 @@ export default function LanguageSettings() {
     isPageMounted.current = true;
 
     if (isPageMounted.current) {
-      setCEFRlevelFromUserContext(userDetails);
+      setCEFRLevelFromUserContext(userDetails);
       setLearnedLanguage(userDetails.learned_language);
       setNativeLanguage(userDetails.native_language);
     }

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -33,7 +33,11 @@ export default function ProfileDetails() {
   const history = useHistory();
   const isPageMounted = useRef(true);
 
-  const [tempUserDetails, setTempUserDetails] = useState("");
+  console.log(
+    "userDetails from the context on the ProfileDetails page:",
+    userDetails,
+  );
+
   const [
     userName,
     setUserName,
@@ -58,13 +62,10 @@ export default function ProfileDetails() {
 
   useEffect(() => {
     isPageMounted.current = true;
-    api.getUserDetails((data) => {
-      if (isPageMounted.current) {
-        setTempUserDetails(data);
-        setUserEmail(data.email);
-        setUserName(data.name);
-      }
-    });
+    if (isPageMounted.current) {
+      setUserEmail(userDetails.email);
+      setUserName(userDetails.name);
+    }
 
     return () => {
       isPageMounted.current = false;
@@ -72,27 +73,25 @@ export default function ProfileDetails() {
     // eslint-disable-next-line
   }, [userDetails, api]);
 
-  function updateUserInfo(info) {
-    const newUserDetails = {
-      ...userDetails,
-      name: info.name,
-    };
-    setUserDetails(newUserDetails);
-    LocalStorage.setUserInfo(info);
-    saveUserInfoIntoCookies(info);
-  }
-
   function handleSave(e) {
     e.preventDefault();
     setErrorMessage("");
     if (!validateRules([validateUserName, validateEmail])) return;
-    api.saveUserDetails(tempUserDetails, setErrorMessage, () => {
-      updateUserInfo(tempUserDetails);
+
+    const newUserDetails = {
+      ...userDetails,
+      name: userName,
+      email: userEmail,
+    };
+    api.saveUserDetails(newUserDetails, setErrorMessage, () => {
+      setUserDetails(newUserDetails);
+      LocalStorage.setUserInfo(newUserDetails);
+      saveUserInfoIntoCookies(newUserDetails);
       history.goBack();
     });
   }
 
-  if (!tempUserDetails) {
+  if (!userDetails) {
     return <LoadingAnimation />;
   }
 
@@ -118,10 +117,6 @@ export default function ProfileDetails() {
               isError={!isUserNameValid}
               errorMessage={userErrorMessage}
               onChange={(e) => {
-                setTempUserDetails({
-                  ...tempUserDetails,
-                  name: e.target.value,
-                });
                 setUserName(e.target.value);
               }}
             />
@@ -135,10 +130,6 @@ export default function ProfileDetails() {
               isError={!isEmailValid}
               errorMessage={emailErrorMessage}
               onChange={(e) => {
-                setTempUserDetails({
-                  ...tempUserDetails,
-                  email: e.target.value,
-                });
                 setUserEmail(e.target.value);
               }}
             />

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -33,11 +33,6 @@ export default function ProfileDetails() {
   const history = useHistory();
   const isPageMounted = useRef(true);
 
-  console.log(
-    "userDetails from the context on the ProfileDetails page:",
-    userDetails,
-  );
-
   const [
     userName,
     setUserName,


### PR DESCRIPTION
## What's new: 
User Setting pages `LanguageSettings` and  `ProfileDetails` are now on the UserContext to send updates to the API

### Minor improvements to consider in the future:

`UserContext` uses a **dynamic** **key** for the user `CEFR Level` per each practiced language, for instance, 
`da_cefr_level` for Danish. 

The  `api.saveUserDetails` is not satisfied with the dynamic key and expects a standalone `cefr_level` key, which in turn is **redundant** in the UserContext since the levels are assigned per each language. 

This is why I had to create a separate object, `newUserDetailsForAPI`. We might consider rethinking how the languages are updated on the API side and adjusting the approach.


```
      const newUserDetails = {
        ...userDetails,
        learned_language: learnedLanguage,
        native_language: nativeLanguage,
        [learnedLanguage + "_cefr_level"]: CEFR,
      };

      const newUserDetailsForAPI = {
        ...newUserDetails,
        cefr_level: CEFR,
      };

      api.saveUserDetails(newUserDetailsForAPI, setErrorMessage, () => {
        setUserDetails(newUserDetails);
        LocalStorage.setUserInfo(newUserDetails);
        saveUserInfoIntoCookies(newUserDetails);
        history.goBack();
      });
```