### PR TITLE
Security: Remove fake wepack-cli package (typo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,8 +150,7 @@
     "vite-plugin-svgr": "^4.5.0",
     "vitest": "^3.2.4",
     "webpack": "^5.76.0",
-    "webpack-bundle-analyzer": "^4.10.2",
-    "wepack-cli": "0.0.1-security"
+    "webpack-bundle-analyzer": "^4.10.2"
   },
   "overrides": {
     "d3-color": "3.1.0",


### PR DESCRIPTION
## Summary

Removes the fake `wepack-cli` devDependency which is a typo of `webpack-cli`.

## Details

- The package `"wepack-cli": "0.0.1-security"` is a placeholder/security warning package on npm
- It was likely added accidentally due to a typo
- The correct `"webpack-cli": "^4.9.2"` is already listed in dependencies (line 58)
- This duplicate with the typo can be safely removed

## Test plan

- [x] Verify `webpack-cli` is still in dependencies
- [ ] Run `npm install` to verify no issues
- [ ] Run build to verify webpack still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)