### PR TITLE
Fix @capacitor/app module resolution by removing external declaration

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -44,8 +44,6 @@ export default defineConfig(({ mode }) => ({
     outDir: 'build',
     chunkSizeWarningLimit: 1000, // KB - our main bundle is ~779 KB
     rollupOptions: {
-      // Externalize Capacitor native-only modules (not available in web builds)
-      external: ['@capacitor/app'],
       output: {
         entryFileNames: 'static/js/[name].[hash].js',
         chunkFileNames: 'static/js/[name].[hash].chunk.js',


### PR DESCRIPTION
## Summary
- Removed `@capacitor/app` from Rollup external configuration in vite.config.js
- The module was being excluded from the bundle, causing runtime import failures on iOS/Android
- The dynamic import in `useDeepLinkHandler.js` now works correctly on native platforms

## Sentry Issues Fixed
This fixes 4 related Sentry issues affecting **44 users** with **103 total events**:
- ZEEGUU-WEB-BG (45 events, 20 users) - iOS
- ZEEGUU-WEB-BH (36 events, 15 users) - Android
- ZEEGUU-WEB-BK (20 events, 7 users) - Android
- ZEEGUU-WEB-BJ (2 events, 2 users) - iOS

## Test plan
- [ ] Build the app with `npm run build`
- [ ] Deploy to iOS TestFlight and verify deep links work
- [ ] Deploy to Android beta and verify deep links work
- [ ] Confirm no new Sentry errors for @capacitor/app module resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)