### PR TITLE
SharedArticleHandler: accept ?upload_id=<id>

### DIFF
--- a/src/api/userArticles.js
+++ b/src/api/userArticles.js
@@ -321,13 +321,7 @@ Zeeguu_API.prototype.removeMLSuggestion = function (
 };
 
 Zeeguu_API.prototype.createArticleUpload = function (payload, callback, onError) {
-  this._post(`/article_upload/create`, qs.stringify(payload), (response) => {
-    try {
-      callback(JSON.parse(response));
-    } catch (e) {
-      if (onError) onError("Failed to parse response");
-    }
-  }, onError);
+  this._post(`/article_upload/create`, qs.stringify(payload), callback, onError, true);
 };
 
 Zeeguu_API.prototype.getArticleUpload = function (uploadId, callback) {
@@ -335,21 +329,15 @@ Zeeguu_API.prototype.getArticleUpload = function (uploadId, callback) {
 };
 
 Zeeguu_API.prototype.promoteArticleUpload = function (uploadId, callback, onError) {
-  this._post(`/article_upload/${uploadId}/promote_to_article`, "", (response) => {
-    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
-  }, onError);
+  this._post(`/article_upload/${uploadId}/promote_to_article`, "", callback, onError, true);
 };
 
 Zeeguu_API.prototype.simplifyArticleUpload = function (uploadId, callback, onError) {
-  this._post(`/article_upload/${uploadId}/simplify`, "", (response) => {
-    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
-  }, onError);
+  this._post(`/article_upload/${uploadId}/simplify`, "", callback, onError, true);
 };
 
 Zeeguu_API.prototype.translateAndAdaptArticleUpload = function (uploadId, callback, onError) {
-  this._post(`/article_upload/${uploadId}/translate_and_adapt`, "", (response) => {
-    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
-  }, onError);
+  this._post(`/article_upload/${uploadId}/translate_and_adapt`, "", callback, onError, true);
 };
 
 Zeeguu_API.prototype.makePersonalCopy = function (articleId, callback) {

--- a/src/api/userArticles.js
+++ b/src/api/userArticles.js
@@ -320,6 +320,38 @@ Zeeguu_API.prototype.removeMLSuggestion = function (
   this._post(`/remove_ml_suggestion`, param, callback);
 };
 
+Zeeguu_API.prototype.createArticleUpload = function (payload, callback, onError) {
+  this._post(`/article_upload/create`, qs.stringify(payload), (response) => {
+    try {
+      callback(JSON.parse(response));
+    } catch (e) {
+      if (onError) onError("Failed to parse response");
+    }
+  }, onError);
+};
+
+Zeeguu_API.prototype.getArticleUpload = function (uploadId, callback) {
+  this._getJSON(`article_upload/${uploadId}`, callback);
+};
+
+Zeeguu_API.prototype.promoteArticleUpload = function (uploadId, callback, onError) {
+  this._post(`/article_upload/${uploadId}/promote_to_article`, "", (response) => {
+    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
+  }, onError);
+};
+
+Zeeguu_API.prototype.simplifyArticleUpload = function (uploadId, callback, onError) {
+  this._post(`/article_upload/${uploadId}/simplify`, "", (response) => {
+    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
+  }, onError);
+};
+
+Zeeguu_API.prototype.translateAndAdaptArticleUpload = function (uploadId, callback, onError) {
+  this._post(`/article_upload/${uploadId}/translate_and_adapt`, "", (response) => {
+    try { callback(JSON.parse(response)); } catch (e) { if (onError) onError(e); }
+  }, onError);
+};
+
 Zeeguu_API.prototype.makePersonalCopy = function (articleId, callback) {
   let param = qs.stringify({ article_id: articleId });
   this._post(`/make_personal_copy`, param, callback);

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -71,14 +71,14 @@ export default function SharedArticleHandler() {
     setStatus("loading");
   };
 
-  const onDerivationError = () => {
+  const onConversionError = () => {
     setStatus("error");
     setErrorMessage("Could not process this article.");
   };
 
-  const runUploadDerivation = (apiFn, noTranslate) => {
+  const runArticleConversion = (apiFn, noTranslate) => {
     beginProcessing();
-    apiFn(uploadId, (result) => navigateToArticle(result.id, noTranslate), onDerivationError);
+    apiFn(uploadId, (result) => navigateToArticle(result.id, noTranslate), onConversionError);
   };
 
   const createAndNavigate = (noTranslate) => {
@@ -89,12 +89,12 @@ export default function SharedArticleHandler() {
         const artinfo = typeof result === "string" ? JSON.parse(result) : result;
         navigateToArticle(artinfo.id, noTranslate);
       },
-      onDerivationError,
+      onConversionError,
     );
   };
 
   const handleTranslateAndAdapt = () => {
-    if (uploadId) return runUploadDerivation(api.translateAndAdaptArticleUpload.bind(api));
+    if (uploadId) return runArticleConversion(api.translateAndAdaptArticleUpload.bind(api));
     beginProcessing();
     api.translateAndAdaptArticle(
       sharedUrl,
@@ -108,7 +108,7 @@ export default function SharedArticleHandler() {
   };
 
   const handleSimplify = () => {
-    if (uploadId) return runUploadDerivation(api.simplifyArticleUpload.bind(api));
+    if (uploadId) return runArticleConversion(api.simplifyArticleUpload.bind(api));
     beginProcessing();
     api.findOrCreateArticle(
       { url: sharedUrl },
@@ -126,17 +126,17 @@ export default function SharedArticleHandler() {
           navigateToArticle(artinfo.id);
         });
       },
-      onDerivationError,
+      onConversionError,
     );
   };
 
   const handleReadOriginal = () => {
-    if (uploadId) return runUploadDerivation(api.promoteArticleUpload.bind(api), true);
+    if (uploadId) return runArticleConversion(api.promoteArticleUpload.bind(api), true);
     createAndNavigate(true);
   };
 
   const handleReadAsIs = () => {
-    if (uploadId) return runUploadDerivation(api.promoteArticleUpload.bind(api), false);
+    if (uploadId) return runArticleConversion(api.promoteArticleUpload.bind(api), false);
     createAndNavigate(false);
   };
 

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -12,6 +12,7 @@ export default function SharedArticleHandler() {
   const history = useHistory();
   const query = useQuery();
   const sharedUrl = query.get("url");
+  const uploadId = query.get("upload_id");
 
   const [status, setStatus] = useState("loading");
   const [errorMessage, setErrorMessage] = useState("");
@@ -19,6 +20,25 @@ export default function SharedArticleHandler() {
   const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
+    if (uploadId) {
+      api.getArticleUpload(
+        uploadId,
+        (upload) => {
+          setArticleDetection({
+            language: upload.language,
+            title: upload.title,
+            url: upload.url,
+          });
+          setStatus("choice");
+        },
+        () => {
+          setStatus("error");
+          setErrorMessage("Could not load the uploaded article.");
+        }
+      );
+      return;
+    }
+
     if (!sharedUrl) {
       setStatus("error");
       setErrorMessage("No URL provided.");
@@ -39,14 +59,19 @@ export default function SharedArticleHandler() {
         );
       }
     );
-  }, [sharedUrl]);
+  }, [sharedUrl, uploadId]);
 
   const navigateToArticle = (id, noTranslate) => {
     const path = "/read/article?id=" + id + (noTranslate ? "&noTranslate=true" : "");
     history.replace(path);
   };
 
-  // Create the article in DB (deferred until user makes a choice)
+  const onDerivationError = () => {
+    setStatus("error");
+    setErrorMessage("Could not process this article.");
+  };
+
+  // URL-based (iOS share) path: create the article in DB on choice.
   const createAndNavigate = (noTranslate) => {
     setIsProcessing(true);
     setStatus("loading");
@@ -56,32 +81,43 @@ export default function SharedArticleHandler() {
         const artinfo = typeof result === "string" ? JSON.parse(result) : result;
         navigateToArticle(artinfo.id, noTranslate);
       },
-      (error) => {
-        setStatus("error");
-        setErrorMessage("Could not process this article.");
-      }
+      onDerivationError,
     );
   };
 
   const handleTranslateAndAdapt = () => {
     setIsProcessing(true);
     setStatus("loading");
+    if (uploadId) {
+      api.translateAndAdaptArticleUpload(
+        uploadId,
+        (result) => navigateToArticle(result.id),
+        onDerivationError,
+      );
+      return;
+    }
     api.translateAndAdaptArticle(
       sharedUrl,
       userDetails.learned_language,
       (result) => navigateToArticle(result.id),
       (error) => {
         console.error("Translation failed:", error);
-        // Fall back to creating original article
         createAndNavigate(false);
       },
     );
   };
 
   const handleSimplify = () => {
-    // Need to create article first, then simplify
     setIsProcessing(true);
     setStatus("loading");
+    if (uploadId) {
+      api.simplifyArticleUpload(
+        uploadId,
+        (result) => navigateToArticle(result.id),
+        onDerivationError,
+      );
+      return;
+    }
     api.findOrCreateArticle(
       { url: sharedUrl },
       (result) => {
@@ -98,18 +134,35 @@ export default function SharedArticleHandler() {
           navigateToArticle(artinfo.id);
         });
       },
-      (error) => {
-        setStatus("error");
-        setErrorMessage("Could not process this article.");
-      }
+      onDerivationError,
     );
   };
 
   const handleReadOriginal = () => {
+    if (uploadId) {
+      setIsProcessing(true);
+      setStatus("loading");
+      api.promoteArticleUpload(
+        uploadId,
+        (artinfo) => navigateToArticle(artinfo.id, true),
+        onDerivationError,
+      );
+      return;
+    }
     createAndNavigate(true);
   };
 
   const handleReadAsIs = () => {
+    if (uploadId) {
+      setIsProcessing(true);
+      setStatus("loading");
+      api.promoteArticleUpload(
+        uploadId,
+        (artinfo) => navigateToArticle(artinfo.id, false),
+        onDerivationError,
+      );
+      return;
+    }
     createAndNavigate(false);
   };
 
