### PR TITLE
Fix the topic button for video preview

### DIFF
--- a/src/pages/ExplainTopicsModal.js
+++ b/src/pages/ExplainTopicsModal.js
@@ -3,22 +3,15 @@ import Modal from "../components/modal_shared/Modal";
 import { darkBlue } from "../components/colors";
 import HighlightOffRoundedIcon from "@mui/icons-material/HighlightOffRounded";
 
-export default function ExplainTopicsModal({
-  infoTopicClick,
-  showInfoTopics,
-  setShowInfoTopics,
-}) {
+export default function ExplainTopicsModal({ infoTopicClick, showInfoTopics, setShowInfoTopics }) {
   return (
     <Modal
       children={
         <>
-          <h1>Article topics are shown differently!</h1>
+          <h1>Topics are shown differently!</h1>
           <div style={{ textAlign: "left", lineHeight: "2em" }}>
             <s.UrlTopics style={{ cursor: "default" }}>
-              <span
-                className="inferred"
-                style={{ marginRight: "0.5em", cursor: "default" }}
-              >
+              <span className="inferred" style={{ marginRight: "0.5em", cursor: "default" }}>
                 {infoTopicClick}
                 <HighlightOffRoundedIcon
                   className="cancelButton"
@@ -26,19 +19,14 @@ export default function ExplainTopicsModal({
                   sx={{ color: darkBlue }}
                 />
               </span>{" "}
-              A dashed-line means that similar articles have been labeled with '
-              {infoTopicClick}'. You can choose to remove them by clicking the
-              cross.
+              A dashed-line means that similar articles have been labeled with '{infoTopicClick}'. You can choose to
+              remove them by clicking the cross.
             </s.UrlTopics>
             <s.UrlTopics style={{ cursor: "default" }}>
-              <span
-                className="gold"
-                style={{ marginRight: "0.5em", cursor: "default" }}
-              >
+              <span className="gold" style={{ marginRight: "0.5em", cursor: "default" }}>
                 {infoTopicClick}
               </span>{" "}
-              The source associated with the article usually publishes '
-              {infoTopicClick}'.
+              The source associated with the article usually publishes '{infoTopicClick}'.
             </s.UrlTopics>
           </div>
         </>

--- a/src/videos/VideoPreview.js
+++ b/src/videos/VideoPreview.js
@@ -8,7 +8,7 @@ import { FaPlay } from "react-icons/fa";
 import { darkBlue } from "../components/colors";
 import { useEffect, useState, useContext } from "react";
 import ExplainTopicsModal from "../pages/ExplainTopicsModal";
-import * as sweetM from "../articles/TagsOfInterests.sc";
+import { TagsOfInterests } from "../articles/TagsOfInterests.sc";
 import HighlightOffRoundedIcon from "@mui/icons-material/HighlightOffRounded";
 import { APIContext } from "../contexts/APIContext";
 
@@ -32,13 +32,13 @@ export default function VideoPreview({ video, notifyVideoClick }) {
   return (
     <s.VideoPreview>
       {showInfoTopics && (
-        <sweetM.TagsOfInterests>
+        <TagsOfInterests>
           <ExplainTopicsModal
             infoTopicClick={infoTopicClick}
             showInfoTopics={showInfoTopics}
             setShowInfoTopics={setShowInfoTopics}
           />
-        </sweetM.TagsOfInterests>
+        </TagsOfInterests>
       )}
       <s.TitleContainer>
         <s.Title>
@@ -64,18 +64,17 @@ export default function VideoPreview({ video, notifyVideoClick }) {
         <div>
           {showInferredTopic && topics.length > 0 && (
             <s.UrlTopics>
-              {topics.map((tuple) => (
-                // Tuple (Topic Title, TopicOriginType)
+              {topics.map(([topicTitle, topicOrigin]) => (
                 <span
                   onClick={() => {
                     setShowInfoTopics(!showInfoTopics);
-                    setInfoTopicClick(tuple[0]);
+                    setInfoTopicClick(topicTitle);
                   }}
-                  key={tuple[0]}
-                  className={tuple[1] === TopicOriginType.INFERRED ? "inferred" : "gold"}
+                  key={topicTitle}
+                  className={topicOrigin === TopicOriginType.INFERRED ? "inferred" : "gold"}
                 >
-                  {tuple[0]}
-                  {tuple[1] === TopicOriginType.INFERRED && (
+                  {topicTitle}
+                  {topicOrigin === TopicOriginType.INFERRED && (
                     <HighlightOffRoundedIcon
                       className="cancelButton"
                       sx={{ color: darkBlue }}
@@ -83,7 +82,7 @@ export default function VideoPreview({ video, notifyVideoClick }) {
                         e.stopPropagation();
                         setShowInferredTopic(false);
                         toast("Your preference was saved.");
-                        api.removeMLSuggestion(video.source_id, tuple[0]);
+                        api.removeMLSuggestion(video.source_id, topicTitle);
                       }}
                     />
                   )}

--- a/src/videos/VideoPreview.sc.js
+++ b/src/videos/VideoPreview.sc.js
@@ -1,11 +1,5 @@
 import styled from "styled-components";
-import {
-  almostBlack,
-  zeeguuDarkOrange,
-  blue100,
-  blue400,
-  blue600,
-} from "../components/colors";
+import { almostBlack, zeeguuDarkOrange, blue100, blue400, blue600 } from "../components/colors";
 
 const VideoPreview = styled.div`
   margin-bottom: 1em;
@@ -109,6 +103,12 @@ const UrlTopics = styled.div`
     text-align: center;
     vertical-align: middle;
     background-color: ${blue100};
+  }
+  .cancelButton {
+    cursor: pointer;
+    padding-left: 0.3em;
+    margin-bottom: -0.3em;
+    margin-right: -0.3em;
   }
   @media (max-width: 990px) {
     margin-bottom: 1.2em;


### PR DESCRIPTION
Fixed the topic button for the video preview such that the (x) is in the middle and that you can actually click the button.

I changed the header of the modal to be "Topics are shown differently!" instead of "Articles topics are shown differently!" to accommodate for multiple sources.