### PR TITLE
Added "Show videos only" filter

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -32,17 +32,20 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
   const [articlesAndVideosList, setArticlesAndVideosList] = useState();
   const [originalList, setOriginalList] = useState(null);
   const [searchError, setSearchError] = useState(false);
-  const [isShowVideosOnly, setIsShowVideosOnly] = useState(false);
+
   const [isExtensionAvailable] = useExtensionCommunication();
   const [doNotShowRedirectionModal_UserPreference, setDoNotShowRedirectionModal_UserPreference] = useState(
     doNotShowRedirectionModal_LocalStorage,
   );
   const [reloadingSearchArticles, setReloadingSearchArticles] = useState(false);
-  const [areVideosAvailable, setAreVideosAvailable] = useState(false);
 
   const searchPublishPriorityRef = useShadowRef(searchPublishPriority);
   const searchDifficultyPriorityRef = useShadowRef(searchDifficultyPriority);
-  const isShowVideosOnlyRef = useShadowRef(isShowVideosOnly);
+
+  // Next three vars required for the "Show Videos Only" toggle button
+  const [areVideosAvailable, setAreVideosAvailable] = useState(false);
+  const [isShowVideosOnlyEnabled, setIsShowVideosOnlyEnabled] = useState(false);
+  const isShowVideosOnlyEnabledRef = useShadowRef(isShowVideosOnlyEnabled);
 
   function getNewArticlesForPage(pageNumber, handleArticleInsertion) {
     if (searchQuery) {
@@ -63,7 +66,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
   }
 
   function updateOnPagination(newUpdatedList) {
-    if (isShowVideosOnlyRef.current) {
+    if (isShowVideosOnlyEnabledRef.current) {
       const videosOnly = [...newUpdatedList].filter((each) => each.video);
       setArticlesAndVideosList(videosOnly);
     } else {
@@ -80,8 +83,8 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
   );
 
   function handleVideoOnlyClick() {
-    setIsShowVideosOnly(!isShowVideosOnly);
-    if (isShowVideosOnly) {
+    setIsShowVideosOnlyEnabled(!isShowVideosOnlyEnabled);
+    if (isShowVideosOnlyEnabled) {
       setArticlesAndVideosList(originalList);
       resetPagination();
     } else {
@@ -200,7 +203,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
           )}
           <s.SortHolder>
             <SortButton
-              className={isShowVideosOnly && "selected"}
+              className={isShowVideosOnlyEnabled && "selected"}
               style={{ visibility: !areVideosAvailable && "hidden" }}
               onClick={handleVideoOnlyClick}
             >
@@ -209,7 +212,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <SortingButtons
               articleList={articlesAndVideosList}
               setArticleList={setArticlesAndVideosList}
-              isShowVideoOnly={isShowVideosOnly}
+              isShowVideoOnly={isShowVideosOnlyEnabled}
             />
           </s.SortHolder>
         </>

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -38,6 +38,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
     doNotShowRedirectionModal_LocalStorage,
   );
   const [reloadingSearchArticles, setReloadingSearchArticles] = useState(false);
+  const [areVideosAvailable, setAreVideosAvailable] = useState(false);
 
   const searchPublishPriorityRef = useShadowRef(searchPublishPriority);
   const searchDifficultyPriorityRef = useShadowRef(searchDifficultyPriority);
@@ -127,6 +128,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
           setArticlesAndVideosList(articles);
           setOriginalList([...articles]);
           setReloadingSearchArticles(false);
+          articles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
         },
         (error) => {
           console.log(error);
@@ -142,6 +144,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
       api.getUserArticles((articles) => {
         setArticlesAndVideosList(articles);
         setOriginalList([...articles]);
+        articles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
       });
       window.addEventListener("scroll", handleScroll, true);
       return () => {
@@ -196,7 +199,11 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <UnfinishedArticlesList articleList={articlesAndVideosList} setArticleList={setArticlesAndVideosList} />
           )}
           <s.SortHolder>
-            <SortButton className={isShowVideosOnly && "selected"} onClick={handleVideoOnlyClick}>
+            <SortButton
+              className={isShowVideosOnly && "selected"}
+              style={{ visibility: !areVideosAvailable && "hidden" }}
+              onClick={handleVideoOnlyClick}
+            >
               Show videos only
             </SortButton>
             <SortingButtons

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -213,7 +213,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <SortingButtons
               articleList={articlesAndVideosList}
               setArticleList={setArticlesAndVideosList}
-              clearStateOnUpdate={isShowVideosOnlyEnabled}
+              clearStateTrigger={isShowVideosOnlyEnabled}
             />
           </s.SortHolder>
         </>

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -44,6 +44,8 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
   // Next three vars required for the "Show Videos Only" toggle button
   const [areVideosAvailable, setAreVideosAvailable] = useState(false);
   const [isShowVideosOnlyEnabled, setIsShowVideosOnlyEnabled] = useState(false);
+  // Ref is needed since it's called in the updateOnPagination function. This function
+  // could have stale values if using the state constant.
   const isShowVideosOnlyEnabledRef = useShadowRef(isShowVideosOnlyEnabled);
 
   function getNewArticlesForPage(pageNumber, handleArticleInsertion) {
@@ -211,7 +213,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <SortingButtons
               articleList={articlesAndVideosList}
               setArticleList={setArticlesAndVideosList}
-              isShowVideoOnly={isShowVideosOnlyEnabled}
+              resetTempListOnChange={isShowVideosOnlyEnabled}
             />
           </s.SortHolder>
         </>

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -17,7 +17,6 @@ import strings from "../i18n/definitions";
 import useShadowRef from "../hooks/useShadowRef";
 import { Link } from "react-router-dom";
 import VideoPreview from "../videos/VideoPreview";
-import { SortButton } from "./SortingButtons.sc";
 
 export default function FindArticles({ content, searchQuery, searchPublishPriority, searchDifficultyPriority }) {
   let api = useContext(APIContext);
@@ -202,13 +201,13 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <UnfinishedArticlesList articleList={articlesAndVideosList} setArticleList={setArticlesAndVideosList} />
           )}
           <s.SortHolder>
-            <SortButton
+            <s.ShowVideoOnlyButton
               className={isShowVideosOnlyEnabled && "selected"}
               style={{ visibility: !areVideosAvailable && "hidden" }}
               onClick={handleVideoOnlyClick}
             >
               Show videos only
-            </SortButton>
+            </s.ShowVideoOnlyButton>
             <SortingButtons
               articleList={articlesAndVideosList}
               setArticleList={setArticlesAndVideosList}

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -213,7 +213,7 @@ export default function FindArticles({ content, searchQuery, searchPublishPriori
             <SortingButtons
               articleList={articlesAndVideosList}
               setArticleList={setArticlesAndVideosList}
-              resetTempListOnChange={isShowVideosOnlyEnabled}
+              clearStateOnUpdate={isShowVideosOnlyEnabled}
             />
           </s.SortHolder>
         </>

--- a/src/articles/FindArticles.sc.js
+++ b/src/articles/FindArticles.sc.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { SortButton } from "./SortingButtons.sc";
 
 const MaterialSelection = styled.div`
   display: flex;
@@ -20,4 +21,15 @@ const SearchHolder = styled.div`
   display: block;
 `;
 
-export { MaterialSelection, SortHolder, SearchHolder };
+const ShowVideoOnlyButton = styled(SortButton)`
+  &.selected {
+    background-color: grey;
+    color: white !important;
+    font-weight: 600;
+    &:hover {
+      filter: brightness(1.02);
+    }
+  }
+`;
+
+export { MaterialSelection, SortHolder, SearchHolder, ShowVideoOnlyButton };

--- a/src/articles/FindArticles.sc.js
+++ b/src/articles/FindArticles.sc.js
@@ -12,8 +12,8 @@ const MaterialSelection = styled.div`
 const SortHolder = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
-  margin-bottom: -3em;
+  justify-content: space-between;
+  margin-bottom: 3em;
 `;
 
 const SearchHolder = styled.div`

--- a/src/articles/SortingButtons.js
+++ b/src/articles/SortingButtons.js
@@ -18,6 +18,11 @@ export default function SortingButtons({ articleList, setArticleList, isShowVide
     setTemporaryList([]);
   }, [isShowVideoOnly]);
 
+  useEffect(() => {
+    // In case the user scrolls and gets more articles without resetting the filter.
+    if (articleList.length > temporaryList.length && temporaryList.length !== 0) setTemporaryList([]);
+  }, [articleList]);
+
   function getReadingCompletion(article) {
     // If the article wasn't open give a negative value so they are first in the list.
     let openAdjustment = article.opened ? 0 : 0.1;

--- a/src/articles/SortingButtons.js
+++ b/src/articles/SortingButtons.js
@@ -3,7 +3,7 @@ import { useLocation } from "react-router";
 import strings from "../i18n/definitions";
 import * as s from "./SortingButtons.sc";
 
-export default function SortingButtons({ articleList, setArticleList, clearStateOnUpdate }) {
+export default function SortingButtons({ articleList, setArticleList, clearStateTrigger }) {
   const [difficultySortState, setDifficultySortState] = useState("");
   const [wordCountSortState, setWordCountSortState] = useState("");
   const [progressSortState, setProgressSortState] = useState("");
@@ -16,7 +16,7 @@ export default function SortingButtons({ articleList, setArticleList, clearState
     setWordCountSortState("");
     setProgressSortState("");
     setTemporaryList([]);
-  }, [clearStateOnUpdate]);
+  }, [clearStateTrigger]);
 
   useEffect(() => {
     // In case the user scrolls and gets more articles without resetting the filter.

--- a/src/articles/SortingButtons.js
+++ b/src/articles/SortingButtons.js
@@ -3,7 +3,7 @@ import { useLocation } from "react-router";
 import strings from "../i18n/definitions";
 import * as s from "./SortingButtons.sc";
 
-export default function SortingButtons({ articleList, setArticleList, resetTempListOnChange }) {
+export default function SortingButtons({ articleList, setArticleList, clearStateOnUpdate }) {
   const [difficultySortState, setDifficultySortState] = useState("");
   const [wordCountSortState, setWordCountSortState] = useState("");
   const [progressSortState, setProgressSortState] = useState("");
@@ -16,7 +16,7 @@ export default function SortingButtons({ articleList, setArticleList, resetTempL
     setWordCountSortState("");
     setProgressSortState("");
     setTemporaryList([]);
-  }, [resetTempListOnChange]);
+  }, [clearStateOnUpdate]);
 
   useEffect(() => {
     // In case the user scrolls and gets more articles without resetting the filter.

--- a/src/articles/SortingButtons.js
+++ b/src/articles/SortingButtons.js
@@ -3,7 +3,7 @@ import { useLocation } from "react-router";
 import strings from "../i18n/definitions";
 import * as s from "./SortingButtons.sc";
 
-export default function SortingButtons({ articleList, setArticleList, isShowVideoOnly }) {
+export default function SortingButtons({ articleList, setArticleList, resetTempListOnChange }) {
   const [difficultySortState, setDifficultySortState] = useState("");
   const [wordCountSortState, setWordCountSortState] = useState("");
   const [progressSortState, setProgressSortState] = useState("");
@@ -16,7 +16,7 @@ export default function SortingButtons({ articleList, setArticleList, isShowVide
     setWordCountSortState("");
     setProgressSortState("");
     setTemporaryList([]);
-  }, [isShowVideoOnly]);
+  }, [resetTempListOnChange]);
 
   useEffect(() => {
     // In case the user scrolls and gets more articles without resetting the filter.

--- a/src/articles/SortingButtons.sc.js
+++ b/src/articles/SortingButtons.sc.js
@@ -3,8 +3,6 @@ import * as b from "../components/allButtons.sc";
 import { almostBlack, veryLightGrey } from "../components/colors";
 
 const SortingButtons = styled.div`
-  margin-bottom: 1em;
-  margin-left: 1em;
   display: flex;
   justify-content: flex-end;
   font-size: medium;
@@ -26,18 +24,27 @@ const SortingButtons = styled.div`
   .ascending::after {
     content: "↓";
   }
-
-  @media (min-width: 768px) {
-    margin-bottom: 3em;
-  }
 `;
 
 const SortButton = styled(b.RoundButton)`
   padding: 0.3rem 0.5rem;
-
+  cursor: pointer;
   font-size: small;
   background-color: ${veryLightGrey};
   color: ${almostBlack} !important;
+
+  &:hover {
+    filter: brightness(0.98);
+  }
+
+  &.selected {
+    background-color: grey;
+    color: white !important;
+    font-weight: 600;
+    &:hover {
+      filter: brightness(1.02);
+    }
+  }
 
   ${(props) =>
     props.isOnTeacherSite &&

--- a/src/articles/SortingButtons.sc.js
+++ b/src/articles/SortingButtons.sc.js
@@ -37,15 +37,6 @@ const SortButton = styled(b.RoundButton)`
     filter: brightness(0.98);
   }
 
-  &.selected {
-    background-color: grey;
-    color: white !important;
-    font-weight: 600;
-    &:hover {
-      filter: brightness(1.02);
-    }
-  }
-
   ${(props) =>
     props.isOnTeacherSite &&
     css`


### PR DESCRIPTION
- Added a button which provides the functionality for the user to only see videos.
- Fixed some of the functionality of the sorting mechanism by storing a temporaryList when the user first sorts rather than using the originalList at the FindArticles component.
- Added a small hover effect to the buttons

The current logic handles everything in the frontend, without requiring a new endpoint, but it's a bit wasteful since we are getting 20 articles each page. I am thinking about changing the recommendations to be 10 articles and 5 videos , in general it's good to reduce the total articles pulled each time.

@silashoeyer Was it something like this?

https://github.com/user-attachments/assets/7e0961b5-bac3-42c2-a8f1-b2da1afb5ddd

