### PR TITLE
Proxy API calls through Vite dev server to fix CORS

### DIFF
--- a/scripts/cap-dev.sh
+++ b/scripts/cap-dev.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+PLATFORM=$1
+if [ "$PLATFORM" != "ios" ] && [ "$PLATFORM" != "android" ] && [ "$PLATFORM" != "both" ]; then
+  echo "Usage: $0 <ios|android|both>"
+  exit 1
+fi
+
+IP=$(ipconfig getifaddr en0)
+if [ -z "$IP" ]; then
+  echo "Could not detect local IP. Are you connected to Wi-Fi?"
+  exit 1
+fi
+
+PORT=3000
+URL="http://$IP:$PORT"
+echo "Starting Vite dev server at $URL ..."
+
+# Route API calls through Vite proxy to avoid CORS issues in mobile WebViews
+export VITE_API_URL="$URL/zeeguu-api"
+
+# Start Vite in background, bound to all interfaces
+npx vite --host &
+VITE_PID=$!
+
+# Wait for Vite to be ready
+until curl -s -o /dev/null http://$IP:$PORT 2>/dev/null; do
+  sleep 0.5
+done
+echo "Vite is ready."
+
+if [ "$PLATFORM" = "both" ]; then
+  LIVE_RELOAD_URL=$URL npx cap sync ios
+  LIVE_RELOAD_URL=$URL npx cap sync android
+  npx cap open ios
+  npx cap open android
+  echo "Hit Run in both Xcode and Android Studio. CSS/JS changes will hot-reload."
+else
+  LIVE_RELOAD_URL=$URL npx cap sync $PLATFORM
+  npx cap open $PLATFORM
+  if [ "$PLATFORM" = "ios" ]; then
+    echo "Hit Run in Xcode. CSS/JS changes will hot-reload."
+  else
+    echo "Hit Run in Android Studio. CSS/JS changes will hot-reload."
+  fi
+fi
+
+echo "Press Ctrl+C to stop."
+
+# Keep running until Ctrl+C
+wait $VITE_PID

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,7 +36,14 @@ export default defineConfig(({ mode }) => ({
   // Development server settings
   server: {
     port: 3000,
-    open: true
+    open: true,
+    proxy: {
+      '/zeeguu-api': {
+        target: 'https://api.zeeguu.org',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/zeeguu-api/, ''),
+      },
+    },
   },
 
   // Build settings


### PR DESCRIPTION
## Summary
- Adds a Vite dev server proxy for `/zeeguu-api` requests, forwarding them to `https://api.zeeguu.org` — keeps everything same-origin and fixes CORS issues in mobile WebViews (Android/iOS)
- Adds `cap-dev.sh` helper script that sets `VITE_API_URL` to use the proxy during mobile development

## Test plan
- [ ] Run `npm run dev` and verify API calls work (no `SyntaxError: Unexpected token '<'` in console)
- [ ] Test on Android/iOS via Capacitor live reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)