### PR TITLE
Hide Recommended/Search tabs when hide_recommendations feature is enabled

### DIFF
--- a/src/articles/_ArticlesRouter.js
+++ b/src/articles/_ArticlesRouter.js
@@ -1,6 +1,7 @@
 import ArticleListBrowser from "./ArticleListBrowser";
 import BookmarkedArticles from "./BookmarkedArticles";
 
+import { Redirect } from "react-router-dom";
 import { PrivateRoute } from "../PrivateRoute";
 import ClassroomArticles from "./ClassroomArticles";
 import TopTabs from "../components/TopTabs";
@@ -19,10 +20,15 @@ import CustomizeGear from "./CustomizeGear";
 
 export default function ArticlesRouter({ hasExtension, isChrome }) {
   const { getBrowsingSessionId } = useBrowsingSession();
+  const hideRecommendations = LocalStorage.hasFeature("hide_recommendations");
 
   const tabsAndLinks = [
-    { text: strings.recommended, link: "/articles", action: <CustomizeGear /> },
-    { text: strings.search, link: "/articles/mySearches" },
+    !hideRecommendations && {
+      text: strings.recommended,
+      link: "/articles",
+      action: <CustomizeGear />,
+    },
+    !hideRecommendations && { text: strings.search, link: "/articles/mySearches" },
     LocalStorage.isStudent() && { text: strings.classroomTab, link: "/articles/classroom" },
   ].filter(Boolean);
 
@@ -32,13 +38,17 @@ export default function ArticlesRouter({ hasExtension, isChrome }) {
       <s.NarrowColumn>
         <TopTabs title={strings.articles} tabsAndLinks={tabsAndLinks} />
 
-        <PrivateRoute
-          path="/articles"
-          exact
-          component={ArticleListBrowser}
-          hasExtension={hasExtension}
-          isChrome={isChrome}
-        />
+        {hideRecommendations ? (
+          <Redirect from="/articles" exact to="/articles/classroom" />
+        ) : (
+          <PrivateRoute
+            path="/articles"
+            exact
+            component={ArticleListBrowser}
+            hasExtension={hasExtension}
+            isChrome={isChrome}
+          />
+        )}
         <PrivateRoute
           path="/articles/bookmarked"
           component={BookmarkedArticles}


### PR DESCRIPTION
## Summary
- Hides "Recommended" and "Search" tabs when `hide_recommendations` feature flag is set
- Redirects `/articles` to `/articles/classroom` for affected users
- Students with this feature only see the Classroom tab with teacher-uploaded texts

## Related
- Backend PR: https://github.com/zeeguu/api/pull/new/feature/hide-recommendations-for-cohort

## Test plan
- [ ] Log in as a student in cohort 564
- [ ] Verify only the Classroom tab is visible in the articles section
- [ ] Verify navigating to `/articles` redirects to `/articles/classroom`
- [ ] Verify normal users still see all three tabs

🤖 Generated with [Claude Code](https://claude.ai/code)