### PR TITLE
Revert "Fix/input validation profile"

### DIFF
--- a/src/friends/Friends.js
+++ b/src/friends/Friends.js
@@ -81,12 +81,7 @@ export default function Friends({ friendUsername, navigationHandler }) {
   }, [pendingSearch, api]);
 
   const handlePendingSearchChange = (isEnterSearch) => {
-    // Remove unsupported characters and trim whitespace for better search results and to prevent errors
-    // The name and email column in the backend only support utf8_bin collation.
-    // The pendingSearch still allows users to type unsupported characters, but they are stripped out before searching. 
-    // REGEX matches characters in the Unicode range U+10000 to U+10FFFF, which includes emoji and many rare characters.
-    // The 'u' flag enables Unicode mode, 'g' flag enables global search to replace all occurrences.
-    const query = pendingSearch.replace(/[\u{10000}-\u{10FFFF}]/gu, "").trim();
+    const query = pendingSearch.trim();
 
     if (query.length < 2 && !isEnterSearch) {
       setSearchResults([]);

--- a/src/pages/LogIn.js
+++ b/src/pages/LogIn.js
@@ -8,7 +8,6 @@ import LocalStorage from "../assorted/LocalStorage";
 import {
   NonEmptyValidator,
   EmailValidator,
-  Utf8Mb3Validator
 } from "../utils/ValidatorRule/Validator";
 import validateRules from "../assorted/validateRules";
 import strings from "../i18n/definitions";

--- a/src/pages/LogIn.js
+++ b/src/pages/LogIn.js
@@ -32,7 +32,6 @@ export default function LogIn({ handleSuccessfulLogIn }) {
     useFormField("", [
       NonEmptyValidator("Please provide an email."),
       EmailValidator,
-      Utf8Mb3Validator(),
     ]);
   const [
     password,

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -19,7 +19,7 @@ import BackArrow from "./settings_pages_shared/BackArrow";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
 import LoadingAnimation from "../../components/LoadingAnimation";
 import useFormField from "../../hooks/useFormField";
-import { EmailValidator, NonEmptyOrWhitespaceOnlyValidator, Utf8Mb3Validator } from "../../utils/ValidatorRule/Validator";
+import { EmailValidator, NonEmptyOrWhitespaceOnlyValidator } from "../../utils/ValidatorRule/Validator";
 import validateRules from "../../assorted/validateRules";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import FullWidthConfirmMsg from "../../components/FullWidthConfirmMsg.sc";
@@ -59,21 +59,15 @@ export default function ProfileDetails() {
 
   const [displayName, setDisplayName, validateDisplayName, isDisplayNameValid, displayNameErrorMessage] = useFormField(
     "",
-    [
-      NonEmptyOrWhitespaceOnlyValidator("Please provide a display name."),
-      Utf8Mb3Validator(),
-    ],
+    NonEmptyOrWhitespaceOnlyValidator("Please provide a display name."),
   );
   const [username, setUsername, validateUsername, isUsernameValid, usernameErrorMessage] = useFormField(
-    "", [
-      NonEmptyOrWhitespaceOnlyValidator("Please provide a username."),
-      Utf8Mb3Validator(),
-    ]
+    "",
+    NonEmptyOrWhitespaceOnlyValidator("Please provide a username."),
   );
   const [email, setEmail, validateEmail, isEmailValid, emailErrorMessage] = useFormField("", [
     NonEmptyOrWhitespaceOnlyValidator("Please provide an email."),
     EmailValidator,
-    Utf8Mb3Validator(),
   ]);
 
   useEffect(() => {

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -11,7 +11,6 @@ import {
   EmailValidator,
   MinimumLengthValidator,
   NonEmptyValidator,
-  Utf8Mb3Validator,
   Validator,
 } from "../../utils/ValidatorRule/Validator";
 import { setTitle } from "../../assorted/setTitle";
@@ -47,12 +46,10 @@ export default function CreateAccount({ handleSuccessfulLogIn }) {
 
   const [name, setName, validateName, isNameValid, nameMsg] = useFormField("", [
     NonEmptyValidator("Please enter a name."),
-    Utf8Mb3Validator(),
   ]);
   const [email, setEmail, validateEmail, isEmailValid, emailMsg] = useFormField("", [
     NonEmptyValidator("Please enter an e-mail."),
     EmailValidator,
-    Utf8Mb3Validator(),
   ]);
   const [password, setPassword, validatePassword, isPasswordValid, passwordMsg] = useFormField("", [
     NonEmptyValidator("Please enter a password."),

--- a/src/utils/ValidatorRule/Validator.js
+++ b/src/utils/ValidatorRule/Validator.js
@@ -44,14 +44,6 @@ function MinimumLengthValidator(n_chars, msg) {
   }, msg);
 }
 
-// MySQL utf8 (utf8mb3) only supports Unicode up to U+FFFF.
-// Characters beyond that (e.g. emoji, rare scripts) require utf8mb4.
-function Utf8Mb3Validator(msg = "Unsupported characters detected. Please remove any emoji or special symbols.") {
-  return new Validator((value) => {
-    return !/[\u{10000}-\u{10FFFF}]/u.test(value);
-  }, msg);
-}
-
 function validateMultipleRules(value, ValidatorRuleList, setErrorMsg) {
   let isValid = true;
   for (let i = 0; i < ValidatorRuleList.length; i++) {
@@ -72,7 +64,6 @@ export {
   NonEmptyValidator,
   NonEmptyOrWhitespaceOnlyValidator,
   MinimumLengthValidator,
-  Utf8Mb3Validator,
   validateMultipleRules,
   PositiveIntegerValidator,
 };


### PR DESCRIPTION
Reverts zeeguu/web#1032

After the `name` and `email` column have been updated/migrated to `utf8mb4_unicode_ci`. This is no longer a problem and is therefore not needed