### PR TITLE
Add smart hide/show header on scroll

### DIFF
--- a/src/components/MainNav/BottomNav/BottomNav.js
+++ b/src/components/MainNav/BottomNav/BottomNav.js
@@ -10,13 +10,11 @@ import BottomNavOptionsForTeacher from "./BottomNavOptionsForTeacher";
 import BottomNavOption from "./BottomNavOption";
 import { fadeIn, fadeOut } from "../../transitions";
 import { slideIn, slideOut } from "../../transitions";
-import useScrollDirection from "../../../hooks/useScrollDirection";
 import * as s from "./BottomNav.sc";
 
 export default function BottomNav() {
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
-  const scrollDirection = useScrollDirection();
 
   const path = useLocation().pathname;
 
@@ -65,7 +63,6 @@ export default function BottomNav() {
         <s.BottomNav
           aria-label="Bottom Navigation"
           $bottomNavTransition={bottomNavTransition}
-          $hidden={scrollDirection === "down"}
         >
           <s.NavList>
             {isOnStudentSide && <BottomNavOptionsForStudent />}

--- a/src/components/MainNav/BottomNav/BottomNav.sc.js
+++ b/src/components/MainNav/BottomNav/BottomNav.sc.js
@@ -9,9 +9,8 @@ const BottomNav = styled.nav`
   padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
   background-color: ${({ theme }) => theme.navBg};
   z-index: 2;
-  transition: transform 0.3s ease-in-out;
+  transition: 0.3s ease-in-out;
   animation: ${({ $bottomNavTransition }) => $bottomNavTransition} 0.3s ease-in-out forwards;
-  transform: ${({ $hidden }) => ($hidden ? "translateY(100%)" : "translateY(0)")};
 `;
 
 const NavList = styled.ul`

--- a/src/hooks/useScrollDirection.js
+++ b/src/hooks/useScrollDirection.js
@@ -15,10 +15,13 @@ export default function useScrollDirection({ threshold = 10, topOffset = 100 } =
   const ticking = useRef(false);
 
   useEffect(() => {
-    const scrollHolder = document.getElementById("scrollHolder");
-    if (!scrollHolder) return;
-
     const updateScrollDirection = () => {
+      const scrollHolder = document.getElementById("scrollHolder");
+      if (!scrollHolder) {
+        ticking.current = false;
+        return;
+      }
+
       const scrollY = scrollHolder.scrollTop;
 
       // Always show header when near the top
@@ -47,10 +50,11 @@ export default function useScrollDirection({ threshold = 10, topOffset = 100 } =
       }
     };
 
-    scrollHolder.addEventListener("scroll", handleScroll, { passive: true });
+    // Listen on window with capture to catch scroll events from scrollHolder
+    window.addEventListener("scroll", handleScroll, true);
 
     return () => {
-      scrollHolder.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("scroll", handleScroll, true);
     };
   }, [threshold, topOffset]);
 


### PR DESCRIPTION
## Summary
- Header hides when scrolling down, reappears when scrolling up
- Maximizes reading area while keeping navigation accessible
- Adds `useScrollDirection` hook for scroll direction detection

## Implementation
- `useScrollDirection` hook uses `requestAnimationFrame` for smooth performance
- 10px threshold prevents jitter from small scroll movements
- Header always visible when near top of page (< 100px)
- Smooth 0.3s CSS transition animation

## Test plan
- [ ] Scroll down on article list - header should slide up and hide
- [ ] Scroll up - header should slide back down
- [ ] Scroll to top - header should always be visible
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)