### PR TITLE
Polish: ChoiceModal copy, loading-report delay, dark-mode title color

### DIFF
--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -88,7 +88,7 @@ const TitleContainer = styled.div`
 
 const Title = styled.div`
   font-size: 1.4em;
-  color: ${zeeguuDarkOrange};
+  color: var(--title-color);
   padding-right: 0.3em;
   font-weight: 500;
   display: block;

--- a/src/components/modal_shared/ChoiceModal.js
+++ b/src/components/modal_shared/ChoiceModal.js
@@ -7,10 +7,11 @@ const Content = styled.div`
   padding: 0.5em 0;
 `;
 
-const Subtitle = styled.p`
-  color: var(--text-muted, #666);
-  margin-bottom: 1.5em;
-  font-size: 0.95rem;
+const Message = styled.p`
+  color: var(--text-primary, #222);
+  margin: 0.5em 0 2.5em 0;
+  font-size: 1.15rem;
+  line-height: 1.5;
 `;
 
 const ButtonStack = styled.div`
@@ -63,12 +64,11 @@ const Spinner = styled.span`
 `;
 
 /**
- * A reusable modal with a title, subtitle, and two action buttons.
+ * A reusable modal with a single message and two action buttons.
  * The `primaryFirst` prop controls which button gets the filled style.
  */
 export default function ChoiceModal({
-  title,
-  subtitle,
+  message,
   primaryLabel,
   secondaryLabel,
   onPrimary,
@@ -80,8 +80,7 @@ export default function ChoiceModal({
   return (
     <Modal open={true} onClose={onSecondary}>
       <Content>
-        <h3>{title}</h3>
-        <Subtitle>{subtitle}</Subtitle>
+        <Message>{message}</Message>
         <ButtonStack>
           <ActionButton
             $primary={primaryFirst}

--- a/src/hooks/useGuardedLanguageSwitch.js
+++ b/src/hooks/useGuardedLanguageSwitch.js
@@ -73,8 +73,7 @@ export default function useGuardedLanguageSwitch() {
 
   const confirmModal = pending ? (
     <ChoiceModal
-      title="Switch language?"
-      subtitle={`Your current article will be saved for later, and you'll be taken to your ${targetLanguageName} home.`}
+      message={`Switch to ${targetLanguageName}? Your current article will be saved for later, and you'll be taken to your ${targetLanguageName} home.`}
       primaryLabel="Switch"
       secondaryLabel="Keep reading"
       onPrimary={handleConfirm}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,8 @@
   --feedback-banner-border: #81d1f6;
   --feedback-banner-hover: linear-gradient(135deg, #b3e5fc, #81d4fa);
 
+  --title-color: #9c7130;
+
   --action-btn-text: #8b5f28;
   --action-btn-bg: #fff5e6;
   --action-btn-hover-bg: #f0e6cc;
@@ -87,6 +89,8 @@
   --feedback-banner-text: #81d4fa;
   --feedback-banner-border: #2a3555;
   --feedback-banner-hover: linear-gradient(135deg, #1e2d4a, #253555);
+
+  --title-color: #ffbb54;
 
   --action-btn-text: #ffcc66;
   --action-btn-bg: #2a2540;

--- a/src/reader/ArticleLanguageModal.js
+++ b/src/reader/ArticleLanguageModal.js
@@ -16,13 +16,12 @@ export default function ArticleLanguageModal({
   isLoading,
 }) {
   const isSameLanguage = articleLanguage === learnedLanguage;
-  const titleLine = `This article is in ${langName(articleLanguage)}`;
+  const articleLangName = langName(articleLanguage);
 
   if (isSameLanguage) {
     return (
       <ChoiceModal
-        title={titleLine}
-        subtitle="Would you like it simplified to your level?"
+        message={`This article is in ${articleLangName}. Do you want it simplified?`}
         primaryLabel="Simplify to my level"
         secondaryLabel="Read without simplification"
         loadingLabel="Simplifying..."
@@ -36,8 +35,7 @@ export default function ArticleLanguageModal({
 
   return (
     <ChoiceModal
-      title={titleLine}
-      subtitle={`You're learning ${langName(learnedLanguage)}`}
+      message={`This article is in ${articleLangName}. You're learning ${langName(learnedLanguage)}.`}
       primaryLabel={`Translate & adapt to ${langName(learnedLanguage)} at my level`}
       secondaryLabel="Read original"
       loadingLabel="Translating..."

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -143,7 +143,9 @@ export default function SharedArticleHandler() {
   if (status === "loading") {
     return (
       <div style={{ textAlign: "center", padding: "4em 2em" }}>
-        <LoadingAnimation />
+        {/* Simplification / translation routinely take 15-25s — hold back the
+            "Report Issue" affordance so users don't think something's broken. */}
+        <LoadingAnimation reportIssueDelay={30000} />
         <p>{isProcessing ? "Preparing article..." : "Opening article..."}</p>
       </div>
     );


### PR DESCRIPTION
## Summary

Three small UI fixes triggered by live testing the new upload flow:

1. **\`ChoiceModal\` copy.** Merge the muted subtitle into a single prominent message so the language-choice modal reads naturally: "This article is in Italian. Do you want it simplified?" — with more breathing room before the buttons. \`ChoiceModal\` drops \`title\`/\`subtitle\` for a single \`message\` prop; call sites updated (\`ArticleLanguageModal\`, \`useGuardedLanguageSwitch\`).

2. **Report Issue delay on \`SharedArticleHandler\`.** The "Preparing article…" loading screen was showing Report Issue after 5s — but simplify / translate routinely take 15-25s. Bumped to 30s so users don't mistake normal LLM latency for a bug.

3. **Article title color.** The preview title was hardcoded to \`zeeguuDarkOrange\` (\`#9c7130\`), muddy-brown in dark mode. Switched to a new \`--title-color\` CSS variable: light unchanged, dark uses \`#ffbb54\` (\`zeeguuOrange\` — readable).

## Test plan
- [ ] Open any article preview in both light + dark modes — title reads clearly in both
- [ ] Trigger the article-language modal — single clean message, more space above buttons
- [ ] Simplify a long article — Report Issue does not appear in the first 30s
- [ ] Use the \`useGuardedLanguageSwitch\` flow (language switcher while reading) — modal still works with the new \`message\` shape