### PR TITLE
Update preference constants for declared-known feature

### DIFF
--- a/src/exercises/removeBookmark/RemoveBookmarkModal.js
+++ b/src/exercises/removeBookmark/RemoveBookmarkModal.js
@@ -36,7 +36,7 @@ export default function RemoveBookmarkModal({
   }, [open]);
 
   const possibleReasons = [
-    ["learned_already", "I know this word"],
+    ["declared_known", "I know this word"],
     ["bad_translation", "Bad translation"],
     ["other", "Other"],
   ];


### PR DESCRIPTION
## Summary

- Add `DECLARED_KNOWN: -6` and `BAD_TRANSLATION: -100` to frontend preference constants
- Change RemoveBookmarkModal reason from `learned_already` to `declared_known` to match new backend handling

Companion PR: zeeguu/api#469 handles routing these reasons to different preference values with gradual erosion for declared-known words.

## Test plan

- [ ] Click "Remove from exercises" → "I know this word" → verify network request sends `reason=declared_known`
- [ ] Click "Remove from exercises" → "Bad translation" → verify network request sends `reason=bad_translation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)