### PR TITLE
Fix UpgradeAccountModal password validator length (3 → 4)

### DIFF
--- a/src/components/UpgradeAccountModal.js
+++ b/src/components/UpgradeAccountModal.js
@@ -115,7 +115,7 @@ export default function UpgradeAccountModal({ open, onClose, onSuccess, triggerR
 
   const [password, setPassword, validatePassword, isPasswordValid, passwordMsg] = useFormField("", [
     NonEmptyValidator("Please enter a password"),
-    MinimumLengthValidator(3, "Password must be at least 4 characters"),
+    MinimumLengthValidator(4, "Password must be at least 4 characters"),
   ]);
 
   const [confirmPassword, setConfirmPassword] = useState("");


### PR DESCRIPTION
## Summary
`UpgradeAccountModal.js` had `MinimumLengthValidator(3, "Password must be at least 4 characters")` — validator accepts 3-char passwords but the error message promises 4, and the backend (`create_basic_account`) rejects anything `< 4`. Result: a user entering a 3-char password passed client validation and then failed server-side with a confusing generic error.

Looks like a half-edit (the number and the message got out of sync). Bumping the validator back to 4 so the client matches the message matches the server.

## Test plan
- [ ] Enter a 3-char password in the upgrade-account modal → validation fails client-side with "at least 4" message (as expected)
- [ ] Enter a 4-char password → passes validation and the form proceeds

cc @xXPinkmagicXx @gabortodor @klnyzzz33

🤖 Generated with [Claude Code](https://claude.com/claude-code)