### PR TITLE
Article preview: image click follows same routing as Open button

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -180,14 +180,16 @@ export default function ArticlePreview({
     }
     if (should_open_with_modal) {
       return (
-        <span
+        <button
+          type="button"
           onClick={() => {
             handleArticleClick();
             handleOpenRedirectionModal();
           }}
+          style={{ background: "none", border: "none", padding: 0, cursor: "pointer" }}
         >
           {img}
-        </span>
+        </button>
       );
     }
     return (

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -159,9 +159,51 @@ export default function ArticlePreview({
     }
   }
 
+  const is_saved = article.has_personal_copy || article.has_uploader || isArticleSaved === true;
+  const externalUrl = article.parent_url || article.url;
+  const should_open_in_zeeguu = Feature.always_open_externally()
+    ? is_saved
+    : article.video ||
+      (!Feature.extension_experiment1() && !hasExtension) ||
+      is_saved ||
+      article.parent_article_id; // Simplified articles (with parent_article_id) always open in Zeeguu reader
+  const should_open_with_modal = doNotShowRedirectionModal_UserPreference === false;
+
+  function imageLink() {
+    const img = <img alt="" src={article.img_url} style={{ cursor: "pointer" }} />;
+    if (should_open_in_zeeguu) {
+      return (
+        <Link to={`/read/article?id=${article.id}`} onClick={handleArticleClick}>
+          {img}
+        </Link>
+      );
+    }
+    if (should_open_with_modal) {
+      return (
+        <span
+          onClick={() => {
+            handleArticleClick();
+            handleOpenRedirectionModal();
+          }}
+        >
+          {img}
+        </span>
+      );
+    }
+    return (
+      <a
+        target={isMobile ? "_self" : "_blank"}
+        rel="noreferrer"
+        href={externalUrl}
+        onClick={handleArticleClick}
+      >
+        {img}
+      </a>
+    );
+  }
+
   function titleLink(article) {
     let linkToRedirect = `/read/article?id=${article.id}`;
-    let is_saved = article.has_personal_copy || article.has_uploader || isArticleSaved === true;
 
     let open_in_zeeguu = (
       <ActionButton as={Link} to={linkToRedirect} onClick={handleArticleClick}>
@@ -202,21 +244,12 @@ export default function ArticlePreview({
         as="a"
         target={isMobile ? "_self" : "_blank"}
         rel="noreferrer"
-        href={article.parent_url || article.url}
+        href={externalUrl}
         onClick={handleArticleClick}
       >
         Open Externally <OpenInNewRoundedIcon style={{ fontSize: 16, marginLeft: 4 }} />
       </ActionButton>
     );
-
-    let should_open_in_zeeguu = Feature.always_open_externally()
-      ? is_saved
-      : article.video ||
-        (!Feature.extension_experiment1() && !hasExtension) ||
-        is_saved ||
-        article.parent_article_id; // Simplified articles (with parent_article_id) always open in Zeeguu reader
-
-    let should_open_with_modal = doNotShowRedirectionModal_UserPreference === false;
 
     if (should_open_in_zeeguu) return open_in_zeeguu;
     else if (should_open_with_modal) return open_externally_with_modal;
@@ -334,11 +367,7 @@ export default function ArticlePreview({
       </div>
 
       <s.ArticleContent>
-        {article.img_url && (
-          <Link to={`/read/article?id=${article.id}`} onClick={handleArticleClick}>
-            <img alt="" src={article.img_url} style={{ cursor: "pointer" }} />
-          </Link>
-        )}
+        {article.img_url && imageLink()}
         <s.Summary>
           {interactiveSummary ? (
             <TranslatableText interactiveText={interactiveSummary} translating={true} pronouncing={true} />


### PR DESCRIPTION
## Summary
- The article-preview image always navigated to the in-app reader, even when the Open button opened the article externally — so users tapping the image got the wrong destination.
- Hoist the existing routing decision (`should_open_in_zeeguu` / `should_open_with_modal`) out of `titleLink` so the image can reuse it. Image now matches the button: in-app `<Link>`, redirection-modal trigger, or external `<a>` with the same `target` / `rel` / `href`.

## Test plan
- [ ] Saved or extension-less article: tap image → opens in-app reader (matches Open button).
- [ ] Unsaved article, redirection-modal preference enabled: tap image → redirection modal appears.
- [ ] Unsaved article, modal disabled: tap image → opens external URL in new tab (desktop) / same tab (mobile), matching Open Externally.
- [ ] Simplified article (`parent_article_id` set): tap image → opens in-app reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)