@@ -143,7 +196,7 @@ export default function SharedArticleHandler() {
         <h2>Could not open article</h2>
         <p>{errorMessage}</p>
         <p style={{ color: "#666", fontSize: "0.9em", wordBreak: "break-all" }}>
-          {sharedUrl}
+          {sharedUrl || (uploadId && `upload #${uploadId}`)}
         </p>
         <button
           onClick={() => history.push("/articles")}

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -66,15 +66,23 @@ export default function SharedArticleHandler() {
     history.replace(path);
   };
 
+  const beginProcessing = () => {
+    setIsProcessing(true);
+    setStatus("loading");
+  };
+
   const onDerivationError = () => {
     setStatus("error");
     setErrorMessage("Could not process this article.");
   };
 
-  // URL-based (iOS share) path: create the article in DB on choice.
+  const runUploadDerivation = (apiFn, noTranslate) => {
+    beginProcessing();
+    apiFn(uploadId, (result) => navigateToArticle(result.id, noTranslate), onDerivationError);
+  };
+
   const createAndNavigate = (noTranslate) => {
-    setIsProcessing(true);
-    setStatus("loading");
+    beginProcessing();
     api.findOrCreateArticle(
       { url: sharedUrl },
       (result) => {
@@ -86,16 +94,8 @@ export default function SharedArticleHandler() {
   };
 
   const handleTranslateAndAdapt = () => {
-    setIsProcessing(true);
-    setStatus("loading");
-    if (uploadId) {
-      api.translateAndAdaptArticleUpload(
-        uploadId,
-        (result) => navigateToArticle(result.id),
-        onDerivationError,
-      );
-      return;
-    }
+    if (uploadId) return runUploadDerivation(api.translateAndAdaptArticleUpload.bind(api));
+    beginProcessing();
     api.translateAndAdaptArticle(
       sharedUrl,
       userDetails.learned_language,
@@ -108,16 +108,8 @@ export default function SharedArticleHandler() {
   };
 
   const handleSimplify = () => {
-    setIsProcessing(true);
-    setStatus("loading");
-    if (uploadId) {
-      api.simplifyArticleUpload(
-        uploadId,
-        (result) => navigateToArticle(result.id),
-        onDerivationError,
-      );
-      return;
-    }
+    if (uploadId) return runUploadDerivation(api.simplifyArticleUpload.bind(api));
+    beginProcessing();
     api.findOrCreateArticle(
       { url: sharedUrl },
       (result) => {
@@ -139,30 +131,12 @@ export default function SharedArticleHandler() {
   };
 
   const handleReadOriginal = () => {
-    if (uploadId) {
-      setIsProcessing(true);
-      setStatus("loading");
-      api.promoteArticleUpload(
-        uploadId,
-        (artinfo) => navigateToArticle(artinfo.id, true),
-        onDerivationError,
-      );
-      return;
-    }
+    if (uploadId) return runUploadDerivation(api.promoteArticleUpload.bind(api), true);
     createAndNavigate(true);
   };
 
   const handleReadAsIs = () => {
-    if (uploadId) {
-      setIsProcessing(true);
-      setStatus("loading");
-      api.promoteArticleUpload(
-        uploadId,
-        (artinfo) => navigateToArticle(artinfo.id, false),
-        onDerivationError,
-      );
-      return;
-    }
+    if (uploadId) return runUploadDerivation(api.promoteArticleUpload.bind(api), false);
     createAndNavigate(false);
   };
 
@@ -196,7 +170,7 @@ export default function SharedArticleHandler() {
         <h2>Could not open article</h2>
         <p>{errorMessage}</p>
         <p style={{ color: "#666", fontSize: "0.9em", wordBreak: "break-all" }}>
-          {sharedUrl || (uploadId && `upload #${uploadId}`)}
+          {sharedUrl || (uploadId ? `upload #${uploadId}` : null)}
         </p>
         <button
           onClick={() => history.push("/articles")}


### PR DESCRIPTION
## Summary
- \`SharedArticleHandler\` now branches on \`?upload_id=<id>\`: calls \`GET /article_upload/<id>\` for language/title, then routes the four choice-modal outcomes to the new upload-derivation endpoints
- Adds API client wrappers: \`createArticleUpload\`, \`getArticleUpload\`, \`promoteArticleUpload\`, \`simplifyArticleUpload\`, \`translateAndAdaptArticleUpload\`
- The existing \`?url=<url>\` path (iOS share) is untouched

Companion to [zeeguu/api#537](https://github.com/zeeguu/api/pull/537). **Merge the api PR first** — this depends on the new endpoints.

The extension rewrite that actually generates \`upload_id\` values is a follow-up PR.

## Test plan
- [ ] Manually navigate to \`/shared-article?upload_id=<id>\` (after creating an upload via the api PR) — choice modal renders with correct language/title
- [ ] Each choice (Simplify / Translate & Adapt / Read Original / Read As-Is) navigates to the reader with the derived article
- [ ] \`?url=<url>\` flow still works (regression)