### PR TITLE
Fix RangeError when time_last_read is missing

### DIFF
--- a/src/articles/UnfinishedArticlePreview.js
+++ b/src/articles/UnfinishedArticlePreview.js
@@ -31,9 +31,11 @@ export default function UnfinishedArticlePreview({ article, onArticleClick }) {
           last_reading_percentage={article.last_reading_percentage}
         ></ReadingCompletionProgress>
       </s.UnfinishedArticleContainer>
-      <s.UnfinishedArticleStats>
-        ({formatDistanceToNow(new Date(article.time_last_read), { addSuffix: true })})
-      </s.UnfinishedArticleStats>
+      {article.time_last_read && (
+        <s.UnfinishedArticleStats>
+          ({formatDistanceToNow(new Date(article.time_last_read), { addSuffix: true })})
+        </s.UnfinishedArticleStats>
+      )}
     </s.ArticlePreview>
   );
 }


### PR DESCRIPTION
## Summary
- Add guard to prevent `RangeError: Invalid time value` when `article.time_last_read` is null/undefined
- The timestamp display is now conditional on the field being present

## Root Cause
The `UnfinishedArticlePreview` component was calling `new Date(article.time_last_read)` without validation. When the field is missing, `new Date(undefined)` produces an `Invalid Date` object, causing date-fns to throw.

## Test plan
- [x] Verify unfinished articles still display timestamps when `time_last_read` is present
- [ ] Verify no crash when an article somehow lacks `time_last_read`

Fixes Sentry issue 7094737727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)