### PR TITLE
Fix cursor jumping to end when editing cloze input

### DIFF
--- a/src/components/VirtualKeyboard/SpecialCharacterBar.js
+++ b/src/components/VirtualKeyboard/SpecialCharacterBar.js
@@ -38,7 +38,8 @@ export function hasSpecialCharacters(languageCode) {
 export default function SpecialCharacterBar({
   languageCode,
   onKeyPress,
-  currentValue = ''
+  currentValue = '',
+  inputRef = null, // Optional ref to input element for cursor-aware insertion
 }) {
   const [isShift, setIsShift] = useState(false);
 
@@ -48,7 +49,23 @@ export default function SpecialCharacterBar({
   const chars = isShift ? charSet.uppercase : charSet.lowercase;
 
   const handleKeyClick = (char) => {
-    onKeyPress(currentValue + char);
+    // If we have direct access to the input, insert at cursor position
+    if (inputRef?.current) {
+      const input = inputRef.current;
+      const start = input.selectionStart || 0;
+      const end = input.selectionEnd || 0;
+      const value = input.value;
+      const newValue = value.slice(0, start) + char + value.slice(end);
+      input.value = newValue;
+      input.setSelectionRange(start + 1, start + 1);
+      // Update width (monospace: 1ch = 1 char)
+      input.style.width = `${Math.max(newValue.length + 1, 3)}ch`;
+      onKeyPress(newValue);
+      input.focus();
+    } else {
+      // Fallback: append to end
+      onKeyPress(currentValue + char);
+    }
     if (isShift) {
       setIsShift(false);
     }

--- a/src/exercises/components/ClozeContextWithExchange.js
+++ b/src/exercises/components/ClozeContextWithExchange.js
@@ -1,4 +1,4 @@
-import { forwardRef, useContext, useState } from "react";
+import { forwardRef, useContext, useState, useRef } from "react";
 import { ClozeTranslatableText } from "../../reader/ClozeTranslatableText.js";
 import ReplaceExampleModal from "../replaceExample/ReplaceExampleModal.js";
 import VirtualKeyboard from "../../components/VirtualKeyboard/VirtualKeyboard.js";
@@ -43,6 +43,7 @@ const ClozeContextWithExchange = forwardRef(function ClozeContextWithExchange(
 ) {
   const { userDetails } = useContext(UserContext);
   const [isKeyboardCollapsed, setIsKeyboardCollapsed] = useState(getInitialKeyboardCollapsed);
+  const clozeInputRef = useRef(null);
 
   // Determine the language for the answer (L2 for this exercise type)
   const answerLanguageCode = exerciseBookmark?.from_lang;
@@ -80,6 +81,7 @@ const ClozeContextWithExchange = forwardRef(function ClozeContextWithExchange(
           answerLanguageCode={answerLanguageCode}
           suppressOSKeyboard={suppressOSKeyboard}
           aboveClozeElement={aboveClozeElement}
+          onInputRefReady={(ref) => { clozeInputRef.current = ref; }}
         />
         {onExampleUpdated && isExerciseOver && (
           <div
@@ -109,6 +111,7 @@ const ClozeContextWithExchange = forwardRef(function ClozeContextWithExchange(
             currentValue={inputValue}
             initialCollapsed={false}
             onCollapsedChange={setIsKeyboardCollapsed}
+            inputRef={clozeInputRef.current}
           />
         </div>
       )}
@@ -121,6 +124,7 @@ const ClozeContextWithExchange = forwardRef(function ClozeContextWithExchange(
             languageCode={answerLanguageCode}
             onKeyPress={onInputChange}
             currentValue={inputValue}
+            inputRef={clozeInputRef.current}
           />
         </div>
       )}

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -504,7 +504,7 @@ const ClozeInput = styled.input`
   background: transparent;
   outline: none;
   font-size: inherit;
-  font-family: inherit;
+  font-family: monospace !important;
   text-align: ${props => props.$isOver ? 'center' : 'left'};
   width: ${props => props.$width}em;
   max-width: ${props => props.$width}em;


### PR DESCRIPTION
## Summary
- Fix cursor jumping to end when typing in middle of cloze input field
- Works for both physical keyboard and virtual/on-screen keyboards
- Uses monospace font for consistent width calculation

## Changes
- Changed ClozeInput to uncontrolled input (defaultValue) to let browser handle cursor naturally
- Removed inputValue from renderedText useEffect dependencies to prevent JSX recreation on every keystroke
- Width updated directly on DOM element, bypassing React state
- Virtual keyboards now insert at cursor position instead of always appending to end

## Test plan
- [ ] Type in middle of word with physical keyboard - cursor should stay in place
- [ ] Type in middle of word with virtual keyboard (Greek) - cursor should stay in place
- [ ] Width should grow correctly as you type
- [ ] Exercise completion should still show correct answer

🤖 Generated with [Claude Code](https://claude.ai/code)