### PR TITLE
Report client timezone for local-day streak rollover

### DIFF
--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -12,6 +12,7 @@ import { ExercisesCounterContext } from "./exercises/ExercisesCounterContext";
 
 import useExercisesCounterNotification from "./hooks/useExercisesCounterNotification";
 import useStreakMilestone from "./hooks/useStreakMilestone";
+import useReportTimezone from "./hooks/useReportTimezone";
 import TopBar from "./components/TopBar";
 import { MOBILE_WIDTH } from "./components/MainNav/screenSize";
 
@@ -44,6 +45,7 @@ export default function AppLayout(props) {
   const path = useLocation().pathname;
 
   useStreakMilestone();
+  useReportTimezone();
 
   //Initial state and setter passed to the value prop of the MainNavContext.Provider
   const [mainNavProperties, setMainNavProperties] = useState({

--- a/src/api/userDetails.js
+++ b/src/api/userDetails.js
@@ -5,6 +5,10 @@ Zeeguu_API.prototype.getUserDetails = function () {
   return this._getJSONPromise("get_user_details");
 };
 
+Zeeguu_API.prototype.setUserTimezone = function (timezone) {
+  return this._post(`user_timezone`, qs.stringify({ timezone }));
+};
+
 Zeeguu_API.prototype.getUserLanguages = function (callback) {
   this._getJSON("user_languages", callback);
 };

--- a/src/assorted/LocalStorage.js
+++ b/src/assorted/LocalStorage.js
@@ -35,6 +35,7 @@ const LocalStorage = {
     InviteCode: "invite_code",
     // Keep in sync with index.html inline theme script
     ThemePreference: "zeeguu-theme-preference",
+    ReportedTimezone: "reported_timezone",
   },
 
   userInfo: function () {

--- a/src/hooks/useReportTimezone.js
+++ b/src/hooks/useReportTimezone.js
@@ -32,6 +32,9 @@ export default function useReportTimezone() {
 
     reportIfChanged(api);
 
+    // Native apps stay in memory across backgrounding, so a traveler who
+    // lands and unlocks their phone won't trigger a fresh mount — listen for
+    // resume to catch the tz change. Web gets a new mount on next page load.
     if (Capacitor.getPlatform() === "web") {
       return;
     }

--- a/src/hooks/useReportTimezone.js
+++ b/src/hooks/useReportTimezone.js
@@ -1,0 +1,55 @@
+import { useContext, useEffect } from "react";
+import { Capacitor } from "@capacitor/core";
+import { APIContext } from "../contexts/APIContext";
+
+const STORAGE_KEY = "reported_timezone";
+
+function detectTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
+function reportIfChanged(api) {
+  const tz = detectTimezone();
+  if (!tz) return;
+  if (localStorage.getItem(STORAGE_KEY) === tz) return;
+  api.setUserTimezone(tz)
+    .then(() => localStorage.setItem(STORAGE_KEY, tz))
+    .catch((err) => console.warn("Failed to report timezone:", err));
+}
+
+export default function useReportTimezone() {
+  const api = useContext(APIContext);
+
+  useEffect(() => {
+    if (!api) return;
+
+    reportIfChanged(api);
+
+    if (Capacitor.getPlatform() === "web") {
+      return;
+    }
+    if (!Capacitor.isPluginAvailable("App")) {
+      return;
+    }
+
+    let listenerHandle = null;
+    (async () => {
+      try {
+        const { App } = await import("@capacitor/app");
+        listenerHandle = await App.addListener("appStateChange", ({ isActive }) => {
+          if (isActive) reportIfChanged(api);
+        });
+      } catch (err) {
+        console.warn("Failed to attach appStateChange listener:", err);
+      }
+    })();
+
+    return () => {
+      if (listenerHandle) listenerHandle.remove();
+    };
+  }, [api]);
+}

--- a/src/hooks/useReportTimezone.js
+++ b/src/hooks/useReportTimezone.js
@@ -1,8 +1,8 @@
 import { useContext, useEffect } from "react";
 import { Capacitor } from "@capacitor/core";
+import * as Sentry from "@sentry/react";
 import { APIContext } from "../contexts/APIContext";
-
-const STORAGE_KEY = "reported_timezone";
+import LocalStorage from "../assorted/LocalStorage";
 
 function detectTimezone() {
   try {
@@ -15,10 +15,13 @@ function detectTimezone() {
 function reportIfChanged(api) {
   const tz = detectTimezone();
   if (!tz) return;
-  if (localStorage.getItem(STORAGE_KEY) === tz) return;
+  if (localStorage.getItem(LocalStorage.Keys.ReportedTimezone) === tz) return;
   api.setUserTimezone(tz)
-    .then(() => localStorage.setItem(STORAGE_KEY, tz))
-    .catch((err) => console.warn("Failed to report timezone:", err));
+    .then(() => localStorage.setItem(LocalStorage.Keys.ReportedTimezone, tz))
+    .catch((err) => {
+      Sentry.captureException(err);
+      console.warn("Failed to report timezone:", err);
+    });
 }
 
 export default function useReportTimezone() {
@@ -44,6 +47,7 @@ export default function useReportTimezone() {
           if (isActive) reportIfChanged(api);
         });
       } catch (err) {
+        Sentry.captureException(err);
         console.warn("Failed to attach appStateChange listener:", err);
       }
     })();


### PR DESCRIPTION
## Summary
- Streaks roll over at server midnight today, which is wrong for users far from the server's zone. This wires the client side of the fix.
- New `useReportTimezone` hook detects the device's IANA zone via `Intl.DateTimeFormat().resolvedOptions().timeZone`, posts it to `/user_timezone` only when it differs from the value cached in `localStorage`.
- Runs on mount (in `AppLayout`, behind login) and on Capacitor `appStateChange` so travelers picked up after they unlock the phone post-landing.
- Pairs with api PR: zeeguu/api#531.

## Test plan
- [ ] Open the web app, confirm one `/user_timezone` POST in network tab on first load
- [ ] Reload, confirm no second POST (cached in localStorage)
- [ ] Change system timezone, reload, confirm a new POST goes out
- [ ] On iOS/Android via Capacitor, background → change tz → resume, confirm POST fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)