### PR TITLE
Use sendBeacon for session updates to prevent fetch errors on navigation

### DIFF
--- a/src/api/browsing_sessions.js
+++ b/src/api/browsing_sessions.js
@@ -24,7 +24,8 @@ Zeeguu_API.prototype.browsingSessionUpdate = function (
     duration: currentDuration * 1000, // the API expects ms
   };
 
-  this._post(`browsing_session_update`, qs.stringify(payload));
+  // Use beacon to prevent "Failed to fetch" errors when user navigates away
+  this._postBeacon(`browsing_session_update`, qs.stringify(payload));
 };
 
 Zeeguu_API.prototype.browsingSessionEnd = function (
@@ -36,5 +37,6 @@ Zeeguu_API.prototype.browsingSessionEnd = function (
     duration: totalTime * 1000,
   };
 
-  this._post(`browsing_session_end`, qs.stringify(payload));
+  // Use beacon to prevent "Failed to fetch" errors when user navigates away
+  this._postBeacon(`browsing_session_end`, qs.stringify(payload));
 };

--- a/src/api/exercise_sessions.js
+++ b/src/api/exercise_sessions.js
@@ -24,7 +24,8 @@ Zeeguu_API.prototype.exerciseSessionUpdate = function (
     duration: currentDuration * 1000, // the API expects ms
   };
 
-  this._post(`exercise_session_update`, qs.stringify(payload));
+  // Use beacon to prevent "Failed to fetch" errors when user navigates away
+  this._postBeacon(`exercise_session_update`, qs.stringify(payload));
 };
 
 Zeeguu_API.prototype.exerciseSessionEnd = function (
@@ -36,7 +37,8 @@ Zeeguu_API.prototype.exerciseSessionEnd = function (
     duration: totalTime * 1000,
   };
 
-  this._post(`exercise_session_end`, qs.stringify(payload));
+  // Use beacon to prevent "Failed to fetch" errors when user navigates away
+  this._postBeacon(`exercise_session_end`, qs.stringify(payload));
 };
 
 // Backwards compatibility aliases (can be removed once all usages are migrated)

--- a/src/api/reading_sessions.js
+++ b/src/api/reading_sessions.js
@@ -40,5 +40,5 @@ Zeeguu_API.prototype.readingSessionEnd = function (
   };
 
   // Use beacon to prevent "Load failed" errors when user navigates away
-  this._postBeacon(`reading_session_start`, qs.stringify(payload));
+  this._postBeacon(`reading_session_end`, qs.stringify(payload));
 };

--- a/src/api/watching_sessions.js
+++ b/src/api/watching_sessions.js
@@ -31,14 +31,6 @@ Zeeguu_API.prototype.updateWatchingSession = function (watchingSessionId, curren
     duration: currentDurationInSeconds * 1000, //the API expects ms
   };
 
-  this._post(
-    `watching_session_update`,
-    qs.stringify(payload),
-    () => {
-      console.log("Watching session updated");
-    },
-    (error) => {
-      console.error(error);
-    },
-  );
+  // Use beacon to prevent "Failed to fetch" errors when user navigates away
+  this._postBeacon(`watching_session_update`, qs.stringify(payload));
 };


### PR DESCRIPTION
## Summary
- Use `sendBeacon` API for session update/end calls instead of `fetch`
- Fixes "Failed to fetch" errors (ZEEGUU-WEB-B4) when users navigate away
- Also fixes a bug in `reading_sessions.js` where `readingSessionEnd` was calling the wrong endpoint (`reading_session_start`)

## Why sendBeacon?
When users navigate away from a page, browsers cancel in-flight `fetch` requests, causing errors in Sentry. `sendBeacon` is designed for this exact use case - it's fire-and-forget and guaranteed to complete even during page navigation.

## Test plan
- [ ] Test exercise session tracking - verify session data is saved when navigating away
- [ ] Test reading session tracking - verify session ends correctly
- [ ] Test browsing session tracking - verify no console errors on navigation
- [ ] Verify Sentry stops receiving "Failed to fetch" errors for session updates

Fixes ZEEGUU-WEB-B4

🤖 Generated with [Claude Code](https://claude.com/claude-code)