### PR TITLE
Improve iOS mobile UX and simplify exercise screens

### DIFF
--- a/src/MainNavWithComponent.sc.js
+++ b/src/MainNavWithComponent.sc.js
@@ -20,6 +20,7 @@ const AppContent = styled.section`
   transition: 0.3s ease-in-out;
   padding: 0 0.2rem 0 0.2rem;
   overflow-x: hidden;
+  overflow-y: auto;
   top: 0;
 
   margin-left: ${({ $screenWidth }) => {

--- a/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
+++ b/src/components/MainNav/BottomNav/BottomNavOptionsForStudent.js
@@ -2,7 +2,6 @@ import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import NotificationIcon from "../../NotificationIcon";
 import BottomNavOption from "./BottomNavOption";
 import NavigationOptions from "../navigationOptions";
-import BottomNavLanguageOption from "./BottomNavLanguageOption";
 import { useContext } from "react";
 import { ExercisesCounterContext } from "../../../exercises/ExercisesCounterContext";
 
@@ -24,7 +23,6 @@ export default function BottomNavOptionsForStudent() {
       />
       {Feature.is_enabled("daily_audio") && <BottomNavOption {...NavigationOptions.dailyAudio} currentPath={path} />}
       <BottomNavOption {...NavigationOptions.words} currentPath={path} />
-      <BottomNavLanguageOption />
     </>
   );
 }

--- a/src/components/MainNav/BottomNav/MoreOptionsPanel.js
+++ b/src/components/MainNav/BottomNav/MoreOptionsPanel.js
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useState, useMemo } from "react";
 import { UserContext } from "../../../contexts/UserContext";
 import { MainNavContext } from "../../../contexts/MainNavContext";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
@@ -6,6 +6,9 @@ import NavigationOptions from "../navigationOptions";
 import FeedbackButton from "../../FeedbackButton";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import NavOption from "../NavOption";
+import NavIcon from "../NavIcon";
+import LanguageModal from "../LanguageModal";
+import navLanguages from "../navLanguages";
 import * as s from "./MoreOptionsPanel.sc";
 
 export default function MoreOptionsPanel({
@@ -16,10 +19,17 @@ export default function MoreOptionsPanel({
   renderMoreOptions,
 }) {
   const { userDetails } = useContext(UserContext);
+  const [showLanguageModal, setShowLanguageModal] = useState(false);
 
   const { mainNavProperties } = useContext(MainNavContext);
   const { isOnStudentSide } = mainNavProperties;
   const path = useLocation().pathname;
+
+  const currentLearnedLanguage = useMemo(() => {
+    const languageCode = userDetails.learned_language;
+    const languageName = navLanguages[languageCode];
+    return languageName || "Language";
+  }, [userDetails.learned_language]);
 
   return (
     <s.MoreOptionsWrapper
@@ -71,6 +81,15 @@ export default function MoreOptionsPanel({
             />
           )}
 
+          {isOnStudentSide && (
+            <NavOption
+              icon={<NavIcon name="language" />}
+              text={currentLearnedLanguage}
+              ariaLabel={`Change language (currently: ${currentLearnedLanguage})`}
+              onClick={() => setShowLanguageModal(true)}
+            />
+          )}
+
           <NavOption
             {...NavigationOptions.settings}
             currentPath={path}
@@ -80,6 +99,12 @@ export default function MoreOptionsPanel({
           <FeedbackButton />
         </s.MoreOptionsList>
       </s.MoreOptionsPanel>
+
+      <LanguageModal
+        prefixMsg={"MoreOptions"}
+        open={showLanguageModal}
+        setOpen={() => setShowLanguageModal(!showLanguageModal)}
+      />
     </s.MoreOptionsWrapper>
   );
 }

--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -10,8 +10,6 @@ import { LoadingAnimation } from "../components/LoadingAnimation.sc";
 import { timeToHumanReadable, formatFutureDueTime } from "../utils/misc/readableTime";
 import CollapsablePanel from "../components/CollapsablePanel";
 import Pluralize from "../utils/text/pluralize";
-import BackArrow from "../pages/Settings/settings_pages_shared/BackArrow";
-import useScreenWidth from "../hooks/useScreenWidth";
 import { StyledButton } from "../components/allButtons.sc";
 import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
@@ -64,7 +62,6 @@ export default function Congratulations({
   const [username, setUsername] = useState();
   const [nextWordDueText, setNextWordDueText] = useState(null);
 
-  const { isMobile } = useScreenWidth();
   const { isAnonymous, checkUpgradeTrigger } = useAnonymousUpgrade();
 
   function deleteBookmark(bookmark) {
@@ -128,10 +125,9 @@ export default function Congratulations({
   return (
     <>
       <s.NarrowColumn className="narrowColumn">
-        {isMobile && <BackArrow func={backButtonAction} />}
         <CenteredColumn className="centeredColumn">
           <h1>
-            {strings.goodJob} {username}!
+            {strings.goodJob}{isAnonymous ? "" : ` ${username}`}!
           </h1>
         </CenteredColumn>
          <CenteredColumn className="centeredColumn">

--- a/src/exercises/OutOfWordsMessage.js
+++ b/src/exercises/OutOfWordsMessage.js
@@ -1,67 +1,19 @@
 import * as s from "./exerciseTypes/Exercise.sc";
-import Pluralize from "../utils/text/pluralize";
-import useScreenWidth from "../hooks/useScreenWidth";
-import BackArrow from "../pages/Settings/settings_pages_shared/BackArrow";
-import { Link } from "react-router-dom";
-import { useContext, useEffect, useState } from "react";
-import { APIContext } from "../contexts/APIContext";
-import { formatFutureDueTime } from "../utils/misc/readableTime";
 
 export default function OutOfWordsMessage({ goBackAction }) {
-  const { isMobile } = useScreenWidth();
-  const api = useContext(APIContext);
-
-  const [totalInLearning, setTotalInLearning] = useState();
-  const [nextWordDueText, setNextWordDueText] = useState(null);
-
-  useEffect(() => {
-    api.getCountOfAllScheduledWords((totalInLearning) => {
-      setTotalInLearning(totalInLearning);
-    });
-    api.getNextWordDueTime((nextTime) => {
-      if (nextTime && new Date(nextTime) > new Date()) {
-        setNextWordDueText(formatFutureDueTime(new Date(nextTime)));
-      }
-    });
-  }, []);
-
   return (
     <s.Exercise>
-      {isMobile && <BackArrow func={goBackAction} />}
       <div className="contextExample">
         <br />
         <br />
 
-        <h2>
-          Nothing more to study at the moment.
-          {nextWordDueText
-            ? ` New words will be ready to practice ${nextWordDueText}.`
-            : ""}{" "}
-          :)
-        </h2>
+        <h2>Nothing more to study at the moment :)</h2>
 
         <br />
         <br />
         <p>
           Words are scheduled for exercises according to spaced-repetition principles and you already practiced the
           words that were due at this moment 🎉
-        </p>
-
-        <br />
-
-        <p>
-          <small>
-            Note: You currently have <b>{totalInLearning}</b> {Pluralize.word(totalInLearning)}{" "}
-            <Link to={"/words"}>
-              <b>in learning</b>
-            </Link>
-            . You can also increase the number of words in learning from the{" "}
-            <Link to={"/account_settings/exercise_scheduling"}>
-              {" "}
-              <b>Settings &gt; Exercises &gt; Scheduling</b>
-            </Link>{" "}
-            preferences page and then you can get more exercises also today.
-          </small>
         </p>
       </div>
     </s.Exercise>

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@ body {
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+  background-color: white;
   font-family:
     "Montserrat",
     -apple-system,

--- a/src/words/Learning.js
+++ b/src/words/Learning.js
@@ -9,6 +9,8 @@ import { WEB_READER } from "../reader/ArticleReader";
 import CollapsablePanel from "../components/CollapsablePanel";
 import { StyledButton } from "../components/allButtons.sc";
 import AddCustomWordModal from "./AddCustomWordModal";
+import Tooltip from "../components/TooltipWrapper";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 
 import { APIContext } from "../contexts/APIContext";
 import { ExercisesCounterContext } from "../exercises/ExercisesCounterContext";
@@ -116,18 +118,22 @@ export default function Learning() {
         <span style={{ color: "gray", fontWeight: "lighter" }}>
           ({count} {count === 1 ? "word" : "words"})
         </span>
+        {level === 1 && (
+          <Tooltip label="Words progress through 4 levels with increasingly harder exercises. Answer correctly on two different days to advance to the next level.">
+            <HelpOutlineIcon style={{ fontSize: "1em", marginLeft: "0.3em", color: "#888", cursor: "help", verticalAlign: "middle" }} />
+          </Tooltip>
+        )}
       </>
     );
   }
 
   return (
     <>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1em" }}>
-        <p style={{ margin: 0 }}>
-          Words in your exercises grouped by level. Each level has progressively harder exercises. When you answer a
-          word correctly on two different days, it moves to the next level.
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1em", marginLeft: "1em" }}>
+        <p style={{ margin: "0 1em 0 0", fontSize: "0.9em", color: "#555" }}>
+          Words you translate while reading are automatically scheduled for exercises and shown here. You can also add words manually.
         </p>
-        <StyledButton onClick={() => setShowAddWordModal(true)}>+</StyledButton>
+        <StyledButton onClick={() => setShowAddWordModal(true)} style={{ whiteSpace: "nowrap" }}>+ Add</StyledButton>
       </div>
 
       {showAddWordModal && (


### PR DESCRIPTION
## Summary
- Fix iOS safe area so content doesn't show behind status bar when scrolling
- Reduce bottom nav to 5 buttons (language selector moved to "More") to fit iPhone SE
- Show "Good Job!" instead of UUID for anonymous users on congratulations screen
- Remove unnecessary back arrows from exercise screens on mobile
- Simplify OutOfWordsMessage to essential content only
- Improve My Words page with better explanation and info tooltip for levels

## Test plan
- [ ] Test on iPhone (especially iPhone SE) that bottom nav fits properly
- [ ] Test scrolling on homepage - content should not show behind status bar
- [ ] Test auto-hide/show of top tabs when scrolling on articles page
- [ ] Test anonymous user flow - should see "Good Job!" not a UUID
- [ ] Test My Words page - explanation and "+ Add" button should be properly aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)