### PR TITLE
Send platform parameter when starting sessions

### DIFF
--- a/src/api/browsing_sessions.js
+++ b/src/api/browsing_sessions.js
@@ -1,5 +1,6 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 Zeeguu_API.prototype.browsingSessionCreate = function (callback) {
   const after_extracting_json = function (json) {
@@ -9,7 +10,7 @@ Zeeguu_API.prototype.browsingSessionCreate = function (callback) {
 
   this._post(
     `browsing_session_start`,
-    "",
+    qs.stringify({ platform: getPlatform() }),
     after_extracting_json
   );
 };

--- a/src/api/exercise_sessions.js
+++ b/src/api/exercise_sessions.js
@@ -1,5 +1,6 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 // Consistent naming with other session types (reading, browsing, listening)
 Zeeguu_API.prototype.exerciseSessionCreate = function (callback) {
@@ -7,7 +8,11 @@ Zeeguu_API.prototype.exerciseSessionCreate = function (callback) {
     let id = JSON.parse(json).id;
     callback(id);
   };
-  this._post(`exercise_session_start`, null, after_extracting_json);
+  this._post(
+    `exercise_session_start`,
+    qs.stringify({ platform: getPlatform() }),
+    after_extracting_json
+  );
 };
 
 Zeeguu_API.prototype.exerciseSessionUpdate = function (
@@ -36,7 +41,11 @@ Zeeguu_API.prototype.exerciseSessionEnd = function (
 
 // Backwards compatibility aliases (can be removed once all usages are migrated)
 Zeeguu_API.prototype.startLoggingExerciseSessionToDB = function (callback) {
-  this._post(`exercise_session_start`, null, callback);
+  this._post(
+    `exercise_session_start`,
+    qs.stringify({ platform: getPlatform() }),
+    callback
+  );
 };
 
 Zeeguu_API.prototype.updateExerciseSession = function (sessionId, duration) {

--- a/src/api/listening_sessions.js
+++ b/src/api/listening_sessions.js
@@ -1,5 +1,6 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 Zeeguu_API.prototype.listeningSessionCreate = function (lessonId, callback) {
   const after_extracting_json = function (json) {
@@ -9,7 +10,7 @@ Zeeguu_API.prototype.listeningSessionCreate = function (lessonId, callback) {
 
   this._post(
     `listening_session_start`,
-    qs.stringify({ lesson_id: lessonId }),
+    qs.stringify({ lesson_id: lessonId, platform: getPlatform() }),
     after_extracting_json
   );
 };

--- a/src/api/reading_sessions.js
+++ b/src/api/reading_sessions.js
@@ -1,5 +1,6 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 Zeeguu_API.prototype.readingSessionCreate = function (articleId, readingSource, callback) {
   // the API expects the article_id to be an integer
@@ -11,7 +12,7 @@ Zeeguu_API.prototype.readingSessionCreate = function (articleId, readingSource, 
 
   this._post(
     `reading_session_start`,
-    qs.stringify({ article_id: articleId, reading_source: readingSource }),
+    qs.stringify({ article_id: articleId, reading_source: readingSource, platform: getPlatform() }),
     after_extracting_json
   );
 };

--- a/src/api/watching_sessions.js
+++ b/src/api/watching_sessions.js
@@ -1,5 +1,6 @@
 import { Zeeguu_API } from "./classDef";
 import qs from "qs";
+import { getPlatform } from "../utils/misc/browserDetection";
 
 // **********
 // CREATE WATCHING SESSION
@@ -11,9 +12,14 @@ Zeeguu_API.prototype.createWatchingSession = function (videoId, callback) {
     callback(video_id);
   };
 
-  this._post(`watching_session_start`, qs.stringify({ video_id: videoId }), onSuccess, (error) => {
-    console.error(error);
-  });
+  this._post(
+    `watching_session_start`,
+    qs.stringify({ video_id: videoId, platform: getPlatform() }),
+    onSuccess,
+    (error) => {
+      console.error(error);
+    }
+  );
 };
 
 // **********


### PR DESCRIPTION
## Summary
- Update all session API calls to include `platform` parameter from `browserDetection.js`
- Enables tracking which platform users are using for each session type

## Updated files
- `src/api/exercise_sessions.js`
- `src/api/reading_sessions.js`
- `src/api/browsing_sessions.js`
- `src/api/listening_sessions.js`
- `src/api/watching_sessions.js`

## Related
- Backend PR: https://github.com/zeeguu/api/pull/466

## Test plan
- [x] Frontend builds successfully
- [ ] Deploy and verify sessions are created with platform data

🤖 Generated with [Claude Code](https://claude.com/claude-code)