### PR TITLE
PageBackground can now be either static or fixed position on the PreferencesPage component

### DIFF
--- a/src/pages/DeleteAccount/DeleteAccount.js
+++ b/src/pages/DeleteAccount/DeleteAccount.js
@@ -59,7 +59,7 @@ export default function DeleteAccount() {
   if (currentStatus === DeletionStatus.UNDEFINED) return <LoadingAnimation />;
 
   return (
-    <PreferencesPage>
+    <PreferencesPage isBackgroundFixed={true}>
       <Header>
         <Heading>{headingMsg}</Heading>
       </Header>

--- a/src/pages/LogIn.js
+++ b/src/pages/LogIn.js
@@ -72,7 +72,7 @@ export default function LogIn({ handleSuccessfulLogIn }) {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Login</Heading>
       </Header>

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -5,7 +5,7 @@ import Main from "./_pages_shared/Main.sc";
 import { Link } from "react-router-dom";
 export default function NotFound() {
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Ooops!</Heading>
       </Header>

--- a/src/pages/ResetPassword.js
+++ b/src/pages/ResetPassword.js
@@ -51,7 +51,7 @@ export default function ResetPassword() {
   }, []);
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Reset Password</Heading>
       </Header>

--- a/src/pages/_pages_shared/PreferencesPage.js
+++ b/src/pages/_pages_shared/PreferencesPage.js
@@ -4,9 +4,10 @@ export default function PreferencesPage({
   children,
   pageWidth,
   layoutVariant,
+  isBackgroundFixed,
 }) {
   return (
-    <s.PageBackground layoutVariant={layoutVariant}>
+    <s.PageBackground layoutVariant={layoutVariant} isBackgroundFixed={isBackgroundFixed}>
       <s.PageContainer layoutVariant={layoutVariant} pageWidth={pageWidth}>
         <s.ContentWrapper>{children}</s.ContentWrapper>
       </s.PageContainer>

--- a/src/pages/_pages_shared/PreferencesPage.sc.js
+++ b/src/pages/_pages_shared/PreferencesPage.sc.js
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 import { zeeguuOrange } from "../../components/colors";
 
 const PageBackground = styled.div`
-  position: fixed;
+  position: ${({ isBackgroundFixed }) => (isBackgroundFixed ? "fixed" : "static")};
   top: 0;
   left: 0;
   right: 0;

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -150,7 +150,7 @@ export default function CreateAccount({ handleSuccessfulLogIn }) {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Modal
         open={showPrivacyNotice}
         onClose={() => {

--- a/src/pages/onboarding/ExcludeWords.js
+++ b/src/pages/onboarding/ExcludeWords.js
@@ -78,7 +78,7 @@ export default function ExcludeWords({ hasExtension }) {
   }, []);
 
   return (
-    <PreferencesPage>
+    <PreferencesPage isBackgroundFixed={true}>
       <Header>
         <Heading>Would you like to exclude articles and exercises containing particular words or&nbsp;phrases?</Heading>
       </Header>

--- a/src/pages/onboarding/ExtensionInstalled.js
+++ b/src/pages/onboarding/ExtensionInstalled.js
@@ -24,7 +24,7 @@ export default function ExtensionInstalled() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <PreferencesPage>
+    <PreferencesPage isBackgroundFixed={true}>
       <Header>
         <Heading>
           Right-click to&nbsp; activate the&nbsp;Zeeguu&nbsp;

--- a/src/pages/onboarding/InstallExtension.js
+++ b/src/pages/onboarding/InstallExtension.js
@@ -23,7 +23,7 @@ export default function InstallExtension() {
   }, []);
 
   return (
-    <PreferencesPage>
+    <PreferencesPage isBackgroundFixed={true}>
       <Header>
         <Heading>
           Read any article on the web<br></br>

--- a/src/pages/onboarding/InviteCode.js
+++ b/src/pages/onboarding/InviteCode.js
@@ -37,7 +37,7 @@ export default function InviteCode() {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Invite Code</Heading>
       </Header>

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -169,7 +169,7 @@ export default function LanguagePreferences() {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>What language would&nbsp;you&nbsp;like&nbsp;to&nbsp;learn?</Heading>
       </Header>

--- a/src/pages/onboarding/SelectInterests.js
+++ b/src/pages/onboarding/SelectInterests.js
@@ -27,7 +27,7 @@ export default function SelectInterests() {
   }, []);
 
   return (
-    <PreferencesPage>
+    <PreferencesPage isBackgroundFixed={true}>
       <Header>
         <Heading>What would you like to read&nbsp;about?</Heading>
       </Header>

--- a/src/pages/onboarding/VerifyEmail.js
+++ b/src/pages/onboarding/VerifyEmail.js
@@ -71,7 +71,7 @@ export default function VerifyEmail() {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Verify Your Email</Heading>
       </Header>

--- a/src/pages/onboarding/Welcome.js
+++ b/src/pages/onboarding/Welcome.js
@@ -51,7 +51,7 @@ export default function Welcome() {
   }
 
   return (
-    <PreferencesPage pageWidth={"narrow"}>
+    <PreferencesPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
         <Heading>Welcome to Zeeguu</Heading>
       </Header>


### PR DESCRIPTION
The PreferencesPage shared component previously had fixed positioning, and it made the all the subpages of the Settings page look weird in medium screen size:

<img width="1395" height="1061" alt="image" src="https://github.com/user-attachments/assets/6f30656c-4d48-4356-9fbb-1dca3669ef5c" />

and in mobile view:

<img width="1019" height="833" alt="image" src="https://github.com/user-attachments/assets/3a24cbd8-9bc9-4489-b362-6d7823b160aa" />

This also made all buttons on the sidebar unclickable, because the component with the fixed position was on top of all other elements on the page. The only possible way to leave the setting page was to click the back arrow at the top.

Now the `position` can be set to either `fixed` if `isBackgroundFixed=true`, otherwise it will be `static`.
This should also solve the issue seen on the 2nd image where the topbar isn't fully visible.