### PR TITLE
Use template for service worker to avoid dirty git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 #development
 .env.development
 
+# generated files
+public/service-worker.js
+
 # production
 /build
 /src/extension/build

--- a/public/service-worker.template.js
+++ b/public/service-worker.template.js
@@ -1,7 +1,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-const OFFLINE_CACHE = "offline-cache-v20260212T14301";
-const DATA_CACHE = "data-cache-v20250814T11364";
+const OFFLINE_CACHE = "__OFFLINE_CACHE_VERSION__";
+const DATA_CACHE = "__DATA_CACHE_VERSION__";
 const OFFLINE_URL = "offline.html";
 
 // These are the files downloaded into the cache for the PWA
@@ -191,7 +191,7 @@ self.addEventListener("activate", (event) => {
 // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/fetch_event
 self.addEventListener("fetch", (event) => {
   const requestUrl = new URL(event.request.url);
-  
+
   // Add a parameter to track media control activations
   if (event.request.mode === "navigate" && event.request.referrer === "") {
     // This might be from a lock screen tap
@@ -204,7 +204,7 @@ self.addEventListener("fetch", (event) => {
     );
     return;
   }
-  
+
   if (event.request.mode === "navigate") {
     handleNavigationRequest(event);
   } else if (CACHE_STATIC_FILES.includes(requestUrl.pathname)) {

--- a/scripts/update-service-worker-version.js
+++ b/scripts/update-service-worker-version.js
@@ -3,28 +3,21 @@ const path = require('path');
 
 // Generate timestamp-based version
 const buildTimestamp = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 14); // Format: YYYYMMDDHHMMSS
-const version = `v${buildTimestamp}`;
 
-console.log(`Updating service worker with version: ${version}`);
+console.log(`Generating service worker with version: v${buildTimestamp}`);
 
-// Path to the service worker - works from project root
-const serviceWorkerPath = path.join(process.cwd(), 'public/service-worker.js');
+// Paths
+const templatePath = path.join(process.cwd(), 'public/service-worker.template.js');
+const outputPath = path.join(process.cwd(), 'public/service-worker.js');
 
-// Read the service worker file
-let content = fs.readFileSync(serviceWorkerPath, 'utf8');
+// Read the template file
+let content = fs.readFileSync(templatePath, 'utf8');
 
-// Replace the version strings
-content = content.replace(
-  /const OFFLINE_CACHE = "offline-cache-v[^"]+";/,
-  `const OFFLINE_CACHE = "offline-cache-${version}";`
-);
+// Replace the placeholders with versioned cache names
+content = content.replace('__OFFLINE_CACHE_VERSION__', `offline-cache-v${buildTimestamp}`);
+content = content.replace('__DATA_CACHE_VERSION__', `data-cache-v${buildTimestamp}`);
 
-content = content.replace(
-  /const DATA_CACHE = "offline-cache-v[^"]+";/,
-  `const DATA_CACHE = "data-cache-${version}";`
-);
+// Write the generated service worker
+fs.writeFileSync(outputPath, content, 'utf8');
 
-// Write the updated content back
-fs.writeFileSync(serviceWorkerPath, content, 'utf8');
-
-console.log('Service worker version updated successfully!');
+console.log('Service worker generated successfully!');


### PR DESCRIPTION
## Summary
- Prebuild script was modifying `service-worker.js` directly with timestamps, causing it to always appear dirty in git
- Created `service-worker.template.js` with placeholders as the source of truth
- Prebuild now generates `service-worker.js` from the template
- Added generated file to `.gitignore`

## Test plan
- [ ] Run `npm run build` and verify service-worker.js is generated correctly
- [ ] Verify git status stays clean after builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)