### PR TITLE
Update status to in_progress when user starts playing

### DIFF
--- a/src/dailyAudio/TodayAudio.js
+++ b/src/dailyAudio/TodayAudio.js
@@ -485,6 +485,8 @@ export default function TodayAudio({ setShowTabs }) {
               api.updateLessonState(lessonData.lesson_id, "resume");
               // Start or resume listening session
               listeningSession.start();
+              // Update context so navigation dot disappears (in_progress)
+              setUserDetails((prev) => ({ ...prev, daily_audio_status: "in_progress" }));
             }
           }}
           onPause={() => {


### PR DESCRIPTION
Removes the notification dot immediately when playback starts, rather than requiring a page refresh.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>