### PR TITLE
Fix: send session duration in seconds instead of converting to ms (issue #107)

### DIFF
--- a/src/api/exercise_sessions.js
+++ b/src/api/exercise_sessions.js
@@ -21,7 +21,7 @@ Zeeguu_API.prototype.exerciseSessionUpdate = function (
 ) {
   let payload = {
     id: exerciseSessionId,
-    duration: currentDuration * 1000, // the API expects ms
+    duration: currentDuration, // the API expects seconds
   };
 
   // Use beacon to prevent "Failed to fetch" errors when user navigates away
@@ -34,7 +34,7 @@ Zeeguu_API.prototype.exerciseSessionEnd = function (
 ) {
   let payload = {
     id: exerciseSessionId,
-    duration: totalTime * 1000,
+    duration: totalTime, // the API expects seconds
   };
 
   // Use beacon to prevent "Failed to fetch" errors when user navigates away

--- a/src/api/reading_sessions.js
+++ b/src/api/reading_sessions.js
@@ -23,7 +23,7 @@ Zeeguu_API.prototype.readingSessionUpdate = function (
 ) {
   let payload = {
     id: readingSessionId,
-    duration: currentDuration * 1000, //the API expects ms
+    duration: currentDuration, // the API expects seconds
   };
 
   // Use beacon to prevent "Load failed" errors when user navigates away
@@ -36,7 +36,7 @@ Zeeguu_API.prototype.readingSessionEnd = function (
 ) {
   let payload = {
     id: readingSessionId,
-    duration: totalTime * 1000,
+    duration: totalTime, // the API expects seconds
   };
 
   // Use beacon to prevent "Load failed" errors when user navigates away

--- a/src/words/SessionHistory.js
+++ b/src/words/SessionHistory.js
@@ -388,9 +388,9 @@ function formatTime(isoString) {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function formatDurationShort(ms) {
-  if (!ms) return "0 min";
-  const minutes = Math.round(ms / 60000);
+function formatDurationShort(seconds) {
+  if (!seconds) return "0 min";
+  const minutes = Math.round(seconds / 60);
   if (minutes < 60) return `${minutes} min`;
   const hours = Math.floor(minutes / 60);
   const remainingMins = minutes % 60;


### PR DESCRIPTION
## Summary

Part of zeeguu/api#107

The frontend timer (`useSession.js`) already counts in **seconds**. The API functions for reading and exercise sessions were unnecessarily multiplying by 1000 before sending, and the API was storing/returning milliseconds — requiring division by 1000 on display.

This PR removes that round-trip. Requires the corresponding API change in [zeeguu/api#auto-fix/issue-107](https://github.com/zeeguu/api/tree/auto-fix/issue-107).

## Changes (the core fix)

- `src/api/reading_sessions.js`: remove `* 1000` in `readingSessionUpdate` and `readingSessionEnd`; add comment "the API expects seconds"
- `src/api/exercise_sessions.js`: same for exercise session update/end
- `src/words/SessionHistory.js`: update `formatDurationShort(ms)` → `formatDurationShort(seconds)` — the `session_history` API now returns seconds for all session types (reading, exercise, browsing, listening), so the summary component displays correct times

---

To discuss this fix, find this session at https://claude.ai/code