### PR TITLE
Fix: rename 'username' to 'name' in account creation API calls (web side, #955)

### DIFF
--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -98,7 +98,6 @@ Zeeguu_API.prototype.logIn = function (email, password, onError, onSuccess) {
       // https://stackoverflow.com/a/45366905/1200070
       response.json().then((data) => {
         if (response.status === 200) {
-          console.log("GOT SESSOIN: " + data);
           this.session = data.session;
           onSuccess(data.session);
           return;

--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -29,7 +29,7 @@ Zeeguu_API.prototype.addUser = function (invite_code, password, userInfo, onSucc
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body:
       `password=${password}&invite_code=${invite_code}` +
-      `&username=${userInfo.name}` +
+      `&name=${userInfo.name}` +
       `&learned_language=${userInfo.learned_language}` +
       `&native_language=${userInfo.native_language}` +
       `&learned_cefr_level=${userInfo.learned_cefr_level}` +
@@ -64,7 +64,7 @@ Zeeguu_API.prototype.addBasicUser = function (invite_code, password, userInfo, o
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body:
-      `password=${password}&invite_code=${invite_code}` + `&username=${userInfo.name}` + `&platform=${getPlatform()}`,
+      `password=${password}&invite_code=${invite_code}` + `&name=${userInfo.name}` + `&platform=${getPlatform()}`,
   })
     .then((response) => {
       if (response.ok) {


### PR DESCRIPTION
## Summary

Fixes the naming inconsistency described in zeeguu/web#955.

The `addUser` and `addBasicUser` API calls were sending the user's display name as the `username` HTTP form parameter. However everywhere else in the stack — the User model, DB column, settings endpoint, and API JSON response — the field is called `name`.

This renames the outgoing form parameter from `username` to `name` in both API calls.

**Must be merged together with the matching API-side PR in zeeguu/api** (also on branch `auto-fix/issue-955-api`).

Closes #955

## Commits

1. **Fix commit** (`d7aea56`): Rename `&username=` → `&name=` in `addUser` and `addBasicUser` in `src/api/accounts.js`.

2. **Cleanup commit** (`4adc798`): Remove leftover debug `console.log("GOT SESSOIN: " + data)` (typo and all) from the `logIn` response handler (boy scout rule).