### PR TITLE
Fix Safari "Load failed" error using sendBeacon API

### DIFF
--- a/src/api/activityLogging.js
+++ b/src/api/activityLogging.js
@@ -96,14 +96,8 @@ Zeeguu_API.prototype.logUserActivity = function (event, article_id = "", value =
 
   console.log(`${hours}:${minutes}:${seconds} -- ` + event);
 
-  return this._post(
-    `upload_user_activity_data`,
-    qs.stringify(event_information),
-    () => {},
-    (error) => {
-      console.log(error);
-    },
-  );
+  // Use beacon to prevent "Load failed" errors when user navigates away
+  this._postBeacon(`upload_user_activity_data`, qs.stringify(event_information));
 };
 
 Zeeguu_API.prototype.daysSinceLastUse = function (callback) {

--- a/src/api/classDef.js
+++ b/src/api/classDef.js
@@ -97,6 +97,27 @@ const Zeeguu_API = class {
     }
   }
 
+  /**
+   * Fire-and-forget POST using sendBeacon API.
+   * Use this for analytics/session updates that should survive page navigation.
+   * Safari aggressively cancels fetch requests on navigation, causing "Load failed" errors.
+   * sendBeacon is designed for this use case and won't be cancelled.
+   */
+  _postBeacon(endpoint, body) {
+    const url = this._appendSessionToUrl(endpoint);
+    const blob = new Blob([body], { type: "application/x-www-form-urlencoded" });
+    const success = navigator.sendBeacon(url, blob);
+    if (!success) {
+      // Fallback to fetch if sendBeacon fails (e.g., payload too large)
+      // Use catch to prevent unhandled rejection on navigation
+      fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body,
+      }).catch(() => {});
+    }
+  }
+
   //migrated from old teacher zeeguu dashboard
   async apiPost(endpoint, data, isForm) {
     const params = { session: this.session };

--- a/src/api/reading_sessions.js
+++ b/src/api/reading_sessions.js
@@ -25,7 +25,8 @@ Zeeguu_API.prototype.readingSessionUpdate = function (
     duration: currentDuration * 1000, //the API expects ms
   };
 
-  this._post(`reading_session_update`, qs.stringify(payload));
+  // Use beacon to prevent "Load failed" errors when user navigates away
+  this._postBeacon(`reading_session_update`, qs.stringify(payload));
 };
 
 Zeeguu_API.prototype.readingSessionEnd = function (
@@ -37,5 +38,6 @@ Zeeguu_API.prototype.readingSessionEnd = function (
     duration: totalTime * 1000,
   };
 
-  this._post(`reading_session_start`, qs.stringify(payload));
+  // Use beacon to prevent "Load failed" errors when user navigates away
+  this._postBeacon(`reading_session_start`, qs.stringify(payload));
 };


### PR DESCRIPTION
## Summary

- Fixes Safari "TypeError: Load failed" errors that occur when users navigate away from pages while API requests are in-flight
- Uses `navigator.sendBeacon()` for fire-and-forget analytics and session update requests
- Safari aggressively cancels fetch requests on navigation, but sendBeacon is designed to survive page unload

## Changes

- Add `_postBeacon()` method to `Zeeguu_API` class with fetch fallback for large payloads
- Use beacon for `readingSessionUpdate` and `readingSessionEnd`
- Use beacon for `logUserActivity`

## Test plan

- [ ] Navigate away from article page while reading - should not produce Sentry errors
- [ ] Verify activity logging still works (check server logs)
- [ ] Verify reading session duration is still tracked correctly

Fixes Sentry issue #5934354603

🤖 Generated with [Claude Code](https://claude.com/claude-code)