### PR TITLE
Fix MainNavWithComponent height for mobile pages with bottom nav

### DIFF
--- a/src/MainNavWithComponent.js
+++ b/src/MainNavWithComponent.js
@@ -70,7 +70,7 @@ export default function MainNavWithComponent(props) {
           hideExerciseCounter: hideExerciseCounter,
         }}
       >
-        <s.MainNavWithComponent $screenWidth={screenWidth}>
+        <s.MainNavWithComponent $screenWidth={screenWidth} $currentPath={path}>
           <MainNav screenWidth={screenWidth} />
           <s.AppContent
             // Update the key when the learned_language changes to trigger a re-render

--- a/src/MainNavWithComponent.sc.js
+++ b/src/MainNavWithComponent.sc.js
@@ -6,7 +6,13 @@ import { PAGES_WITHOUT_BOTTOM_NAV } from "./components/MainNav/BottomNav/pagesWi
 const MainNavWithComponent = styled.div`
   box-sizing: border-box;
   top: 0;
-  height: 100%;
+  height: ${({ $screenWidth, $currentPath }) => {
+    if ($screenWidth <= MOBILE_WIDTH && !PAGES_WITHOUT_BOTTOM_NAV.some((page) => $currentPath.startsWith(page))) {
+      return "calc(100% - 4rem)";
+    } else {
+      return "100%";
+    }
+  }};
   display: flex;
   justify-content: space-around;
   flex-direction: ${({ $screenWidth }) => ($screenWidth <= MOBILE_WIDTH ? "column" : "row")};


### PR DESCRIPTION
## Summary
- Fixes MainNavWithComponent height to be `calc(100% - 4rem)` only when:
  - `$screenWidth <= MOBILE_WIDTH` (700px)
  - AND not on pages without bottom nav (`PAGES_WITHOUT_BOTTOM_NAV = ["/read"]`)
- Otherwise sets `height: 100%` (for desktop and mobile pages without bottom nav)

## Changes
- Updated `MainNavWithComponent.sc.js` to conditionally calculate height based on screen width and current path
- Passed `$currentPath` prop to `MainNavWithComponent` styled component in `MainNavWithComponent.js`

## Impact
- Desktop pages now have full height (no unnecessary 4rem subtraction)
- Mobile pages with bottom nav maintain proper spacing
- Mobile pages without bottom nav (e.g., `/read`) have full height