### PR TITLE
Add share link to article reader

### DIFF
--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -15,6 +15,7 @@ import LikeFeedBackBox from "./LikeFeedbackBox";
 import { extractVideoIDFromURL } from "../utils/misc/youtube";
 
 import ArticleSource from "./ArticleSource";
+import ShareArticle from "./ShareArticle";
 import ReportBroken from "./ReportBroken";
 
 import TopToolbar from "./TopToolbar";
@@ -343,6 +344,7 @@ export default function ArticleReader({ teacherArticleID }) {
           <s.ArticleInfoContainer>
             <ArticleStatInfo articleInfo={articleInfo}></ArticleStatInfo>
             {!articleInfo.parent_url && <ArticleSource url={articleInfo.url} />}
+            <ShareArticle articleID={articleID} />
           </s.ArticleInfoContainer>
           <hr></hr>
 

--- a/src/reader/ShareArticle.js
+++ b/src/reader/ShareArticle.js
@@ -1,0 +1,58 @@
+import { toast } from "react-toastify";
+import ShareIcon from "@mui/icons-material/Share";
+import styled from "styled-components";
+import { darkGrey } from "../components/colors";
+
+const ShareLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: ${darkGrey};
+  font-size: small;
+  font-weight: 500;
+  font-family: "Montserrat";
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export default function ShareArticle({ articleID }) {
+  const shareUrl = `https://zeeguu.org/read/article?id=${articleID}`;
+
+  const handleShare = async () => {
+    // Try native share API first (mobile)
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Check out this article on Zeeguu",
+          url: shareUrl,
+        });
+        return;
+      } catch (err) {
+        // User cancelled or share failed, fall back to clipboard
+      }
+    }
+
+    // Fall back to clipboard
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success("Link copied to clipboard!");
+    } catch (err) {
+      toast.error("Failed to copy link");
+    }
+  };
+
+  return (
+    <ShareLink onClick={handleShare}>
+      <ShareIcon style={{ fontSize: "1em" }} />
+      share
+    </ShareLink>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a small "share" link in the article info line (next to the source chip)
- Uses native share API on mobile devices
- Falls back to clipboard copy on desktop
- Toast notification confirms successful copy

## Screenshot
The link appears as: `A1 · B2 original on illvid.dk · 🔗 share`

## Test plan
- [ ] Open an article in the reader
- [ ] Click "share" link
- [ ] On mobile: native share sheet should appear
- [ ] On desktop: link should be copied to clipboard with toast confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)