### PR TITLE
Fix 401 on daily_streak API call

### DIFF
--- a/src/contexts/ProgressContext.js
+++ b/src/contexts/ProgressContext.js
@@ -18,6 +18,7 @@ function ProgressProvider({ children }) {
   const [totalLearned, setTotalLearned] = useState(null);
 
   useEffect(() => {
+    if (!userDetails?.learned_language) return;
     api.getDailyStreak((data) => {
       setDaysPracticed(data.daily_streak);
     });


### PR DESCRIPTION
## Summary
- Guard `getDailyStreak` in `ProgressContext` to only fire when `userDetails.learned_language` is set
- Prevents race condition where the API call fires before session validation completes, causing a 401 on expired sessions

## Test plan
- [ ] Log out and verify no 401 errors in console for `daily_streak`
- [ ] Log in and verify daily streak still displays correctly
- [ ] Switch languages and verify streak updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)