### PR TITLE
Remove text-transform: lowercase from translations

### DIFF
--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -17,7 +17,6 @@ const AlterMenuSC = styled.div`
 
   .additionalTrans {
     height: 100%;
-    text-transform: lowercase;
     white-space: normal;
     border-bottom: 1px solid ${zeeguuLightYellow} !important;
     color: ${almostBlack};

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -261,7 +261,6 @@ const TranslatableText = styled.div`
     max-width: 100%;
     font-weight: 600;
     color: ${almostBlack};
-    text-transform: lowercase;
     text-align: left;
     display: flex;
   }


### PR DESCRIPTION
## Summary
- Remove `text-transform: lowercase` from translation display
- Translations now preserve original casing (e.g., "UN World Book Day" stays uppercase)

Fixes #831

## Test plan
- [ ] Open an article with a proper noun (e.g., "UNESCO")
- [ ] Translate it and verify the translation preserves casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)