### PR TITLE
Fix: show translation (not repeated word) on MultipleChoiceContext solution

### DIFF
--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -30,7 +30,6 @@ export default function MultipleChoiceContext({
   const [exerciseBookmark, setExerciseBookmark] = useState({ ...bookmarksToStudy[0], isExercise: true });
   const [clickedIndex, setClickedIndex] = useState(null);
   const [clickedOption, setClickedOption] = useState(null);
-  const [wordInContextHeadline, setWordInContextHeadline] = useState(removePunctuation(bookmarksToStudy[0].from));
   const isExerciseOverRef = useShadowRef(isExerciseOver);
 
   useEffect(() => {
@@ -78,7 +77,6 @@ export default function MultipleChoiceContext({
     setClickedOption(index);
     if (selectedChoiceId === exerciseBookmark.id) {
       setClickedIndex(index);
-      setWordInContextHeadline(removePunctuation(exerciseBookmark.to));
       notifyCorrectAnswer(exerciseBookmark);
     } else {
       setClickedIndex(null);
@@ -113,7 +111,9 @@ export default function MultipleChoiceContext({
         {strings.multipleChoiceContextHeadline}
       </div>
 
-      <h1 className="wordInContextHeadline">{wordInContextHeadline}</h1>
+      <h1 className="wordInContextHeadline">
+        {isExerciseOver ? removePunctuation(exerciseBookmark.to) : removePunctuation(exerciseBookmark.from)}
+      </h1>
       <div style={{ visibility: isExerciseOver ? 'visible' : 'hidden' }}>
         {bookmarkProgressBar}
       </div>

--- a/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
+++ b/src/exercises/exerciseTypes/multipleChoiceContext/MultipleChoiceContext.js
@@ -36,11 +36,7 @@ export default function MultipleChoiceContext({
     speech.stopAudio(); // Stop any pending speech from previous exercise
     resetSubSessionTimer();
     setExerciseType(EXERCISE_TYPE);
-    let initExerciseBookmarks = [...bookmarksToStudy];
-    for (let i = 0; i < initExerciseBookmarks.length; i++) {
-      if (i === 0) initExerciseBookmarks[i].isExercise = true;
-      else initExerciseBookmarks[i].isExercise = false;
-    }
+    const initExerciseBookmarks = bookmarksToStudy.map((b, i) => ({ ...b, isExercise: i === 0 }));
     setExerciseBookmarks(shuffle(initExerciseBookmarks));
     // eslint-disable-next-line
   }, []);
@@ -72,7 +68,7 @@ export default function MultipleChoiceContext({
     // eslint-disable-next-line
   }, [reload, bookmarksToStudy]);
 
-  function notifyChoiceSelection(selectedChoiceId, selectedChoiceContext, index, e) {
+  function notifyChoiceSelection(selectedChoiceId, index, e) {
     if (isExerciseOver) return;
     setClickedOption(index);
     if (selectedChoiceId === exerciseBookmark.id) {
@@ -126,7 +122,7 @@ export default function MultipleChoiceContext({
             className={
               clickedOption !== null ? (index === clickedOption ? (option.isExercise ? "correct" : "wrong") : "") : ""
             }
-            onClick={(e) => notifyChoiceSelection(option.id, option.context, index, e)}
+            onClick={(e) => notifyChoiceSelection(option.id, index, e)}
           >
             {option.left_ellipsis && <>...</>}
             <span


### PR DESCRIPTION
## Summary

Closes #999

In the **MultipleChoiceContext** exercise, clicking "Show Solution" showed the learned L2 word twice — once in the headline and once highlighted in the sentence context. The translation was never revealed.

**Root cause:** `wordInContextHeadline` was stored in state, initialized to `exerciseBookmark.from` (the L2 word). It was only updated to `exerciseBookmark.to` (the translation) when the user selected the **correct** answer. When "Show Solution" was clicked, `isExerciseOver` was set to true externally but the headline state never updated.

**Fix:** Remove the stateful headline and replace it with a derived value: show `exerciseBookmark.from` during the exercise, `exerciseBookmark.to` once the exercise is over — regardless of whether the user answered correctly or clicked "Show Solution".

---

## Commits

**Commit 1 — core fix** (`Fix: show translation (not repeated L2 word) on MultipleChoiceContext solution`):
- Remove `wordInContextHeadline` state
- Replace with inline derived expression: `isExerciseOver ? removePunctuation(exerciseBookmark.to) : removePunctuation(exerciseBookmark.from)`
- Remove now-unnecessary `setWordInContextHeadline` call in `notifyChoiceSelection`

**Commit 2 — cleanup** (`Refactor: simplify MultipleChoiceContext (boy scout rule)`):
- Replace 4-line for-loop with a single `.map()` when initialising `isExercise` flags
- Remove unused `selectedChoiceContext` parameter from `notifyChoiceSelection`

---

To discuss this fix or request changes, find this session at:
https://claude.ai/code/session_01XDzZpStH9hhodMUwUpvLSC