### PR TITLE
Fix styled-components keyframe interpolation crash

### DIFF
--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from "styled-components";
+import styled, { keyframes, css } from "styled-components";
 import { almostBlack, zeeguuOrange, zeeguuTransparentMediumOrange, orange600 } from "../components/colors";
 
 const TranslatableText = styled.div`
@@ -515,8 +515,8 @@ const ClozeInput = styled.input`
   font-weight: ${props => props.$isOver ? '700' : 'normal'};
   cursor: ${props => props.$isOver ? 'default' : 'text'};
   animation: ${props => {
-    if (props.$isCorrect) return `${correctAnswerAnimation} 0.6s ease-out forwards`;
-    if (props.$isEmpty) return `${pulseUnderline} 2s ease-in-out infinite`;
+    if (props.$isCorrect) return css`${correctAnswerAnimation} 0.6s ease-out forwards`;
+    if (props.$isEmpty) return css`${pulseUnderline} 2s ease-in-out infinite`;
     return 'none';
   }};
 `;


### PR DESCRIPTION
## Summary
- Fix intermittent blank screen crash during exercises caused by styled-components error #12
- The `ClozeInput` animation was interpolating keyframes inside template strings, which is not supported in styled-components v4+
- Now uses the `css` helper to properly inject keyframes on-demand

## User reports
- "When doing exercises now, after two or three, the screen goes blank after an answer has been given"
- "I suddenly got a full white screen... I think it's an audio exercise"

## Sentry
- Issue ID: f85d6e1b3bc74dd5b436a7abe3467680
- Error: `An error occurred. See styled-components errors #12`

## Test plan
- [ ] Do multiple cloze exercises in a row
- [ ] Verify the pulse animation still works on empty inputs
- [ ] Verify the correct answer animation still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)