### PR TITLE
Fix iOS session persistence and add TestFlight automation

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -10,6 +10,10 @@ const config: CapacitorConfig = {
     // This helps with CORS issues in the WebView
     androidScheme: 'https'
   },
+  ios: {
+    // Enable Web Inspector for debugging (even in release builds)
+    webContentsDebuggingEnabled: true
+  },
   plugins: {
     SplashScreen: {
       launchShowDuration: 2000,  // Show for 2 seconds

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,6 +11,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+  pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
 end
 

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -2,12 +2,15 @@ PODS:
   - Capacitor (7.4.4):
     - CapacitorCordova
   - CapacitorCordova (7.4.4)
+  - CapacitorPreferences (7.0.3):
+    - Capacitor
   - CapacitorSplashScreen (7.0.3):
     - Capacitor
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
 
 EXTERNAL SOURCES:
@@ -15,14 +18,17 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
+  CapacitorPreferences:
+    :path: "../../node_modules/@capacitor/preferences"
   CapacitorSplashScreen:
     :path: "../../node_modules/@capacitor/splash-screen"
 
 SPEC CHECKSUMS:
   Capacitor: 358dd1c3fdd71d969547b17e159fd8a7736cb45f
   CapacitorCordova: bf648a636f3c153f652d312ae145fb508b6ffced
+  CapacitorPreferences: 913eef88272c13eb6445b21e51fe8ef6635412cc
   CapacitorSplashScreen: e388b8e0ed0e982a9d3a40417f478e7a018a8763
 
-PODFILE CHECKSUM: defae69d045aabbbb2d1c81b9ed5ce5a3409e308
+PODFILE CHECKSUM: 377da153d9060469198b1e5350b4c89236747a36
 
 COCOAPODS: 1.16.2

--- a/ios/App/fastlane/Appfile
+++ b/ios/App/fastlane/Appfile
@@ -1,0 +1,11 @@
+# App identifier from your Xcode project
+app_identifier("org.zeeguu.app")
+
+# Your Apple ID email (set FASTLANE_USER environment variable)
+apple_id(ENV["FASTLANE_USER"])
+
+# Team ID (from Apple Developer account)
+team_id("1928065")
+
+# App Store Connect Team ID
+itc_team_id("1928065")

--- a/ios/App/fastlane/Fastfile
+++ b/ios/App/fastlane/Fastfile
@@ -1,0 +1,66 @@
+default_platform(:ios)
+
+platform :ios do
+
+  desc "Build and upload to TestFlight"
+  lane :beta do |options|
+    # Increment build number automatically
+    increment_build_number(
+      xcodeproj: "App.xcodeproj"
+    )
+
+    # Build the app
+    build_app(
+      workspace: "App.xcworkspace",
+      scheme: "App",
+      export_method: "app-store",
+      clean: true
+    )
+
+    # Upload to TestFlight and distribute to external testers
+    # (Internal testers automatically see all builds)
+    upload_to_testflight(
+      skip_waiting_for_build_processing: false,
+      distribute_external: true,
+      groups: ["beta-testers"],
+      changelog: options[:notes] || "Bug fixes and improvements"
+    )
+  end
+
+  desc "Build and upload to App Store (for review)"
+  lane :release do |options|
+    # Increment build number
+    increment_build_number(
+      xcodeproj: "App.xcodeproj"
+    )
+
+    # Build the app
+    build_app(
+      workspace: "App.xcworkspace",
+      scheme: "App",
+      export_method: "app-store",
+      clean: true
+    )
+
+    # Upload to App Store Connect
+    upload_to_app_store(
+      skip_metadata: true,
+      skip_screenshots: true,
+      submit_for_review: false,
+      release_notes: {
+        "default" => options[:notes] || "Bug fixes and improvements"
+      }
+    )
+  end
+
+  desc "Just build the app (no upload)"
+  lane :build do
+    build_app(
+      workspace: "App.xcworkspace",
+      scheme: "App",
+      export_method: "app-store",
+      clean: true
+    )
+  end
+
+end

--- a/ios/App/fastlane/README.md
+++ b/ios/App/fastlane/README.md
@@ -1,0 +1,48 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
+```
+
+Build and upload to TestFlight
+
+### ios release
+
+```sh
+[bundle exec] fastlane ios release
+```
+
+Build and upload to App Store (for review)
+
+### ios build
+
+```sh
+[bundle exec] fastlane ios build
+```
+
+Just build the app (no upload)
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,64 @@
+# iOS Deployment
+
+## Quick Reference
+
+```bash
+# Check current version
+npm run ios:version
+
+# Build and open Xcode (for manual archive)
+npm run ios:open
+
+# Build and deploy to TestFlight (automatic)
+npm run ios:beta
+
+# With custom release notes
+npm run ios:beta -- notes:"Fixed login persistence"
+
+# Bump version and deploy
+npm run ios:bump -- 1.0.3 && npm run ios:beta
+
+# Deploy to App Store (for review)
+npm run ios:release
+```
+
+## Scripts Explained
+
+| Script | What it does |
+|--------|--------------|
+| `ios:version` | Shows current marketing version and build number |
+| `ios:build` | Builds web app + syncs to iOS project |
+| `ios:open` | Builds + opens Xcode (for manual archive) |
+| `ios:bump -- X.Y.Z` | Sets marketing version (e.g., 1.0.3) |
+| `ios:beta` | Builds + uploads to TestFlight + distributes to testers |
+| `ios:release` | Builds + uploads to App Store Connect |
+
+## Version Numbers
+
+- **Marketing version** (1.0.3): What users see in App Store. Bump manually for releases.
+- **Build number** (7): Auto-incremented by fastlane on each upload.
+
+## First-Time Setup
+
+1. Install fastlane: `brew install fastlane`
+2. Create App-Specific Password at https://appleid.apple.com
+3. Add to `~/.zshrc`:
+   ```bash
+   export FASTLANE_USER="your-apple-id@example.com"
+   export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+   ```
+
+## Typical Release Flow
+
+```bash
+# 1. Bump version for new release
+npm run ios:bump -- 1.1.0
+
+# 2. Build and deploy to TestFlight
+npm run ios:beta -- notes:"New feature: audio lessons"
+
+# 3. Test on device via TestFlight app
+
+# 4. When ready, submit to App Store
+npm run ios:release
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
         "@capacitor/ios": "^7.4.3",
+        "@capacitor/preferences": "^7.0.3",
         "@capacitor/splash-screen": "^7.0.3",
         "@emotion/react": "^11.4.1",
         "@emotion/styled": "^11.3.0",
@@ -1921,6 +1922,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^7.4.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-7.0.3.tgz",
+      "integrity": "sha512-s8u2PCnxCj6auvZZaFb//KJSyvgwwtKu6aFA7PQ1FQULhZw+3zCb78biyWcl71KF0iBuC2jYlj4PjTeaF5OIGQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/splash-screen": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
     "@capacitor/ios": "^7.4.3",
+    "@capacitor/preferences": "^7.0.3",
     "@capacitor/splash-screen": "^7.0.3",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
@@ -100,7 +101,13 @@
     "ext:publish:firefox": "npm run ext:buildZipFirefox && node src/extension/scripts/publish-firefox.js",
     "ext:publish": "npm run ext:publish:chrome && npm run ext:publish:firefox",
     "ext:zipSources": "cd src/extension && zip -FSr zeeguu-reader-source-code.zip . -x 'build/*' 'node_modules/*' 'src/zeeguu-react/node_modules/*' 'src/zeeguu-react/build/*' '.git/*' build.zip '.idea/*'",
-    "prebuild": "BROWSERSLIST_IGNORE_OLD_DATA=1 node scripts/update-service-worker-version.js"
+    "prebuild": "BROWSERSLIST_IGNORE_OLD_DATA=1 node scripts/update-service-worker-version.js",
+    "ios:build": "npm run build && npx cap sync ios",
+    "ios:open": "npm run ios:build && npx cap open ios",
+    "ios:version": "grep MARKETING_VERSION ios/App/App.xcodeproj/project.pbxproj | head -1 && cd ios/App && agvtool what-version",
+    "ios:bump": "cd ios/App && agvtool new-marketing-version",
+    "ios:beta": "npm run ios:build && cd ios/App && fastlane beta",
+    "ios:release": "npm run ios:build && cd ios/App && fastlane release"
   },
   "browserslist": {
     "production": [

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -19,6 +19,9 @@ import ReadingHistory from "./words/WordHistory";
 import ActivityRouter from "./activity/_ActivityRouter";
 import ArticleReader from "./reader/ArticleReader";
 import LoadingAnimation from "./components/LoadingAnimation";
+import { getSharedSession } from "./utils/cookies/userInfo";
+import LocalStorage from "./assorted/LocalStorage";
+import { Capacitor } from "@capacitor/core";
 
 // Lazy load separate parts of the app
 const LazyTeacherRouter = lazy(() => import("./teacher/_routing/_TeacherRouter"));
@@ -41,18 +44,29 @@ import IndividualExercise from "./pages/IndividualExercise";
 import Swiper from "./swiper/Swiper";
 import KeyboardTest from "./pages/KeyboardTest";
 
-// Helper to detect if we're in a Capacitor app
+// Helper to detect if we're in a Capacitor native app
 const isCapacitor = () => {
-  return window.location.protocol === "capacitor:" || window.location.protocol === "ionic:";
+  const platform = Capacitor.getPlatform();
+  return platform === 'ios' || platform === 'android';
 };
 
 // Component to handle mobile app homepage redirect
 function HomePage() {
-  // If running in Capacitor (mobile app), redirect to language preferences
-  // Otherwise show the full landing page
+  // Check if user is logged in first
+  const session = getSharedSession();
+  if (session) {
+    // User is logged in - redirect to articles (or last visited page)
+    const lastVisitedPage = LocalStorage.getLastVisitedPage();
+    const redirectTo = lastVisitedPage || "/articles";
+    return <Redirect to={redirectTo} />;
+  }
+
+  // Not logged in - show appropriate page
   if (isCapacitor()) {
+    // Mobile app: go to language preferences (start of registration)
     return <Redirect to="/language_preferences" />;
   }
+  // Web: show full landing page
   return <LandingPage />;
 }
 


### PR DESCRIPTION
## Summary
- Fix iOS app losing login state when killed and restarted by using `@capacitor/preferences` for persistent native storage instead of localStorage
- Fix `isCapacitor()` detection to use `Capacitor.getPlatform()` instead of broken `window.location.protocol` check  
- Fix `HomePage` routing to check session BEFORE redirecting - previously sent all Capacitor users to create account page regardless of login status
- Add npm scripts and fastlane for automated TestFlight deployment

## Changes
- **`src/utils/cookies/userInfo.js`**: Switch from localStorage to Capacitor Preferences plugin for native iOS/Android storage with async initialization and caching
- **`src/App.js`**: Add `initializeSession()` call before rendering to load session from native storage
- **`src/MainAppRouter.js`**: Fix `HomePage` to check if user is logged in before deciding where to redirect
- **`capacitor.config.ts`**: Enable WebView debugging for iOS
- **`package.json`**: Add iOS deployment scripts (ios:build, ios:open, ios:version, ios:bump, ios:beta, ios:release)
- **`ios/App/fastlane/`**: Add Fastfile and Appfile for TestFlight automation

## Test plan
- [ ] Build and deploy to TestFlight with `npm run ios:beta`
- [ ] Log in on iOS app
- [ ] Kill app completely (swipe up from app switcher)
- [ ] Reopen app - should go directly to articles, not create account page
- [ ] Web app should still work normally with cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)