### PR TITLE
Changes for new api model

### DIFF
--- a/src/api/activityLogging.js
+++ b/src/api/activityLogging.js
@@ -77,6 +77,7 @@ Zeeguu_API.prototype.logUserActivity = function (
   article_id = "",
   value = "",
   extra_data = "",
+  source_id = "",
 ) {
   let event_information = {
     time: new Date().toJSON(),
@@ -84,6 +85,7 @@ Zeeguu_API.prototype.logUserActivity = function (
     value: value,
     extra_data: extra_data,
     article_id: article_id,
+    source_id: source_id,
   };
 
   const currentDate = new Date();
@@ -110,8 +112,9 @@ Zeeguu_API.prototype.logReaderActivity = function (
   article_id = "",
   value = "",
   extra_data = "",
+  source_id = "",
 ) {
-  return this.logUserActivity(event, article_id, value, extra_data);
+  return this.logUserActivity(event, article_id, value, extra_data, source_id);
 };
 
 Zeeguu_API.prototype.daysSinceLastUse = function (callback) {

--- a/src/api/activityLogging.js
+++ b/src/api/activityLogging.js
@@ -114,6 +114,15 @@ Zeeguu_API.prototype.logReaderActivity = function (
   extra_data = "",
   source_id = "",
 ) {
+  /**
+   * Logs an activity that occurred in the text reader.
+   *
+   * @param {string} event - The type of event that occurred.
+   * @param {string} [article_id=""] - The ID of the article associated with the event.
+   * @param {string} [value=""] - Additional information about the event.
+   * @param {string} [extra_data=""] - Extra data related to the event.
+   * @param {string} [source_id=""] - The ID of source associated with the event.
+   */
   return this.logUserActivity(event, article_id, value, extra_data, source_id);
 };
 

--- a/src/api/translations.js
+++ b/src/api/translations.js
@@ -12,6 +12,9 @@ Zeeguu_API.prototype.getOneTranslation = function (
   isArticleContent,
   leftEllipsis,
   rightEllipsis,
+  contextType,
+  formatting,
+  fragmentId,
 ) {
   let w_sent_i, w_token_i, w_total_tokens;
   let c_paragraph_i, c_sent_i, c_token_i;
@@ -31,6 +34,9 @@ Zeeguu_API.prototype.getOneTranslation = function (
     articleID: articleID,
     left_ellipsis: leftEllipsis,
     right_ellipsis: rightEllipsis,
+    context_type: contextType,
+    formatting: formatting,
+    fragment_id: fragmentId,
   };
   return this._post(
     `get_one_translation/${from_lang}/${to_lang}`,

--- a/src/api/translations.js
+++ b/src/api/translations.js
@@ -8,8 +8,7 @@ Zeeguu_API.prototype.getOneTranslation = function (
   bookmark_token_i,
   context,
   context_token_i,
-  articleID,
-  isArticleContent,
+  sourceID,
   leftEllipsis,
   rightEllipsis,
   contextIdentifier,
@@ -22,19 +21,22 @@ Zeeguu_API.prototype.getOneTranslation = function (
   let payload = {
     word: word,
     context: context,
+    source_id: sourceID,
     w_sent_i: w_sent_i,
     w_token_i: w_token_i,
     w_total_tokens: w_total_tokens,
     c_paragraph_i: c_paragraph_i,
     c_sent_i: c_sent_i,
     c_token_i: c_token_i,
-    in_content: isArticleContent,
-    articleID: articleID,
     left_ellipsis: leftEllipsis,
     right_ellipsis: rightEllipsis,
     context_identifier: contextIdentifier,
   };
+
+  /*   
+  console.log("Sending bookmark!");
   console.dir(payload);
+  */
   return this._post(
     `get_one_translation/${from_lang}/${to_lang}`,
     qs.stringify(payload),
@@ -99,12 +101,14 @@ Zeeguu_API.prototype.updateBookmark = function (
   word,
   translation,
   context,
+  context_type,
   callback,
 ) {
   let payload = {
     word: word,
     translation: translation,
     context: context,
+    context_type: context_type,
   };
 
   return this._post(

--- a/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
+++ b/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
@@ -49,7 +49,6 @@ export default function FindWordInContextCloze({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
+++ b/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
@@ -48,7 +48,7 @@ export default function FindWordInContextCloze({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
+++ b/src/exercises/exerciseTypes/findWordInContextCloze/FindWordInContextCloze.js
@@ -56,6 +56,9 @@ export default function FindWordInContextCloze({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     // eslint-disable-next-line

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -54,7 +54,6 @@ export default function MultipleChoice({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -53,7 +53,7 @@ export default function MultipleChoice({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -61,6 +61,9 @@ export default function MultipleChoice({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
 

--- a/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
+++ b/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
@@ -57,7 +57,6 @@ export default function MultipleChoiceAudio({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
+++ b/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
@@ -56,7 +56,7 @@ export default function MultipleChoiceAudio({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
+++ b/src/exercises/exerciseTypes/multipleChoiceAudio/MultipleChoiceAudio.js
@@ -64,6 +64,9 @@ export default function MultipleChoiceAudio({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     consolidateChoice();

--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -64,7 +64,6 @@ export default function MultipleChoiceContext({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -71,6 +71,9 @@ export default function MultipleChoiceContext({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     // eslint-disable-next-line

--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -63,7 +63,7 @@ export default function MultipleChoiceContext({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
+++ b/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
@@ -51,7 +51,6 @@ export default function MultipleChoiceL2toL1({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
+++ b/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
@@ -58,6 +58,9 @@ export default function MultipleChoiceL2toL1({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     // eslint-disable-next-line

--- a/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
+++ b/src/exercises/exerciseTypes/multipleChoiceL2toL1/MultipleChoiceL2toL1.js
@@ -50,7 +50,7 @@ export default function MultipleChoiceL2toL1({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -83,6 +83,7 @@ export default function OrderWords({
   const moveElementInitialPosition = useRef();
   const scrollY = useRef();
   const speech = useContext(SpeechContext);
+  const exerciseBookmark = bookmarksToStudy[0];
 
   // Exercise Functions / Setup / Handle Interactions
 
@@ -93,12 +94,17 @@ export default function OrderWords({
       if (IS_DEBUG) console.log("Setting article info.");
       setInteractiveText(
         new InteractiveText(
-          bookmarksToStudy[0].context,
-          articleInfo,
+          exerciseBookmark.context_tokenized,
+          exerciseBookmark.article_id,
           api,
+          [],
           "TRANSLATE WORDS IN EXERCISE",
+          exerciseBookmark.from_lang,
           EXERCISE_TYPE,
           speech,
+          exerciseBookmark.context_type,
+          null,
+          exerciseBookmark.fragment_id,
         ),
       );
     });

--- a/src/exercises/exerciseTypes/orderWords/OrderWords.js
+++ b/src/exercises/exerciseTypes/orderWords/OrderWords.js
@@ -95,7 +95,7 @@ export default function OrderWords({
       setInteractiveText(
         new InteractiveText(
           exerciseBookmark.context_tokenized,
-          exerciseBookmark.article_id,
+          exerciseBookmark.source_id,
           api,
           [],
           "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -63,6 +63,9 @@ export default function SpellWhatYouHear({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     if (!SessionStorage.isAudioExercisesEnabled()) handleDisabledAudio();

--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -56,7 +56,6 @@ export default function SpellWhatYouHear({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
+++ b/src/exercises/exerciseTypes/spellWhatYouHear/SpellWhatYouHear.js
@@ -55,7 +55,7 @@ export default function SpellWhatYouHear({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
+++ b/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
@@ -47,7 +47,7 @@ export default function TranslateL2toL1({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
+++ b/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
@@ -55,6 +55,9 @@ export default function TranslateL2toL1({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     // eslint-disable-next-line

--- a/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
+++ b/src/exercises/exerciseTypes/translateL2toL1/TranslateL2toL1.js
@@ -48,7 +48,6 @@ export default function TranslateL2toL1({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -54,7 +54,6 @@ export default function TranslateWhatYouHear({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -61,6 +61,9 @@ export default function TranslateWhatYouHear({
         exerciseBookmark.from_lang,
         EXERCISE_TYPE,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
     if (!SessionStorage.isAudioExercisesEnabled()) handleDisabledAudio();

--- a/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
+++ b/src/exercises/exerciseTypes/translateWhatYouHear/TranslateWhatYouHear.js
@@ -53,7 +53,7 @@ export default function TranslateWhatYouHear({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
+++ b/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
@@ -48,7 +48,7 @@ export default function WordInContextExercise({
     setInteractiveText(
       new InteractiveText(
         exerciseBookmark.context_tokenized,
-        exerciseBookmark.article_id,
+        exerciseBookmark.source_id,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
+++ b/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
@@ -56,6 +56,9 @@ export default function WordInContextExercise({
         exerciseBookmark.from_lang,
         exerciseType,
         speech,
+        exerciseBookmark.context_type,
+        null,
+        exerciseBookmark.fragment_id,
       ),
     );
 

--- a/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
+++ b/src/exercises/exerciseTypes/wordInContextExercises/WordInContextExercise.js
@@ -49,7 +49,6 @@ export default function WordInContextExercise({
       new InteractiveText(
         exerciseBookmark.context_tokenized,
         exerciseBookmark.article_id,
-        exerciseBookmark.context_in_content,
         api,
         [],
         "TRANSLATE WORDS IN EXERCISE",

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -204,7 +204,6 @@ export default function ArticleReader({ teacherArticleID }) {
             new InteractiveText(
               each.tokens,
               articleInfo.id,
-              false,
               api,
               each.past_bookmarks,
               api.TRANSLATE_TEXT,
@@ -222,7 +221,6 @@ export default function ArticleReader({ teacherArticleID }) {
         new InteractiveText(
           articleTitleData.tokens,
           articleInfo.id,
-          false,
           api,
           articleTitleData.past_bookmarks,
           api.TRANSLATE_TEXT,

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -62,6 +62,7 @@ export default function ArticleReader({ teacherArticleID }) {
 
   const [interactiveText, setInteractiveText] = useState();
   const [interactiveTitle, setInteractiveTitle] = useState();
+  const [interactiveFragments, setInteractiveFragments] = useState();
   const {
     translateInReader,
     pronounceInReader,
@@ -195,30 +196,40 @@ export default function ArticleReader({ teacherArticleID }) {
     setScrollPosition(0);
 
     api.getArticleInfo(articleID, (articleInfo) => {
-      setInteractiveText(
-        new InteractiveText(
-          articleInfo.tokenized_paragraphs,
-          articleInfo.id,
-          true,
-          api,
-          articleInfo.translations,
-          api.TRANSLATE_TEXT,
-          articleInfo.language,
-          UMR_SOURCE,
-          speech,
+      console.log("Here is the article info!");
+      console.dir(articleInfo);
+      setInteractiveFragments(
+        articleInfo.tokenized_fragments.map(
+          (each) =>
+            new InteractiveText(
+              each.tokens,
+              articleInfo.id,
+              false,
+              api,
+              each.past_bookmarks,
+              api.TRANSLATE_TEXT,
+              articleInfo.language,
+              UMR_SOURCE,
+              speech,
+              each.context_type,
+              each.formatting,
+              each.fragment_id,
+            ),
         ),
       );
+      const articleTitleData = articleInfo.tokenized_title_new;
       setInteractiveTitle(
         new InteractiveText(
-          articleInfo.tokenized_title,
+          articleTitleData.tokens,
           articleInfo.id,
           false,
           api,
-          articleInfo.translations,
+          articleTitleData.past_bookmarks,
           api.TRANSLATE_TEXT,
           articleInfo.language,
           UMR_SOURCE,
           speech,
+          articleTitleData.context_type,
         ),
       );
       setArticleInfo(articleInfo);
@@ -263,7 +274,7 @@ export default function ArticleReader({ teacherArticleID }) {
     }
   }
 
-  if (!articleInfo || !interactiveText) {
+  if (!articleInfo || !interactiveFragments) {
     return <LoadingAnimation />;
   }
 
@@ -292,7 +303,6 @@ export default function ArticleReader({ teacherArticleID }) {
       UMR_SOURCE,
     );
   };
-
   return (
     <>
       <TopToolbar
@@ -361,12 +371,16 @@ export default function ArticleReader({ teacherArticleID }) {
           )}
 
           <s.MainText>
-            <TranslatableText
-              interactiveText={interactiveText}
-              translating={translateInReader}
-              pronouncing={pronounceInReader}
-              updateBookmarks={fetchBookmarks}
-            />
+            {interactiveFragments &&
+              interactiveFragments.map((interactiveText) => (
+                <TranslatableText
+                  interactiveText={interactiveText}
+                  translating={translateInReader}
+                  pronouncing={pronounceInReader}
+                  setIsRendered={setReaderReady}
+                  updateBookmarks={fetchBookmarks}
+                />
+              ))}
           </s.MainText>
         </div>
 

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -60,7 +60,7 @@ export default function ArticleReader({ teacherArticleID }) {
 
   const [articleInfo, setArticleInfo] = useState();
 
-  const [interactiveText, setInteractiveText] = useState();
+  const [interactiveText] = useState();
   const [interactiveTitle, setInteractiveTitle] = useState();
   const [interactiveFragments, setInteractiveFragments] = useState();
   const {
@@ -157,7 +157,7 @@ export default function ArticleReader({ teacherArticleID }) {
   };
 
   useEffect(() => {
-    if (interactiveText !== undefined) {
+    if (interactiveFragments !== undefined) {
       setTimeout(() => {
         try {
           let scrollElement = document.getElementById("scrollHolder");
@@ -188,7 +188,7 @@ export default function ArticleReader({ teacherArticleID }) {
         }
       }, 250);
     }
-  }, [interactiveText, last_reading_percentage]);
+  }, [interactiveFragments, last_reading_percentage]);
 
   function onCreate() {
     scrollEvents.current = [];
@@ -203,16 +203,15 @@ export default function ArticleReader({ teacherArticleID }) {
           (each) =>
             new InteractiveText(
               each.tokens,
-              articleInfo.id,
+              articleInfo.source_id,
               api,
               each.past_bookmarks,
               api.TRANSLATE_TEXT,
               articleInfo.language,
               UMR_SOURCE,
               speech,
-              each.context_type,
+              each.context_identifier,
               each.formatting,
-              each.fragment_id,
             ),
         ),
       );
@@ -227,7 +226,7 @@ export default function ArticleReader({ teacherArticleID }) {
           articleInfo.language,
           UMR_SOURCE,
           speech,
-          articleTitleData.context_type,
+          articleTitleData.context_identifier,
         ),
       );
       setArticleInfo(articleInfo);
@@ -282,7 +281,7 @@ export default function ArticleReader({ teacherArticleID }) {
       setAnswerSubmitted(true);
       setArticleInfo(newArticleInfo);
     });
-    api.logReaderActivity(api.LIKE_ARTICLE, articleInfo.id, state, UMR_SOURCE);
+    api.logReaderActivity(api.LIKE_ARTICLE, articleID, state, UMR_SOURCE);
   };
 
   const updateArticleDifficultyFeedback = (answer) => {
@@ -296,7 +295,7 @@ export default function ArticleReader({ teacherArticleID }) {
     );
     api.logReaderActivity(
       api.DIFFICULTY_FEEDBACK,
-      articleInfo.id,
+      articleID,
       answer,
       UMR_SOURCE,
     );

--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -14,8 +14,7 @@ function wordShouldSkipCount(word) {
 export default class InteractiveText {
   constructor(
     tokenizedParagraphs,
-    articleID,
-    isArticleContent,
+    sourceId,
     api,
     previousBookmarks,
     translationEvent = api.TRANSLATE_TEXT,
@@ -25,6 +24,7 @@ export default class InteractiveText {
     contextType,
     formatting,
     fragmentId,
+    subtitleId,
   ) {
     function _updateTokensWithBookmarks(bookmarks, paragraphs) {
       function areCoordinatesInParagraphMatrix(
@@ -142,14 +142,14 @@ export default class InteractiveText {
       }
     }
     this.api = api;
-    this.article_id = articleID;
+    this.sourceId = sourceId;
     this.language = language;
-    this.isArticleContent = articleID && isArticleContent;
     this.translationEvent = translationEvent;
     this.source = source;
     this.contextType = contextType;
     this.formatting = formatting;
     this.fragmentId = fragmentId;
+    this.subtitleId = subtitleId;
 
     // Might be worth to store a flag to keep track of wether or not the
     // bookmark / text are part of the content or stand by themselves.
@@ -187,7 +187,7 @@ export default class InteractiveText {
         [wordSent_i, wordToken_i, word.total_tokens],
         context,
         [cParagraph_i, cSent_i, cToken_i],
-        this.article_id,
+        this.sourceId,
         this.isArticleContent,
         leftEllipsis,
         rightEllipsis,
@@ -210,7 +210,7 @@ export default class InteractiveText {
 
     this.api.logReaderActivity(
       this.translationEvent,
-      this.article_id,
+      this.sourceId,
       word.word,
       this.source,
     );
@@ -232,7 +232,7 @@ export default class InteractiveText {
     let alternative_info = `${word.translation} => ${alternative} (${preferredSource})`;
     this.api.logReaderActivity(
       this.api.SEND_SUGGESTION,
-      this.article_id,
+      this.sourceId,
       alternative_info,
       this.source,
     );
@@ -252,7 +252,7 @@ export default class InteractiveText {
         -1,
         word.service_name,
         word.translation,
-        this.article_id,
+        this.sourceId,
       )
       .then((response) => response.json())
       .then((data) => {
@@ -263,7 +263,7 @@ export default class InteractiveText {
 
   playAll() {
     console.log("playing all");
-    this.zeeguuSpeech.playAll(this.article_id);
+    this.zeeguuSpeech.playAll(this.sourceId);
   }
 
   pause() {
@@ -281,7 +281,7 @@ export default class InteractiveText {
 
     this.api.logReaderActivity(
       this.api.SPEAK_TEXT,
-      this.article_id,
+      this.sourceId,
       word.word,
       this.source,
     );

--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -22,6 +22,7 @@ export default class InteractiveText {
     source = "",
     zeeguuSpeech,
     contextIdentifier,
+    formatting,
   ) {
     function _updateTokensWithBookmarks(bookmarks, paragraphs) {
       function areCoordinatesInParagraphMatrix(
@@ -36,6 +37,7 @@ export default class InteractiveText {
           target_t_i < paragraphs[0][target_s_i].length
         );
       }
+      if (!bookmarks) return;
 
       for (let i = 0; i < bookmarks.length; i++) {
         let bookmark = bookmarks[i];
@@ -183,7 +185,6 @@ export default class InteractiveText {
         context,
         [cParagraph_i, cSent_i, cToken_i],
         this.sourceId,
-        this.isArticleContent,
         leftEllipsis,
         rightEllipsis,
         this.contextIdentifier,
@@ -203,9 +204,10 @@ export default class InteractiveText {
 
     this.api.logReaderActivity(
       this.translationEvent,
-      this.sourceId,
+      null,
       word.word,
       this.source,
+      this.sourceId,
     );
   }
 
@@ -217,7 +219,7 @@ export default class InteractiveText {
       word.word,
       alternative,
       context,
-      this.isArticleContent,
+      this.contextIdentifier["context_type"],
     );
     word.translation = alternative;
     word.service_name = "Own alternative selection";
@@ -225,9 +227,10 @@ export default class InteractiveText {
     let alternative_info = `${word.translation} => ${alternative} (${preferredSource})`;
     this.api.logReaderActivity(
       this.api.SEND_SUGGESTION,
-      this.sourceId,
+      null,
       alternative_info,
       this.source,
+      this.sourceId,
     );
 
     onSuccess();
@@ -274,9 +277,10 @@ export default class InteractiveText {
 
     this.api.logReaderActivity(
       this.api.SPEAK_TEXT,
-      this.sourceId,
+      null,
       word.word,
       this.source,
+      this.sourceId,
     );
   }
 

--- a/src/reader/LinkedWordListClass.js
+++ b/src/reader/LinkedWordListClass.js
@@ -72,6 +72,7 @@ export class Word extends Item {
     this.mergedTokens = [...this.prev.mergedTokens];
 
     this.token = this.prev.token;
+    this.total_tokens += this.prev.total_tokens;
 
     this.prev.detach();
     return this;

--- a/src/reader/ReportBroken.js
+++ b/src/reader/ReportBroken.js
@@ -30,7 +30,13 @@ export default function ReportBroken({ sourceID, UMR_SOURCE }) {
   };
 
   function reportBroken() {
-    api.logReaderActivity(api.USER_FEEDBACK, sourceID, feedback, UMR_SOURCE);
+    api.logReaderActivity(
+      api.USER_FEEDBACK,
+      "",
+      feedback,
+      UMR_SOURCE,
+      sourceID,
+    );
     setIsFeedbackSent(true);
     setTimeout(() => handleClose(), 1000);
   }

--- a/src/reader/ReportBroken.js
+++ b/src/reader/ReportBroken.js
@@ -13,7 +13,7 @@ import { gray, darkBlue } from "../components/colors";
 import CloseSharpIcon from "@mui/icons-material/CloseSharp";
 import { APIContext } from "../contexts/APIContext";
 
-export default function ReportBroken({ articleID, UMR_SOURCE }) {
+export default function ReportBroken({ sourceID, UMR_SOURCE }) {
   const api = useContext(APIContext);
   const [open, setOpen] = useState(false);
   const [feedback, setFeedback] = useState("");
@@ -30,7 +30,7 @@ export default function ReportBroken({ articleID, UMR_SOURCE }) {
   };
 
   function reportBroken() {
-    api.logReaderActivity(api.USER_FEEDBACK, articleID, feedback, UMR_SOURCE);
+    api.logReaderActivity(api.USER_FEEDBACK, sourceID, feedback, UMR_SOURCE);
     setIsFeedbackSent(true);
     setTimeout(() => handleClose(), 1000);
   }

--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, createElement } from "react";
 import TranslatableWord from "./TranslatableWord";
 import * as s from "./TranslatableText.sc";
 import { removePunctuation } from "../utils/text/preprocessing";
@@ -24,6 +24,9 @@ export function TranslatableText({
   const [paragraphs, setParagraphs] = useState([]);
   const [firstWordID, setFirstWordID] = useState(0);
   const [renderedText, setRenderedText] = useState();
+  const divType = interactiveText.formatting
+    ? interactiveText.formatting
+    : "div";
 
   useEffect(() => {
     if (bookmarkToStudy) {
@@ -35,13 +38,17 @@ export function TranslatableText({
 
   useEffect(() => {
     setRenderedText(
-      paragraphs.map((par, index) => (
-        <div key={index} className="textParagraph">
-          {index === 0 && leftEllipsis && <>...</>}
-          {par.getWords().map((word) => renderWordJSX(word))}
-          {index === 0 && rightEllipsis && <>...</>}
-        </div>
-      )),
+      paragraphs.map((par, index) =>
+        createElement(
+          divType,
+          { className: "textParagraph", key: index },
+          <>
+            {index === 0 && leftEllipsis && <>...</>}
+            {par.getWords().map((word) => renderWordJSX(word))}
+            {index === 0 && rightEllipsis && <>...</>}
+          </>,
+        ),
+      ),
     );
     //eslint-disable-next-line
   }, [

--- a/src/words/EditBookmarkButton.js
+++ b/src/words/EditBookmarkButton.js
@@ -123,7 +123,7 @@ export default function EditBookmarkButton({
           );
         }
         if (setReload) setReload(!reload);
-        if (notifyWordChange) notifyWordChange(bookmark.id);
+        if (notifyWordChange) notifyWordChange(bookmark);
         toast.success("Thank you for the contribution!");
         handleClose();
       },

--- a/src/words/WordsOnDate.js
+++ b/src/words/WordsOnDate.js
@@ -28,8 +28,17 @@ export function WordsOnDate({ day, notifyDelete }) {
       {articleIDs.map((article_id) => (
         <s.Article key={article_id}>
           <s.ArticleTitle>
-            {bookmarks_by_article.get(article_id)[0].title}
-            <Link to={"/read/article?id=" + article_id}>{strings.open}</Link>
+            {bookmarks_by_article.get(article_id)[0].title ? (
+              <>
+                {bookmarks_by_article.get(article_id)[0].title}
+                <Link to={"/read/article?id=" + article_id}>
+                  {strings.open}
+                </Link>
+              </>
+            ) : (
+              // If the source is missing, tell it to the user.
+              <span style={{ color: "grey" }}>[Source deleted]</span>
+            )}
           </s.ArticleTitle>
 
           {bookmarks_by_article.get(article_id).map((bookmark) => (


### PR DESCRIPTION
- Now we are starting to log the source_id rather than the article id. However, the minimal change is that a lot of the reporting can be done with an article_id, and the backend can then recover the source_id associated with it. So instead of forcing to send the source_id, either can be send (article or source id) and then the backend will log accordingly.
- Updated Exercises to send source id.