### PR TITLE
Fix formatting when showing solution

### DIFF
--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -103,10 +103,6 @@ export function TranslatableText({
       : [];
     const isWordBold = boldWords.includes(removePunctuation(word.word));
 
-    if (isWordBold) {
-      return <span style={{ fontWeight: "bold" }}>{word.word + " "}</span>;
-    }
-
     if (isCorrect) {
       if (word.id === firstWordID && overrideBookmarkHighlightText) {
         // In case we want to override the highlighted bookmark
@@ -148,6 +144,9 @@ export function TranslatableText({
         );
       }
     } else {
+      if (isWordBold) {
+        return <span style={{ fontWeight: "bold" }}>{word.word + " "}</span>;
+      }
       if (!bookmarkToStudy || translatedWords) {
         return (
           <TranslatableWord


### PR DESCRIPTION
- Some exercises we were incorrectly formatting the text by overriding the solution styling with bold.


| Before | After |
| :-: | :-: |
| **Exercise Start** |  |
| ![{C6E230F7-AECE-4783-BCF4-CC031956B426}](https://github.com/user-attachments/assets/d189fee9-ce8c-4649-bd1f-91957af38799) | ![{BAA3F117-F3C8-412A-AD2D-C435B1558DC8}](https://github.com/user-attachments/assets/ac064b91-31c0-44a8-93fb-e72274a4c3b6) |
| **Exercise Completed** |  |
| ![{751066A8-A514-4506-9B62-0980C1CEE73A}](https://github.com/user-attachments/assets/117390fa-7831-44e6-ae1c-79b6a911f55e) | ![{DC1BA5B6-627E-4D5C-ACD5-BBA9F783F8FE}](https://github.com/user-attachments/assets/ad768d3b-b865-4160-b068-1ca6c63f9557) |

