### PR TITLE
Add platform tracking for accounts and activity events

### DIFF
--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -1,4 +1,5 @@
 import { Zeeguu_API } from "./classDef";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 Zeeguu_API.prototype.getUserDetails = function (callback) {
   this._getJSON("get_user_details", callback);
@@ -24,7 +25,8 @@ Zeeguu_API.prototype.addUser = function (
       `&username=${userInfo.name}` +
       `&learned_language=${userInfo.learned_language}` +
       `&native_language=${userInfo.native_language}` +
-      `&learned_cefr_level=${userInfo.learned_cefr_level}`,
+      `&learned_cefr_level=${userInfo.learned_cefr_level}` +
+      `&platform=${getPlatform()}`,
   })
     .then((response) => {
       if (response.ok) {
@@ -62,7 +64,8 @@ Zeeguu_API.prototype.addBasicUser = function (
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body:
       `password=${password}&invite_code=${invite_code}` +
-      `&username=${userInfo.name}`,
+      `&username=${userInfo.name}` +
+      `&platform=${getPlatform()}`,
   })
     .then((response) => {
       if (response.ok) {
@@ -140,7 +143,7 @@ Zeeguu_API.prototype.addAnonUser = function (
   onError,
 ) {
   let url = this.baseAPIurl + `/add_anon_user`;
-  let body = `uuid=${uuid}&password=${password}`;
+  let body = `uuid=${uuid}&password=${password}&platform=${getPlatform()}`;
 
   if (languagePrefs?.learned_language) {
     body += `&learned_language_code=${languagePrefs.learned_language}`;

--- a/src/api/activityLogging.js
+++ b/src/api/activityLogging.js
@@ -1,5 +1,9 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
+
+// Cache platform once at module load - avoids repeated detection on every activity log
+const PLATFORM = getPlatform();
 
 // Reader Opening Actions
 Zeeguu_API.prototype.CLICKED_ARTICLE = "CLICKED ARTICLE";
@@ -102,6 +106,7 @@ Zeeguu_API.prototype.logUserActivity = function (event, article_id = "", value =
     extra_data: extra_data,
     article_id: article_id,
     source_id: source_id,
+    platform: PLATFORM,
   };
 
   const currentDate = new Date();

--- a/src/utils/misc/browserDetection.js
+++ b/src/utils/misc/browserDetection.js
@@ -1,3 +1,42 @@
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * Platform constants for analytics tracking.
+ * Keep in sync with backend: zeeguu/core/constants.py
+ */
+export const PLATFORM = {
+  WEB_DESKTOP: 1,
+  WEB_MOBILE: 2,
+  IOS_APP: 3,
+  ANDROID_APP: 4,
+  EXTENSION: 5,
+  UNKNOWN: 0,
+};
+
+/**
+ * Returns the platform identifier (integer) for analytics tracking.
+ */
+function getPlatform() {
+  try {
+    const capacitorPlatform = Capacitor.getPlatform();
+    if (capacitorPlatform === "ios") return PLATFORM.IOS_APP;
+    if (capacitorPlatform === "android") return PLATFORM.ANDROID_APP;
+  } catch (e) {
+    // Capacitor not available, fall back to user agent detection
+  }
+
+  // Check if running as browser extension
+  if (typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.id) {
+    return PLATFORM.EXTENSION;
+  }
+
+  // Web browser detection
+  if (isMobile()) {
+    return PLATFORM.WEB_MOBILE;
+  }
+  return PLATFORM.WEB_DESKTOP;
+}
+
 function runningInChromeDesktop() {
   let userAgent = navigator.userAgent;
   if (userAgent.match(/chrome|chromium|crios/i) && isMobile() === false) {
@@ -34,4 +73,5 @@ export {
   runningInChromeDesktop,
   runningInFirefoxDesktop,
   isSupportedBrowser,
+  getPlatform,
 };


### PR DESCRIPTION
## Summary
- Send platform identifier with account creation and activity logging
- Platform detected via Capacitor (native apps) or user agent (web)
- Platform cached at module load to minimize overhead on frequent activity calls

## Platform Constants
| Value | Platform |
|-------|----------|
| 0 | unknown |
| 1 | web_desktop |
| 2 | web_mobile |
| 3 | ios_app |
| 4 | android_app |
| 5 | extension |

## Related PR
- API: https://github.com/zeeguu/api/pull/463

## Test plan
- [ ] Verify account creation sends platform parameter
- [ ] Verify activity logging sends platform parameter
- [ ] Test on web desktop browser
- [ ] Test on mobile browser
- [ ] Test in Capacitor app (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)