### PR TITLE
Gate gamification polling hooks behind the feature flag

### DIFF
--- a/src/hooks/useBadgeCounterNotification.js
+++ b/src/hooks/useBadgeCounterNotification.js
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { APIContext } from "../contexts/APIContext";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
+import Feature from "../features/Feature";
 
 export default function useBadgeCounterNotification() {
   const path = useLocation().pathname;
@@ -10,7 +11,9 @@ export default function useBadgeCounterNotification() {
   const [totalNumberOfBadges, setTotalNumberOfBadges] = useState(0);
 
   useEffect(() => {
+    if (!Feature.has_gamification()) return;
     updateBadgeCounter();
+    // eslint-disable-next-line
   }, [path]);
 
   function updateBadgeCounter() {

--- a/src/hooks/useFriendRequestNotification.js
+++ b/src/hooks/useFriendRequestNotification.js
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { APIContext } from "../contexts/APIContext";
+import Feature from "../features/Feature";
 
 export default function useFriendRequestNotification() {
   const path = useLocation().pathname;
@@ -10,6 +11,7 @@ export default function useFriendRequestNotification() {
   const hasFriendRequestNotification = friendRequestCount > 0;
 
   useEffect(() => {
+    if (!Feature.has_gamification()) return;
     updateFriendRequestCounter();
     // eslint-disable-next-line
   }, [path]);


### PR DESCRIPTION
## Summary
- `useBadgeCounterNotification` and `useFriendRequestNotification` are mounted in `AppLayout`, so their `useEffect` currently fires on every route change for **every** user, whether or not they have the `gamification` feature flag set.
- That silently sent two HTTP calls per navigation (`/badges/count_unseen`, `/get_number_of_received_friend_requests`) for accounts that will never display the result.
- `Feature.has_gamification()` already gates the UI that consumes these counts (`TopBar`, `SideNavProfileOption`), so this PR aligns the data fetch with the render.

## Change
Two tiny diffs — one `if (!Feature.has_gamification()) return;` added at the top of each hook's `useEffect` and the matching import.

No behavior change for gamification users. Non-gamification users stop making the extra requests.

## Test plan
- [ ] Toggle `LocalStorage` `gamification` feature off → confirm no `/badges/count_unseen` or `/get_number_of_received_friend_requests` requests in the Network tab on route change
- [ ] Toggle it on → confirm both requests still fire and the red dot behavior is unchanged

cc @xXPinkmagicXx @gabortodor @klnyzzz33 — flagging ahead of the release tonight so you're aware of the small change sneaking into gamification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)