### PR TITLE
Simplify translation history: log search_word, skip re-searches

### DIFF
--- a/src/api/translations.js
+++ b/src/api/translations.js
@@ -248,3 +248,7 @@ Zeeguu_API.prototype.basicTranlsate = function (from_lang, to_lang, phrase) {
 Zeeguu_API.prototype.getTranslationHistory = function (limit = 50) {
   return this.apiGet(`/translation_history?limit=${limit}`).then((res) => res.data);
 };
+
+Zeeguu_API.prototype.logTranslationSearch = function (searchWord) {
+  return this._post("log_translation_search", `search_word=${encodeURIComponent(searchWord)}`);
+};

--- a/src/translate/Translate.js
+++ b/src/translate/Translate.js
@@ -94,7 +94,7 @@ export default function Translate() {
     if (location.state?.searchWord) {
       const word = location.state.searchWord;
       setSearchWord(word);
-      performSearch(word);
+      performSearch(word, true); // Skip logging - already in history
       // Clear the state so refreshing doesn't re-trigger
       window.history.replaceState({}, document.title);
     }
@@ -170,7 +170,7 @@ export default function Translate() {
     return true;
   }
 
-  function performSearch(word) {
+  function performSearch(word, skipHistory = false) {
     if (!word || !isValidWord(word)) {
       setError("Please enter a valid word or phrase");
       return;
@@ -237,6 +237,11 @@ export default function Translate() {
         const finalTranslations = direction === "toNative" ? toNativeResults : toLearnedResults;
         setTranslations(finalTranslations);
         setActiveDirection(direction);
+
+        // Log to history (only for new searches, not from history navigation)
+        if (!skipHistory && finalTranslations.length > 0) {
+          api.logTranslationSearch(word);
+        }
 
         // Auto-fetch examples for each translation (skip for long phrases)
         const wordCount = word.split(/\s+/).length;

--- a/src/translate/TranslateHistory.js
+++ b/src/translate/TranslateHistory.js
@@ -72,17 +72,7 @@ export default function TranslateHistory() {
         >
           <s.TranslationHeader>
             <s.TranslationInfo>
-              <s.TranslationText>
-                {item.search_word}
-                {item.translation && (
-                  <span style={{ fontWeight: 400, color: "#666", marginLeft: "0.5rem" }}>
-                    → {item.translation}
-                  </span>
-                )}
-              </s.TranslationText>
-              <s.TranslationSource>
-                {item.from_language} → {item.to_language}
-              </s.TranslationSource>
+              <s.TranslationText>{item.search_word}</s.TranslationText>
             </s.TranslationInfo>
             <s.TranslationSource>{formatTime(item.search_time)}</s.TranslationSource>
           </s.TranslationHeader>


### PR DESCRIPTION
## Summary
- `logTranslationSearch` now sends `search_word` instead of `meaning_id`
- `performSearch` takes `skipHistory` param - `true` when navigating from history
- Simplified history display (just search_word + time)
- Uses `date-fns` formatDistanceToNow and existing styles from `Translate.sc.js`

## Depends on
- API PR: https://github.com/zeeguu/api/pull/491

## Test plan
- [ ] Search for word → appears in history once (not twice)
- [ ] Click history item → re-searches but doesn't add duplicate entry
- [ ] History shows only searches for current learned language

🤖 Generated with [Claude Code](https://claude.com/claude-code)