### PR TITLE
when working with user_words it makes no sense to "delete" one. I

### DIFF
--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -126,7 +126,6 @@ export default function WordEditForm({ bookmark, errorMessage, handleClose, upda
 
         {isNotEdited ? (
           <s.DoneButtonHolder>
-            <st.FeedbackDelete type="button" onClick={() => deleteAction(bookmark)} value={strings.deleteWord} />
             <st.FeedbackSubmit type="submit" value={strings.done} style={{ marginLeft: "1em", marginTop: "1em" }} />
           </s.DoneButtonHolder>
         ) : (


### PR DESCRIPTION
Instead, in the edit box one can simply chose to not include it in exercises if they don't want to.