### PR TITLE
Use requires_email_verification from API for redirect logic

### DIFF
--- a/src/PrivateRoute.js
+++ b/src/PrivateRoute.js
@@ -41,11 +41,10 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
   }
 
   // Check email verification - redirect to verify page if not verified
-  // Skip for anonymous users and if already on verify_email page
+  // Uses backend-computed field that considers grandfathering for existing users
   if (
     userDetails &&
-    !userDetails.is_anonymous &&
-    userDetails.email_verified === false &&
+    userDetails.requires_email_verification &&
     !isVerifyEmailPage
   ) {
     return (

--- a/src/PrivateRouteWithMainNav.js
+++ b/src/PrivateRouteWithMainNav.js
@@ -25,12 +25,8 @@ export const PrivateRouteWithMainNav = ({ component: Component, ...rest }) => {
   }
 
   // Check email verification - redirect to verify page if not verified
-  // Skip for anonymous users
-  if (
-    userDetails &&
-    !userDetails.is_anonymous &&
-    userDetails.email_verified === false
-  ) {
+  // Uses backend-computed field that considers grandfathering for existing users
+  if (userDetails && userDetails.requires_email_verification) {
     return (
       <Redirect
         to={{


### PR DESCRIPTION
## Summary
- Frontend now uses the backend-computed `requires_email_verification` field
- This considers date-based grandfathering - only users created after deployment need verification
- Fixes issue where existing users were incorrectly redirected to verify_email page

## Test plan
- [ ] Existing users should not be redirected to verify email
- [ ] New users created after 2026-02-17 should be redirected if email not verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)