### PR TITLE
Show CEFR in the language modal; hide from feed for on-demand cohort

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -227,6 +227,8 @@ export default function ArticlePreview({
     return null;
   }
 
+  const cefrLevel = article.metrics?.cefr_level || article.cefr_level || "B1";
+
   return (
     <s.ArticlePreview
       style={{
@@ -302,14 +304,11 @@ export default function ArticlePreview({
         {!Feature.always_open_externally() && (
           <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
             <img
-              src={getStaticPath(
-                "icons",
-                `${getHighestCefrLevel(article.metrics?.cefr_level || article.cefr_level || "B1")}-level-icon.png`,
-              )}
+              src={getStaticPath("icons", `${getHighestCefrLevel(cefrLevel)}-level-icon.png`)}
               alt="difficulty icon"
               style={{ width: "16px", height: "16px" }}
             />
-            <span>{article.metrics?.cefr_level || article.cefr_level || "B1"}</span>
+            <span>{cefrLevel}</span>
           </div>
         )}
 

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -296,18 +296,22 @@ export default function ArticlePreview({
 
       {/* Metadata row: CEFR level, simplified tag, source */}
       <div style={{ display: "flex", alignItems: "center", marginTop: "15px" }}>
-        {/* Difficulty (CEFR level) */}
-        <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-          <img
-            src={getStaticPath(
-              "icons",
-              `${getHighestCefrLevel(article.metrics?.cefr_level || article.cefr_level || "B1")}-level-icon.png`,
-            )}
-            alt="difficulty icon"
-            style={{ width: "16px", height: "16px" }}
-          />
-          <span>{article.metrics?.cefr_level || article.cefr_level || "B1"}</span>
-        </div>
+        {/* Difficulty (CEFR level) — hidden for the on-demand cohort, where
+            the feed shows originals and the level only matters at the
+            simplify-decision modal. Default users still see it here. */}
+        {!Feature.always_open_externally() && (
+          <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+            <img
+              src={getStaticPath(
+                "icons",
+                `${getHighestCefrLevel(article.metrics?.cefr_level || article.cefr_level || "B1")}-level-icon.png`,
+              )}
+              alt="difficulty icon"
+              style={{ width: "16px", height: "16px" }}
+            />
+            <span>{article.metrics?.cefr_level || article.cefr_level || "B1"}</span>
+          </div>
+        )}
 
         {/* Simplified tag */}
         {article.parent_article_id && (

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -227,7 +227,7 @@ export default function ArticlePreview({
     return null;
   }
 
-  const cefrLevel = article.metrics?.cefr_level || article.cefr_level || "B1";
+  const cefrLevel = article.metrics?.cefr_level || article.cefr_level;
 
   return (
     <s.ArticlePreview
@@ -298,10 +298,11 @@ export default function ArticlePreview({
 
       {/* Metadata row: CEFR level, simplified tag, source */}
       <div style={{ display: "flex", alignItems: "center", marginTop: "15px" }}>
-        {/* Difficulty (CEFR level) — hidden for the on-demand cohort, where
-            the feed shows originals and the level only matters at the
-            simplify-decision modal. Default users still see it here. */}
-        {!Feature.always_open_externally() && (
+        {/* Difficulty (CEFR level) — hidden for the on-demand cohort (feed
+            shows originals; level matters at the simplify-decision modal).
+            Also hidden when we don't actually know the level — better to
+            show nothing than to fake a default. */}
+        {cefrLevel && !Feature.always_open_externally() && (
           <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
             <img
               src={getStaticPath("icons", `${getHighestCefrLevel(cefrLevel)}-level-icon.png`)}

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -16,6 +16,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import DynamicFlagImage from "../DynamicFlagImage.js";
 import LanguageOptionLabel from "./LanguageOptionLabel.js";
 import LocalStorage from "../../assorted/LocalStorage.js";
+import { getUserCefrLevel } from "../../utils/misc/cefrHelpers.js";
 import { saveSharedUserInfo } from "../../utils/cookies/userInfo.js";
 
 const MAX_MODAL_LANGUAGES = 7;
@@ -63,9 +64,7 @@ export default function LanguageModal({ open, setOpen }) {
   }, [open, api, session]);
 
   const getCefrLevelValueForLanguage = (languageCode) => {
-    const cefrKey = languageCode + "_cefr_level";
-    const cefrLevel = userDetails[cefrKey];
-    return cefrLevel?.toString() || "1";
+    return getUserCefrLevel(userDetails, languageCode)?.toString() || "1";
   };
 
   const handleCefrLevelChange = (languageCode, newLevel, e) => {

--- a/src/components/MainNav/SideNav/SideNavLanguageOption.js
+++ b/src/components/MainNav/SideNav/SideNavLanguageOption.js
@@ -6,6 +6,7 @@ import NavOption from "../NavOption";
 import NavIcon from "../NavIcon";
 import navLanguages from "../navLanguages";
 import { CEFR_LEVELS } from "../../../assorted/cefrLevels";
+import { getUserCefrLevel } from "../../../utils/misc/cefrHelpers";
 import LocalStorage from "../../../assorted/LocalStorage";
 import { saveSharedUserInfo } from "../../../utils/cookies/userInfo";
 import styled from "styled-components";
@@ -49,9 +50,7 @@ export default function SideNavLanguageOption({ screenWidth }) {
   }, [userDetails.learned_language]);
 
   const currentCefrLevel = useMemo(() => {
-    const languageCode = userDetails.learned_language;
-    const cefrKey = languageCode + "_cefr_level";
-    const cefrLevel = userDetails[cefrKey];
+    const cefrLevel = getUserCefrLevel(userDetails, userDetails.learned_language);
     const level = CEFR_LEVELS.find(level => level.value === cefrLevel?.toString());
     return level ? level.label.split(' | ')[0] : 'A1';
   }, [userDetails.learned_language, userDetails]);

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -5,6 +5,7 @@ import { APIContext } from "../../contexts/APIContext";
 import { UserContext } from "../../contexts/UserContext";
 import { saveSharedUserInfo } from "../../utils/cookies/userInfo";
 import { CEFR_LEVELS } from "../../assorted/cefrLevels";
+import { getUserCefrLevel } from "../../utils/misc/cefrHelpers";
 import strings from "../../i18n/definitions";
 import LocalStorage from "../../assorted/LocalStorage";
 import LoadingAnimation from "../../components/LoadingAnimation";
@@ -62,9 +63,7 @@ export default function LanguageSettings() {
   const isPageMounted = useRef(true);
 
   function setCEFRLevelFromUserContext(data) {
-    const levelKey = data.learned_language + "_cefr_level";
-    const levelNumber = data[levelKey];
-    setCEFR(levelNumber);
+    setCEFR(getUserCefrLevel(data, data.learned_language));
   }
 
   useEffect(() => {

--- a/src/reader/ArticleLanguageModal.js
+++ b/src/reader/ArticleLanguageModal.js
@@ -8,6 +8,7 @@ function langName(code) {
 export default function ArticleLanguageModal({
   articleTitle,
   articleLanguage,
+  articleCefrLevel,
   articleImage,
   learnedLanguage,
   source,
@@ -19,13 +20,17 @@ export default function ArticleLanguageModal({
 }) {
   const isSameLanguage = articleLanguage === learnedLanguage;
   const articleLangName = langName(articleLanguage);
+  const levelClause = articleCefrLevel ? ` at ${articleCefrLevel} level` : "";
 
   if (isSameLanguage) {
+    const sameLangMessage = articleCefrLevel
+      ? `This article is${levelClause}. Do you want it simplified to your level?`
+      : "Do you want it simplified to your level?";
     return (
       <ChoiceModal
         title={articleTitle}
         heroImage={articleImage}
-        message="Do you want it simplified to your level?"
+        message={sameLangMessage}
         primaryLabel="Simplify"
         secondaryLabel="Read as is"
         loadingLabel="Simplifying..."
@@ -41,7 +46,7 @@ export default function ArticleLanguageModal({
     <ChoiceModal
       title={articleTitle}
       heroImage={articleImage}
-      message={`This article is in ${articleLangName}. Do you want it translated to ${langName(learnedLanguage)} at your level?`}
+      message={`This article is in ${articleLangName}${levelClause}. Do you want it translated to ${langName(learnedLanguage)} at your level?`}
       primaryLabel="Translate"
       secondaryLabel="Read original"
       loadingLabel="Translating..."

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -370,7 +370,7 @@ export default function ArticleReader({ teacherArticleID }) {
       {showLanguageModal && (
         <ArticleLanguageModal
           articleLanguage={articleInfo.language}
-
+          articleCefrLevel={articleInfo.cefr_level}
           learnedLanguage={userDetails.learned_language}
           source={entrySource}
           onTranslateAndAdapt={handleTranslateAndAdapt}

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -30,6 +30,7 @@ import DigitalTimer from "../components/DigitalTimer";
 import DevButton from "../components/DevButton";
 import { APIContext } from "../contexts/APIContext";
 import ArticleLanguageModal from "./ArticleLanguageModal";
+import { shouldShowLanguageChoice } from "../utils/misc/cefrHelpers";
 
 // UMR stands for historical reasons for: Unified Multilingual Reader
 export const WEB_READER = "UMR";
@@ -236,11 +237,16 @@ export default function ArticleReader({ teacherArticleID }) {
       api.setArticleOpened(articleInfo.id);
       api.logUserActivity(api.OPEN_ARTICLE, articleID, "", WEB_READER);
 
-      // Show language modal for deeplinked articles (share is handled in SharedArticleHandler)
+      // Show language modal for deeplinked articles (share is handled in
+      // SharedArticleHandler). Skip when same-language and the article is
+      // already at or below the user's level — simplifying down doesn't help
+      // and the backend rejects it. Cross-language always shows the modal
+      // so the user can opt into translate&adapt.
       if (
         entrySource === "deeplink" &&
         !articleInfo.url?.includes("#translated-from-") &&
-        !teacherArticleID
+        !teacherArticleID &&
+        shouldShowLanguageChoice(articleInfo.language, articleInfo.cefr_level, userDetails)
       ) {
         setShowLanguageModal(true);
       }

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -237,11 +237,8 @@ export default function ArticleReader({ teacherArticleID }) {
       api.setArticleOpened(articleInfo.id);
       api.logUserActivity(api.OPEN_ARTICLE, articleID, "", WEB_READER);
 
-      // Show language modal for deeplinked articles (share is handled in
-      // SharedArticleHandler). Skip when same-language and the article is
-      // already at or below the user's level — simplifying down doesn't help
-      // and the backend rejects it. Cross-language always shows the modal
-      // so the user can opt into translate&adapt.
+      // Deeplinked articles only — share flow is handled in SharedArticleHandler.
+      // Skip modal when simplification wouldn't help — see shouldShowLanguageChoice.
       if (
         entrySource === "deeplink" &&
         !articleInfo.url?.includes("#translated-from-") &&

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -189,6 +189,7 @@ export default function SharedArticleHandler() {
       <ArticleLanguageModal
         articleTitle={articleDetection.title}
         articleLanguage={articleDetection.language}
+        articleCefrLevel={articleDetection.cefr_level}
         articleImage={articleDetection.img_url}
         learnedLanguage={userDetails.learned_language}
         source="share"

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -78,28 +78,18 @@ export default function SharedArticleHandler() {
       sharedUrl,
       (result) => {
         setArticleDetection(result);
-        // Same-language articles already at or below the user's level don't
-        // benefit from simplification — skip the modal and just open the
-        // article as-is. Cross-language articles still get the choice
-        // because translate&adapt is real work regardless of source CEFR.
+        // Skip modal when simplification wouldn't help — see shouldShowLanguageChoice.
         if (shouldShowLanguageChoice(result.language, result.cefr_level, userDetails)) {
           setStatus("choice");
           return;
         }
-        setIsProcessing(true);
-        setProcessingAction("promote");
-        setStatus("loading");
-        api.findOrCreateArticle(
-          { url: sharedUrl },
-          (artinfo) => {
-            const parsed = typeof artinfo === "string" ? JSON.parse(artinfo) : artinfo;
-            history.replace("/read/article?id=" + parsed.id);
-          },
-          () => {
-            setStatus("error");
-            setErrorMessage("Could not process this article.");
-          },
-        );
+        // detect_article_info already created/found the article when it was
+        // cached — short-circuit to avoid a second findOrCreateArticle call.
+        if (result.exists && result.id) {
+          history.replace("/read/article?id=" + result.id);
+          return;
+        }
+        createAndNavigate("promote", false);
       },
       (error) => {
         setStatus("error");

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -6,6 +6,7 @@ import useQuery from "../hooks/useQuery";
 import useTimedProgressMessage from "../hooks/useTimedProgressMessage";
 import LoadingAnimation from "../components/LoadingAnimation";
 import ArticleLanguageModal from "./ArticleLanguageModal";
+import { shouldShowLanguageChoice } from "../utils/misc/cefrHelpers";
 
 const PROGRESS_STAGES = {
   simplify: [
@@ -77,7 +78,28 @@ export default function SharedArticleHandler() {
       sharedUrl,
       (result) => {
         setArticleDetection(result);
-        setStatus("choice");
+        // Same-language articles already at or below the user's level don't
+        // benefit from simplification — skip the modal and just open the
+        // article as-is. Cross-language articles still get the choice
+        // because translate&adapt is real work regardless of source CEFR.
+        if (shouldShowLanguageChoice(result.language, result.cefr_level, userDetails)) {
+          setStatus("choice");
+          return;
+        }
+        setIsProcessing(true);
+        setProcessingAction("promote");
+        setStatus("loading");
+        api.findOrCreateArticle(
+          { url: sharedUrl },
+          (artinfo) => {
+            const parsed = typeof artinfo === "string" ? JSON.parse(artinfo) : artinfo;
+            history.replace("/read/article?id=" + parsed.id);
+          },
+          () => {
+            setStatus("error");
+            setErrorMessage("Could not process this article.");
+          },
+        );
       },
       (error) => {
         setStatus("error");

--- a/src/utils/misc/cefrHelpers.js
+++ b/src/utils/misc/cefrHelpers.js
@@ -8,6 +8,35 @@ const NUMERIC_TO_CEFR = {
   6: "C2",
 };
 
+const CEFR_ORDINAL = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 5, C2: 6 };
+
+/**
+ * Decide whether the language-choice modal is worth showing for an article
+ * the user is about to read.
+ *
+ * Cross-language: always show — translate-and-adapt is real work regardless
+ * of the source CEFR.
+ *
+ * Same-language: only show if the article is strictly harder than the user's
+ * CEFR. If the article is already at or below their level, simplifying it
+ * down doesn't help (and the backend rejects it). When we don't have a
+ * solid level for either side, default to showing the modal — better to ask
+ * than to silently skip an offer.
+ */
+export function shouldShowLanguageChoice(
+  articleLanguage,
+  articleCefrLevel,
+  userDetails,
+) {
+  if (!userDetails) return true;
+  if (articleLanguage !== userDetails.learned_language) return true;
+
+  const userNumeric = userDetails[articleLanguage + "_cefr_level"];
+  const articleOrd = CEFR_ORDINAL[articleCefrLevel];
+  if (!articleOrd || !userNumeric) return true;
+  return articleOrd > Number(userNumeric);
+}
+
 /**
  * Convert numeric CEFR level to string.
  * User settings store levels as 1-6, API expects "A1"-"C2".

--- a/src/utils/misc/cefrHelpers.js
+++ b/src/utils/misc/cefrHelpers.js
@@ -33,8 +33,8 @@ export function shouldShowLanguageChoice(
 
   const userNumeric = userDetails[articleLanguage + "_cefr_level"];
   const articleOrd = CEFR_ORDINAL[articleCefrLevel];
-  if (!articleOrd || !userNumeric) return true;
-  return articleOrd > Number(userNumeric);
+  if (!articleOrd || userNumeric == null) return true;
+  return articleOrd > userNumeric;
 }
 
 /**

--- a/src/utils/misc/cefrHelpers.js
+++ b/src/utils/misc/cefrHelpers.js
@@ -11,6 +11,18 @@ const NUMERIC_TO_CEFR = {
 const CEFR_ORDINAL = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 5, C2: 6 };
 
 /**
+ * Read the user's CEFR level (1-6) for a given language code from the
+ * userDetails object. Returns undefined when the level isn't set.
+ *
+ * userDetails stores per-language CEFR under `<lang>_cefr_level` keys
+ * (e.g. `de_cefr_level`, `en_cefr_level`).
+ */
+export function getUserCefrLevel(userDetails, languageCode) {
+  if (!userDetails || !languageCode) return undefined;
+  return userDetails[languageCode + "_cefr_level"];
+}
+
+/**
  * Decide whether the language-choice modal is worth showing for an article
  * the user is about to read.
  *
@@ -31,7 +43,7 @@ export function shouldShowLanguageChoice(
   if (!userDetails) return true;
   if (articleLanguage !== userDetails.learned_language) return true;
 
-  const userNumeric = userDetails[articleLanguage + "_cefr_level"];
+  const userNumeric = getUserCefrLevel(userDetails, articleLanguage);
   const articleOrd = CEFR_ORDINAL[articleCefrLevel];
   if (!articleOrd || userNumeric == null) return true;
   return articleOrd > userNumeric;


### PR DESCRIPTION
## Summary

Two coordinated UI shifts that move the CEFR signal from the feed card to the simplify-decision modal — where it actually informs a choice. Pairs with [zeeguu/api PR](https://github.com/zeeguu/api/pull/new/feat/cefr-in-language-modal); the API change feeds the `cefr_level` into `ArticleLanguageModal` for share-flow articles.

## Changes

- **`articles/ArticlePreview.js`**: hide the CEFR badge for users with `Feature.always_open_externally()`. For that cohort the feed serves originals and the level isn't actionable from the card. Default users still see the badge — they're on simplified-first feed where the level is descriptive of what they're about to read.
- **`reader/ArticleLanguageModal.js`**: accept `articleCefrLevel` prop and surface it in the message copy ("This article is at C1 level. Do you want it simplified to your level?" / "This article is in German at C1 level. Do you want it translated to English at your level?"). Falls back to the original copy when the level is missing.
- **`reader/ArticleReader.js`**: pass `articleInfo.cefr_level` (already on the response).
- **`reader/SharedArticleHandler.js`**: pass `articleDetection.cefr_level` from the share-flow API response (added in the API PR).

## Test plan

- [ ] As an `always_open_externally` user (e.g. id 4607): the feed cards no longer show the CEFR icon/badge.
- [ ] As a default user: the CEFR icon/badge in the feed card is unchanged.
- [ ] Share an article from Safari → the language modal shows "This article is at <level> level. ..." in the copy.
- [ ] Open an article via deeplink from WhatsApp / chat → same: the level appears in the modal.
- [ ] If the API returns `cefr_level: null`, the modal renders without the level clause (no "at level" awkwardness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)