### PR TITLE
added props back for new icons

### DIFF
--- a/src/components/MainNav/NavIcon.js
+++ b/src/components/MainNav/NavIcon.js
@@ -29,9 +29,9 @@ const iconProps = {
 
   const navIcons = {
     home: <HomeRoundedIcon />,
-    exercises: <FitnessCenterRoundedIcon />,
+    exercises: <FitnessCenterRoundedIcon {...iconProps} />,
     dailyAudio: <HeadphonesRoundedIcon />,
-    words: <TranslateRoundedIcon />,
+    words: <TranslateRoundedIcon {...iconProps} />,
     history: <HistoryRoundedIcon />,
     statistics: <DonutSmallRoundedIcon />,
     settings: <SettingsRoundedIcon />,

--- a/src/words/WordsTooltip.js
+++ b/src/words/WordsTooltip.js
@@ -14,9 +14,10 @@ export default function WordsToolTip({open, setOpen, value, isOnCongratulationsP
             title={
                 <span>
                   {
-                    value.level === 4 && value.is_about_to_be_learned === true
+                   isOnCongratulationsPage ? (
+                     value.level === 4 && value.is_about_to_be_learned === true
                       ? "Congratulations! You have learned this word. You won't practice this word anymore"
-                      : isOnCongratulationsPage ? (
+                      : 
             <>
               You need to get this word correct{" "}
               {value.cooling_interval === 0


### PR DESCRIPTION
I cannot recreate the issue you experienced with the congratulations hover message? All my words on level 4 has the correct hover message on the words page. 

But I found some other issues with the icons we are using so here is an update.