### PR TITLE
Fix: null-guard getDailyStreak and topic callbacks

### DIFF
--- a/src/contexts/ProgressContext.js
+++ b/src/contexts/ProgressContext.js
@@ -20,6 +20,7 @@ function ProgressProvider({ children }) {
   useEffect(() => {
     if (!userDetails?.learned_language) return;
     api.getDailyStreak((data) => {
+      if (!data) return;
       setDaysPracticed(data.daily_streak);
     });
   }, [userDetails?.learned_language]);

--- a/src/hooks/useSelectInterest.js
+++ b/src/hooks/useSelectInterest.js
@@ -10,16 +10,16 @@ export default function useSelectInterest(api) {
 
   useEffect(() => {
     api.getAvailableTopics((data) => {
-      setAvailableTopics(data);
+      if (data) setAvailableTopics(data);
     });
 
     api.getSubscribedTopics((data) => {
-      setSubscribedTopics(data);
+      if (data) setSubscribedTopics(data);
     });
 
     //custom interest filters
     api.getSubscribedSearchers((data) => {
-      setSubscribedSearches(data);
+      if (data) setSubscribedSearches(data);
     });
   }, [api]);
 


### PR DESCRIPTION
Fixes two Sentry crashes caused by `_getJSON` calling `callback(null)` on network failure:

| Sentry issue | Location | Error |
|---|---|---|
| ZEEGUU-WEB-BP | `ProgressContext.js` | `null.daily_streak` |
| ZEEGUU-WEB-DN | `useSelectInterest.js` | spread of null topics |

Minimal fix: guard each callback before dereferencing. The long-term solution (global toast on network failure) is tracked in #1006.

Supersedes #1003 (which also fixed `App.js` — already covered by the promise migration in master).

https://claude.ai/code/session_01Gy24MmyjQbi9P2qunHLWhw