### PR TITLE
Fix iOS auto-zoom on search input focus

### DIFF
--- a/src/articles/SearchField.sc.js
+++ b/src/articles/SearchField.sc.js
@@ -28,7 +28,7 @@ const SearchInput = styled.input`
   height: 1.5em;
   box-sizing: border-box;
   width: 50%;
-  font-size: 0.9rem;
+  font-size: 1rem; /* Must be >= 16px to prevent iOS auto-zoom on focus */
   height: 2.5rem;
   padding: 0 1rem;
   margin: 0;


### PR DESCRIPTION
## Summary
- Fixes the screen zoom issue when tapping Search on iOS devices
- Increases `SearchInput` font-size from `0.9rem` (~14.4px) to `1rem` (16px)
- iOS Safari auto-zooms on inputs with font-size < 16px as an accessibility feature

## Root Cause
iOS Safari assumes that input fields with small font sizes need magnification for readability. When users tap on an input with `font-size < 16px`, it automatically zooms the page. The `SearchInput` had `0.9rem` (~14.4px), triggering this behavior.

## Test plan
- [ ] Test on iOS Safari: tap the search input and verify no page zoom occurs
- [ ] Verify the search input text is still readable and visually appropriate

Fixes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)