### PR TITLE
Mark words as learned when user selects 'I learned it already'

### DIFF
--- a/src/api/userWords.js
+++ b/src/api/userWords.js
@@ -130,8 +130,8 @@ Zeeguu_API.prototype.userSetForExercises = function (bookmark_id) {
   this._post(`use_in_exercises/${bookmark_id}`);
 };
 
-Zeeguu_API.prototype.userSetNotForExercises = function (bookmark_id) {
-  this._post(`dont_use_in_exercises/${bookmark_id}`);
+Zeeguu_API.prototype.userSetNotForExercises = function (bookmark_id, reason = "") {
+  this._post(`dont_use_in_exercises/${bookmark_id}`, { reason });
 };
 
 Zeeguu_API.prototype.prioritizeBookmarksToStudy = function (

--- a/src/words/WordEditForm.js
+++ b/src/words/WordEditForm.js
@@ -36,8 +36,8 @@ export default function WordEditForm({
       `WORD_EDIT_FORM_REMOVE: ${reason}`
     );
     
-    // Remove word from exercises
-    api.userSetNotForExercises(bookmarkId);
+    // Remove from exercises (pass reason so backend can mark as learned if appropriate)
+    api.userSetNotForExercises(bookmarkId, reason);
     
     // Update local state
     bookmark.fit_for_study = false;
@@ -165,7 +165,7 @@ export default function WordEditForm({
         <s.DoneButtonHolder>
           {bookmark.from.split(" ").length < MAX_WORDS_IN_BOOKMARK_FOR_EXERCISES && (
             <StyledGreyButton type="button" onClick={() => setShowExcludeModal(true)} style={{ marginTop: "1em" }}>
-              Remove word from exercises
+              Remove from exercises
             </StyledGreyButton>
           )}
           {isNotEdited ? (


### PR DESCRIPTION
## Summary
- When user removes a word from exercises with reason "I learned it already", the word is now marked as learned (sets `learned_time`)
- Updated button text from "Remove word from exercises" to "Remove from exercises"
- Passes the removal reason to the backend API

## Requires
- Corresponding API change: zeeguu/api PR (to be created)

## Test plan
- [ ] Remove a word using "I learned it already" option
- [ ] Verify the word appears in the Learned tab
- [ ] Remove a word using other reasons (too easy, bad translation)
- [ ] Verify those words do NOT appear in Learned tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)