### PR TITLE
App Store screenshot generation tooling

### DIFF
--- a/ios/App/appstore-screenshots/copy-to-fastlane.js
+++ b/ios/App/appstore-screenshots/copy-to-fastlane.js
@@ -7,7 +7,7 @@ const fastlaneDir = path.join(__dirname, '..', 'fastlane', 'screenshots', 'en-US
 // Find all iPhone screenshots in output folder
 const files = fs.readdirSync(outputDir);
 const iphoneScreenshots = files
-  .filter(f => f.match(/^screenshot\d+-iphone\.png$/))
+  .filter(f => f.match(/^screenshot-iphone-\d+\.png$/))
   .sort((a, b) => {
     const numA = parseInt(a.match(/\d+/)[0]);
     const numB = parseInt(b.match(/\d+/)[0]);
@@ -34,7 +34,7 @@ for (const iphoneFile of iphoneScreenshots) {
   fs.copyFileSync(iphoneSrc, iphoneDst);
   console.log(`Copied: ${iphoneFile} -> ${idx}_APP_IPHONE_65_${idx}.png`);
 
-  const ipadFile = iphoneFile.replace('-iphone', '-ipad');
+  const ipadFile = iphoneFile.replace('-iphone-', '-ipad-');
   const ipadSrc = path.join(outputDir, ipadFile);
   const ipadDst = path.join(fastlaneDir, `${idx}_APP_IPAD_PRO_3GEN_129_${idx}.png`);
   if (fs.existsSync(ipadSrc)) {

--- a/ios/App/appstore-screenshots/fixtures/mock-data.js
+++ b/ios/App/appstore-screenshots/fixtures/mock-data.js
@@ -66,6 +66,7 @@ const USER_DETAILS = {
 
 const USER_PREFERENCES = {
   audio_exercises: "true",
+  filter_disturbing_content: "true",
 };
 
 const SYSTEM_LANGUAGES = {
@@ -427,19 +428,20 @@ const NEXT_IN_LEARNING = [
 const TODAYS_LESSON = {
   lesson_id: 42,
   audio_url: "https://api.zeeguu.org/audio/daily_lessons/42.mp3",
-  duration_seconds: 285,
+  duration_seconds: 351,
   created_at: new Date().toISOString(),
+  title: "Marco e Anna parlano delle bevande",
   words: [
     makeBookmark(101, "pelle luminosa", "glowing skin", "Ha benefici per la pelle luminosa."),
     makeBookmark(104, "ortica", "nettle", "L'ortica è una pianta medicinale."),
     makeBookmark(108, "sapore", "taste", "Il sapore è dolce e fresco."),
   ],
-  pause_position_seconds: 0,
+  pause_position_seconds: 351,
   is_paused: false,
-  is_completed: false,
-  listened_count: 0,
-  canonical_suggestion: null,
-  lesson_type: "three_words_lesson",
+  is_completed: true,
+  listened_count: 1,
+  canonical_suggestion: "bevande naturali",
+  lesson_type: "topic",
 };
 
 const PAST_LESSONS = {
@@ -488,6 +490,40 @@ const PAST_LESSONS = {
   pagination: { total: 2, limit: 20, offset: 0, has_more: false },
 };
 
+// ─── Interests / Topics picker ─────────────────────────────────
+
+const SUBSCRIBED_TOPICS = [
+  { id: 2, title: "Health & Society" },
+  { id: 5, title: "Technology & Science" },
+];
+
+const AVAILABLE_TOPICS = [
+  { id: 1, title: "Arts" },
+  { id: 3, title: "Business" },
+  { id: 4, title: "Culture" },
+  { id: 6, title: "Environment" },
+  { id: 7, title: "Sports" },
+  { id: 8, title: "Food & Cooking" },
+  { id: 9, title: "Politics" },
+  { id: 10, title: "Travel" },
+];
+
+// ─── Filters page ──────────────────────────────────────────────
+
+const FILTERED_SEARCHES = [
+  { id: 71, search: "trump" },
+  { id: 72, search: "bitcoin" },
+];
+
+// ─── Share / Simplify prompt ───────────────────────────────────
+
+const DETECT_ARTICLE_INFO = {
+  language: "it",
+  title: "Nordic latte, la bevanda svedese detox per una pelle luminosa",
+  url: "https://vogue.it/article/nordic-latte",
+  img_url: `https://${FIXTURE_IMAGE_HOST}/article1-nordic-latte.jpg`,
+};
+
 // ─── Route matching ────────────────────────────────────────────
 
 function getResponse(url, method) {
@@ -533,6 +569,15 @@ function getResponse(url, method) {
   if (route === "user_words_next_in_learning") return NEXT_IN_LEARNING;
   if (route.startsWith("bookmarks_next_in_learning")) return NEXT_IN_LEARNING;
   if (route === "total_learned_bookmarks") return 47;
+
+  // ── Interests / Filters ──
+  if (route === "available_topics") return AVAILABLE_TOPICS;
+  if (route === "subscribed_topics") return SUBSCRIBED_TOPICS;
+  if (route === "subscribed_searches") return [];
+  if (route === "filtered_searches") return FILTERED_SEARCHES;
+
+  // ── Share / Simplify prompt ──
+  if (route === "detect_article_info") return DETECT_ARTICLE_INFO;
 
   // ── Daily Audio ──
   if (route === "get_todays_lesson") return TODAYS_LESSON;

--- a/ios/App/appstore-screenshots/render-live.js
+++ b/ios/App/appstore-screenshots/render-live.js
@@ -5,8 +5,10 @@
  * Produces deterministic screenshots at iPhone and iPad sizes.
  *
  * Usage:
- *   node render-live.js
- *   BASE_URL=http://localhost:5173 node render-live.js   # use local dev server
+ *   node render-live.js                   # render all 9 live screens (localhost:3000)
+ *   node render-live.js 8 9               # only screenshots 08 and 09
+ *   node render-live.js 5-7               # range 05..07
+ *   BASE_URL=https://www.zeeguu.org node render-live.js   # use production
  */
 
 const puppeteer = require("puppeteer");
@@ -14,7 +16,7 @@ const path = require("path");
 const fs = require("fs");
 const { getResponse, FIXTURE_IMAGE_HOST } = require("./fixtures/mock-data");
 
-const BASE_URL = process.env.BASE_URL || "https://www.zeeguu.org";
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
 // Apple required screenshot sizes
 // CSS px × deviceScaleFactor = actual pixel dimensions
@@ -25,28 +27,50 @@ const devices = [
   { name: "android-tablet", width: 600, height: 960, scale: 2 },  // → 1200×1920
 ];
 
-// Final ordering (interleaved with marketing screenshots from render.js):
-//  1. Marketing: "Follow topics you love"       (screenshot1.html)
-//  2. Live: Articles feed                       ← screenshot02
-//  3. Marketing: "Read at your own level"       (screenshot2.html)
-//  4. Live: Article reader                      ← screenshot04
-//  5. Marketing: "Practice words you looked up" (screenshot4.html)
-//  6. Live: Match exercise                      ← screenshot06
-//  7. Live: Multiple choice exercise            ← screenshot07
-//  8. Marketing: "Listen to audio lessons"      (screenshot5.html)
-//  9. Live: Daily audio                         ← screenshot09
-// 10. Marketing: "Start now!"                   (screenshot6.html)
+// Final ordering (slot 10 is the "Start now!" marketing slide from render.js):
+//  1. Live: Topics / Interests picker  ← screenshot01
+//  2. Live: Filters                    ← screenshot02
+//  3. Live: Articles feed              ← screenshot03
+//  4. Live: Simplify prompt            ← screenshot04
+//  5. Live: Article reader             ← screenshot05
+//  6. Live: Match exercise             ← screenshot06
+//  7. Live: Multiple choice exercise   ← screenshot07
+//  8. Live: Daily audio — generate     ← screenshot08
+//  9. Live: Daily audio — lesson ready ← screenshot09
+// 10. Marketing: "Start now!"          (screenshot6.html via render.js)
 const screens = [
-  { name: "screenshot02", path: "/articles", wait: 5000 },
-  { name: "screenshot04", path: "/read/article?id=1", wait: 6000 },
+  { name: "screenshot01", path: "/account_settings/interests?fromArticles=1", wait: 3000 },
+  { name: "screenshot02", path: "/account_settings/filters?fromArticles=1", wait: 3000 },
+  { name: "screenshot03", path: "/articles", wait: 5000 },
+  {
+    name: "screenshot04",
+    path: "/shared-article?url=https%3A%2F%2Fvogue.it%2Farticle%2Fnordic-latte",
+    wait: 4000,
+  },
+  { name: "screenshot05", path: "/read/article?id=1", wait: 6000 },
   { name: "screenshot06", path: "/exercise/Match/101,102,103", wait: 5000 },
   { name: "screenshot07", path: "/exercise/MultipleChoiceL2toL1/101,102,103", wait: 5000 },
+  {
+    name: "screenshot08",
+    path: "/daily-audio",
+    wait: 4000,
+    mockOverrides: { get_todays_lesson: { lesson: null } },
+    preLoad: async (page) => {
+      await page.evaluateOnNewDocument(() => {
+        localStorage.setItem("audio_lesson_lesson_type_it", "topic");
+        localStorage.setItem(
+          "audio_lesson_suggestion_topic_it",
+          "bevande naturali",
+        );
+      });
+    },
+  },
   { name: "screenshot09", path: "/daily-audio", wait: 5000 },
 ];
 
 const FIXTURE_IMAGES_DIR = path.join(__dirname, "fixtures", "images");
 
-function setupRequestInterception(page) {
+function setupRequestInterception(page, overrides = {}) {
   page.on("request", (request) => {
     const url = request.url();
 
@@ -94,6 +118,27 @@ function setupRequestInterception(page) {
         return;
       }
 
+      // Per-screen overrides take precedence over the shared mock fixture.
+      const routeMatch = url.match(/api\.zeeguu\.org\/+([^?]*)/);
+      const route = routeMatch ? routeMatch[1].replace(/^\/+/, "") : null;
+      if (route && Object.prototype.hasOwnProperty.call(overrides, route)) {
+        const override = overrides[route];
+        const isString = typeof override === "string";
+        request
+          .respond({
+            status: 200,
+            headers: {
+              "Access-Control-Allow-Origin": "*",
+              "Content-Type": isString
+                ? "text/plain; charset=utf-8"
+                : "application/json; charset=utf-8",
+            },
+            body: isString ? override : JSON.stringify(override),
+          })
+          .catch(() => {});
+        return;
+      }
+
       const response = getResponse(url, request.method());
       if (response !== null) {
         const isString = typeof response === "string";
@@ -130,9 +175,34 @@ function setupRequestInterception(page) {
   });
 }
 
+// Parse CLI args like `8`, `8 9`, `5-7` into a set of zero-padded screen numbers.
+// Empty set means "render all".
+function parseScreenFilter(argv) {
+  const selected = new Set();
+  for (const arg of argv) {
+    const range = arg.match(/^(\d+)-(\d+)$/);
+    if (range) {
+      const [lo, hi] = [parseInt(range[1]), parseInt(range[2])].sort((a, b) => a - b);
+      for (let i = lo; i <= hi; i++) selected.add(String(i).padStart(2, "0"));
+    } else if (/^\d+$/.test(arg)) {
+      selected.add(arg.padStart(2, "0"));
+    }
+  }
+  return selected;
+}
+
 async function renderScreenshots() {
   const outputDir = path.join(__dirname, "output");
   if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+
+  const selected = parseScreenFilter(process.argv.slice(2));
+  const activeScreens = selected.size
+    ? screens.filter((s) => selected.has(s.name.replace(/^screenshot/, "")))
+    : screens;
+  if (selected.size && !activeScreens.length) {
+    console.error(`No screens matched filter: ${[...selected].join(", ")}`);
+    process.exit(1);
+  }
 
   const browser = await puppeteer.launch({
     headless: "new",
@@ -140,8 +210,9 @@ async function renderScreenshots() {
   });
 
   for (const device of devices) {
-    for (const screen of screens) {
-      const label = `${screen.name}-${device.name}`;
+    for (const screen of activeScreens) {
+      const num = screen.name.replace(/^screenshot/, "");
+      const label = `screenshot-${device.name}-${num}`;
       console.log(`${label}...`);
 
       const page = await browser.newPage();
@@ -158,7 +229,7 @@ async function renderScreenshots() {
       ]);
 
       await page.setRequestInterception(true);
-      setupRequestInterception(page);
+      setupRequestInterception(page, screen.mockOverrides || {});
 
       // Set session cookie so the app thinks we're logged in
       const domain = new URL(BASE_URL).hostname;
@@ -168,6 +239,8 @@ async function renderScreenshots() {
         domain,
         path: "/",
       });
+
+      if (screen.preLoad) await screen.preLoad(page);
 
       try {
         await page.goto(`${BASE_URL}${screen.path}`, {
@@ -182,11 +255,25 @@ async function renderScreenshots() {
         if (screen.path.includes("/exercise/")) {
           await page.evaluate(() => {
             // The IndividualExercise component shows the type name as a small label
-            // Find and hide it (it's a plain text node like "MultipleChoiceL2toL1")
+            // (e.g. "Match", "MultipleChoiceL2toL1"). Match the bare component name
+            // exactly — a prefix match would also hide the instruction text
+            // ("Match each word with its translation").
+            const DEBUG_LABELS = new Set([
+              "Match",
+              "MultipleChoice",
+              "MultipleChoiceContext",
+              "MultipleChoiceL2toL1",
+              "MultipleChoiceAudio",
+              "TranslateL2toL1",
+              "TranslateWhatYouHear",
+              "SpellWhatYouHear",
+              "FindWordInContext",
+              "FindWordInContextCloze",
+              "ClickWordInContext",
+            ]);
             const allElements = document.querySelectorAll("*");
             for (const el of allElements) {
-              if (el.children.length === 0 &&
-                  el.textContent.match(/^(Match|MultipleChoice|Translate|SpellWhat|FindWord|ClickWord)/)) {
+              if (el.children.length === 0 && DEBUG_LABELS.has(el.textContent.trim())) {
                 el.style.display = "none";
               }
             }

--- a/ios/App/appstore-screenshots/render.js
+++ b/ios/App/appstore-screenshots/render.js
@@ -8,18 +8,10 @@ const devices = [
   { name: 'android-tablet', width: 1200, height: 1920 },
 ];
 
-// Marketing screenshots mapped to final ordering positions:
-//  01: "Follow topics you love"
-//  02: "Read at your own level"
-//  05: "Practice words you looked up"
-//  08: "Listen to audio lessons daily"
-//  10: "Start now!"
-// (Live app screenshots fill 03, 04, 06, 07, 09 via render-live.js)
+// Only slot 10 ("Start now!" with language flags) is produced as marketing now;
+// live captures (render-live.js) fill slots 01–09. The other .html templates
+// are kept on disk in case we want to re-enable them later.
 const screenshots = [
-  { file: 'screenshot1.html', position: '01' },
-  { file: 'screenshot2.html', position: '03' },
-  { file: 'screenshot4.html', position: '05' },
-  { file: 'screenshot5.html', position: '08' },
   { file: 'screenshot6.html', position: '10' },
 ];
 
@@ -61,7 +53,7 @@ async function renderScreenshots() {
         document.body.style.transformOrigin = 'top left';
       }, device.width, device.height);
 
-      const outputName = `screenshot${entry.position}-${device.name}.png`;
+      const outputName = `screenshot-${device.name}-${entry.position}.png`;
       await page.screenshot({
         path: path.join(__dirname, 'output', outputName),
         fullPage: false

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dev": "vite",
     "local": "VITE_API_URL='http://localhost:9001' vite",
     "remote": "VITE_API_URL='https://api.zeeguu.org' vite",
+    "screenshots": "cd ios/App/appstore-screenshots && rm -f output/*.png && BASE_URL=${BASE_URL:-http://localhost:3000} node render-live.js && node render.js && node copy-to-fastlane.js",
     "test": "vitest",
     "build": "vite build",
     "build:with-sourcemaps": "vite build --sourcemap && npm run sentry:sourcemaps",


### PR DESCRIPTION
## Summary
- Per-screen mock overrides + preLoad hooks in `render-live.js` so screens needing custom API state (no-lesson-today, localStorage pre-fill) can be rendered deterministically.
- CLI filter: `node render-live.js 8 9` or `5-7` for iterating on a subset.
- Default `BASE_URL` flipped to `localhost:3000` (was production) — the 99% case when iterating. Override with `BASE_URL=https://www.zeeguu.org` at release time.
- `npm run screenshots` orchestrates the full pipeline: clears output, renders 9 live screens + slot-10 marketing, copies to fastlane.
- Output filenames renamed to `screenshot-<device>-<NN>.png` so all iPhones/iPads sort together.
- Mock fixtures for new screens (topics picker, filters page, simplify prompt, daily-audio generate + completed lesson).
- `render.js` trimmed to produce only the slot-10 marketing slide; other `.html` templates kept on disk for future use.

The refreshed App Store PNGs and the UX changes that drove most of these screen choices are in a separate PR (follows).

## Test plan
- [ ] `npm run screenshots` against a local dev server at `localhost:3000` produces 10 PNGs per device in `output/`
- [ ] `node render-live.js 4` renders only screenshot 04
- [ ] `node render-live.js 5-7` renders screenshots 05, 06, 07
- [ ] Fastlane dir ends up with 10 sequentially-numbered iPhone + 10 iPad PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)