### PR TITLE
Add pull-to-refresh to article recommendations list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-loader-spinner": "^4.0.0",
         "react-modal": "^3.14.4",
         "react-router-dom": "^5.2.0",
+        "react-simple-pull-to-refresh": "^1.3.4",
         "react-swipeable": "^7.0.2",
         "react-toastify": "^9.1.3",
         "react-youtube": "^10.1.0",
@@ -10544,6 +10545,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-simple-pull-to-refresh": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/react-simple-pull-to-refresh/-/react-simple-pull-to-refresh-1.3.4.tgz",
+      "integrity": "sha512-PCSkKLK1bvSakc/LNQTk3JGJFEVzxWelGupIOn0jl9akh+dx2G/NR1bRXRI7/w5QE/Rz73HiUZ5Fga6j4RT6Dw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.10.2 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.10.2 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-loader-spinner": "^4.0.0",
     "react-modal": "^3.14.4",
     "react-router-dom": "^5.2.0",
+    "react-simple-pull-to-refresh": "^1.3.4",
     "react-swipeable": "^7.0.2",
     "react-toastify": "^9.1.3",
     "react-youtube": "^10.1.0",

--- a/src/articles/ArticleListBrowser.js
+++ b/src/articles/ArticleListBrowser.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import PullToRefresh from "react-simple-pull-to-refresh";
 import ArticlePreview from "./ArticlePreview";
 import SearchField from "./SearchField";
 import * as s from "./ArticleListBrowser.sc";
@@ -124,47 +125,56 @@ export default function ArticleListBrowser({ content, searchQuery, searchPublish
     LocalStorage.setDoNotShowRedirectionModal(doNotShowRedirectionModal_UserPreference);
   }, [doNotShowRedirectionModal_UserPreference]);
 
-  useEffect(() => {
-    resetPagination();
-    setSearchError(false);
-    if (searchQuery) {
-      setTitle(strings.titleSearch + ` '${searchQuery}'`);
-      setReloadingSearchArticles(true);
-      api.search(
-        searchQuery,
-        searchPublishPriority,
-        searchDifficultyPriority,
-        (articles) => {
-          setArticlesAndVideosList(articles);
-          setOriginalList([...articles]);
-          setReloadingSearchArticles(false);
-          articles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
-        },
-        (error) => {
-          setArticlesAndVideosList([]);
-          setOriginalList([]);
-          setReloadingSearchArticles(false);
-          setSearchError(true);
-        },
-      );
-    } else {
-      setTitle(strings.titleHome);
-      // First fetch unfinished articles, then fetch main articles
-      api.getUnfinishedUserReadingSessions((unfinished) => {
-        setUnfinishedArticles(unfinished);
-        api.getUserArticles((articles) => {
-          // Filter out unfinished articles from the main list
-          let filteredArticles = [...articles];
-          for (let i = 0; i < unfinished.length; i++) {
-            filteredArticles = filteredArticles.filter(
-              (article) => article.id !== unfinished[i].id,
-            );
-          }
-          setArticlesAndVideosList(filteredArticles);
-          setOriginalList([...filteredArticles]);
-          filteredArticles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
+  function loadArticles() {
+    return new Promise((resolve) => {
+      resetPagination();
+      setSearchError(false);
+      if (searchQuery) {
+        setTitle(strings.titleSearch + ` '${searchQuery}'`);
+        setReloadingSearchArticles(true);
+        api.search(
+          searchQuery,
+          searchPublishPriority,
+          searchDifficultyPriority,
+          (articles) => {
+            setArticlesAndVideosList(articles);
+            setOriginalList([...articles]);
+            setReloadingSearchArticles(false);
+            articles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
+            resolve();
+          },
+          (error) => {
+            setArticlesAndVideosList([]);
+            setOriginalList([]);
+            setReloadingSearchArticles(false);
+            setSearchError(true);
+            resolve();
+          },
+        );
+      } else {
+        setTitle(strings.titleHome);
+        api.getUnfinishedUserReadingSessions((unfinished) => {
+          setUnfinishedArticles(unfinished);
+          api.getUserArticles((articles) => {
+            let filteredArticles = [...articles];
+            for (let i = 0; i < unfinished.length; i++) {
+              filteredArticles = filteredArticles.filter(
+                (article) => article.id !== unfinished[i].id,
+              );
+            }
+            setArticlesAndVideosList(filteredArticles);
+            setOriginalList([...filteredArticles]);
+            filteredArticles.some((e) => e.video) ? setAreVideosAvailable(true) : setAreVideosAvailable(false);
+            resolve();
+          });
         });
-      });
+      }
+    });
+  }
+
+  useEffect(() => {
+    loadArticles();
+    if (!searchQuery) {
       window.addEventListener("scroll", handleScroll, true);
       return () => {
         window.removeEventListener("scroll", handleScroll, true);
@@ -190,7 +200,8 @@ export default function ArticleListBrowser({ content, searchQuery, searchPublish
   }
 
   return (
-    <>
+    <PullToRefresh onRefresh={loadArticles} pullingContent="">
+      <>
       {!searchQuery && (
         <>
           <UnfinishedArticlesList unfinishedArticles={unfinishedArticles} onArticleHidden={handleArticleHidden} />
@@ -266,6 +277,7 @@ export default function ArticleListBrowser({ content, searchQuery, searchPublish
           There are no more results.
         </div>
       )}
-    </>
+      </>
+    </PullToRefresh>
   );
 }


### PR DESCRIPTION
## Summary
- Adds pull-to-refresh on the article recommendations homepage (and search results) via `react-simple-pull-to-refresh`
- The list-load logic in `ArticleListBrowser.js` is extracted into a `loadArticles()` Promise so both the initial `useEffect` and the refresh gesture share the same path
- Library's `isTreeScrollable` walks DOM ancestors, so the gesture only engages when `#scrollHolder.scrollTop === 0` — no conflict with the existing infinite-scroll pagination

## Test plan
- [ ] Desktop Chrome (devtools Device Mode): at top of list, click-drag down → spinner appears, list refetches
- [ ] iOS Simulator: pull-down gesture from list top triggers refresh
- [ ] Android emulator: pull-down gesture from list top triggers refresh
- [ ] Scroll to middle of list, pull down → does NOT trigger refresh (parent scroll handled first)
- [ ] Scroll to bottom → infinite-scroll pagination still fires
- [ ] Search results page: pull-to-refresh also works and re-runs the search

🤖 Generated with [Claude Code](https://claude.com/claude-code)