### PR TITLE
Share daily audio lessons via /shared-lesson/:id

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,16 @@
                     android:pathPrefix="/exercise" />
             </intent-filter>
 
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="zeeguu.org"
+                    android:pathPrefix="/shared-lesson" />
+            </intent-filter>
+
             <!-- Share Sheet: receive shared URLs/text from other apps -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -6,7 +6,8 @@
         "appID": "E9Y43LYCSK.org.zeeguu.app",
         "paths": [
           "/read/article*",
-          "/exercise/*"
+          "/exercise/*",
+          "/shared-lesson/*"
         ]
       }
     ]

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -50,6 +50,7 @@ import ExercisesForArticle from "./exercises/ExercisesForArticle";
 import { WEB_READER } from "./reader/ArticleReader";
 import VideoPlayer from "./videos/VideoPlayer";
 import DailyAudioRouter from "./dailyAudio/_DailyAudioRouter";
+import SharedLessonView from "./dailyAudio/SharedLessonView";
 import IndividualExercise from "./pages/IndividualExercise";
 import Swiper from "./swiper/Swiper";
 import KeyboardTest from "./pages/KeyboardTest";
@@ -129,6 +130,7 @@ export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
       <PrivateRoute path="/watch/video" component={VideoPlayer} />
       <PrivateRouteWithLayout path="/exercises" component={ExercisesRouter} />
       <PrivateRouteWithLayout path="/daily-audio" component={DailyAudioRouter} />
+      <PrivateRouteWithLayout path="/shared-lesson/:id" component={SharedLessonView} />
       <PrivateRouteWithLayout path="/translate" component={TranslateRouter} />
       <PrivateRouteWithLayout path="/my-articles" component={MyArticlesRouter} />
       <PrivateRouteWithLayout path="/words" component={WordsRouter} />

--- a/src/api/dailyAudio.js
+++ b/src/api/dailyAudio.js
@@ -90,32 +90,11 @@ Zeeguu_API.prototype.generateDailyLesson = function (callback, onError, suggesti
 };
 
 Zeeguu_API.prototype.getSharedAudioLesson = function (lessonId, callback, onError) {
-  this.apiLog(`GET shared_audio_lesson/${lessonId}`);
-
-  fetch(`${this.baseAPIurl}/shared_audio_lesson/${lessonId}`)
-    .then((response) => {
-      if (!response.ok) {
-        return response.json().then((data) => {
-          throw new Error(data.error || "Network response was not ok");
-        });
-      }
-      return response.json();
-    })
-    .then((data) => {
-      if (data.audio_url) {
-        const audioUrl = `${this.baseAPIurl}${data.audio_url}`;
-        callback({ ...data, audio_url: audioUrl });
-      } else {
-        throw new Error("No audio URL in response");
-      }
-    })
-    .catch((error) => {
-      console.error("Error getting shared audio lesson:", error);
-      Sentry.captureException(error, { tags: { endpoint: "shared_audio_lesson" } });
-      if (onError) {
-        onError(error);
-      }
-    });
+  this._getJSON(
+    `shared_audio_lesson/${lessonId}`,
+    (data) => callback({ ...data, audio_url: `${this.baseAPIurl}${data.audio_url}` }),
+    { onError },
+  );
 };
 
 Zeeguu_API.prototype.deleteTodaysLesson = function (callback, onError) {

--- a/src/api/dailyAudio.js
+++ b/src/api/dailyAudio.js
@@ -7,40 +7,15 @@ function getTimezoneOffsetMinutes() {
 }
 
 Zeeguu_API.prototype.getTodaysLesson = function (callback, onError) {
-  this.apiLog("GET get_todays_lesson");
-  
-  const timezoneOffset = getTimezoneOffsetMinutes();
-  
-  fetch(this._appendSessionToUrl(`get_todays_lesson?timezone_offset=${timezoneOffset}`))
-    .then((response) => {
-      if (!response.ok) {
-        return response.json().then(data => {
-          throw new Error(data.error || "Network response was not ok");
-        });
-      }
-      return response.json();
-    })
-    .then((data) => {
-      if (data.lesson === null) {
-        // No lesson for today, call callback with null to indicate no lesson
-        callback(null);
-      } else if (data.audio_url) {
-        // Convert relative audio URL to full URL with session
-        const audioUrl = `${this.baseAPIurl}${data.audio_url}?session=${this.session}`;
-        callback({ ...data, audio_url: audioUrl });
-      } else {
-        throw new Error("No audio URL in response");
-      }
-    })
-    .catch((error) => {
-      if (!error.message.includes("No lesson generated yet today")) {
-        console.error("Error getting today's lesson:", error);
-        Sentry.captureException(error, { tags: { endpoint: "get_todays_lesson" } });
-      }
-      if (onError) {
-        onError(error);
-      }
-    });
+  this._getJSON(
+    `get_todays_lesson?timezone_offset=${getTimezoneOffsetMinutes()}`,
+    (data) => {
+      if (data.lesson === null) return callback(null);
+      const audioUrl = `${this.baseAPIurl}${data.audio_url}?session=${this.session}`;
+      callback({ ...data, audio_url: audioUrl });
+    },
+    { onError },
+  );
 };
 
 Zeeguu_API.prototype.generateDailyLesson = function (callback, onError, suggestion, suggestionType) {
@@ -126,46 +101,11 @@ Zeeguu_API.prototype.deleteTodaysLesson = function (callback, onError) {
 };
 
 Zeeguu_API.prototype.getPastDailyLessons = function (limit, offset, callback, onError) {
-  this.apiLog("GET past_daily_lessons");
-  
-  let url = "past_daily_lessons";
-  const params = [];
-  if (limit) params.push(`limit=${limit}`);
-  if (offset) params.push(`offset=${offset}`);
-  
-  const timezoneOffset = getTimezoneOffsetMinutes();
-  params.push(`timezone_offset=${timezoneOffset}`);
-  
-  if (params.length > 0) {
-    // Check if URL already has query parameters
-    url += url.includes('?') ? `&${params.join('&')}` : `?${params.join('&')}`;
-  }
-  
-  fetch(this._appendSessionToUrl(url))
-    .then((response) => {
-      if (!response.ok) {
-        // Try to parse as JSON first, but handle HTML responses
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.includes("application/json")) {
-          return response.json().then(data => {
-            throw new Error(data.error || "Network response was not ok");
-          });
-        } else {
-          throw new Error(`Server error: ${response.status} ${response.statusText}`);
-        }
-      }
-      return response.json();
-    })
-    .then((data) => {
-      callback(data);
-    })
-    .catch((error) => {
-      console.error("Error getting past daily lessons:", error);
-      Sentry.captureException(error, { tags: { endpoint: "past_daily_lessons" } });
-      if (onError) {
-        onError(error);
-      }
-    });
+  const params = new URLSearchParams();
+  if (limit) params.set("limit", limit);
+  if (offset) params.set("offset", offset);
+  params.set("timezone_offset", getTimezoneOffsetMinutes());
+  this._getJSON(`past_daily_lessons?${params}`, callback, { onError });
 };
 
 Zeeguu_API.prototype.updateLessonState = function (lessonId, action, positionSeconds, callback, onError) {
@@ -206,49 +146,9 @@ Zeeguu_API.prototype.updateLessonState = function (lessonId, action, positionSec
 };
 
 Zeeguu_API.prototype.checkDailyLessonFeasibility = function (callback, onError) {
-  this.apiLog("GET check_daily_lesson_feasibility");
-  
-  fetch(this._appendSessionToUrl("check_daily_lesson_feasibility"))
-    .then((response) => {
-      if (!response.ok) {
-        return response.json().then(data => {
-          throw new Error(data.error || "Network response was not ok");
-        });
-      }
-      return response.json();
-    })
-    .then((data) => {
-      callback(data);
-    })
-    .catch((error) => {
-      console.error("Error checking daily lesson feasibility:", error);
-      if (onError) {
-        onError(error);
-      }
-    });
+  this._getJSON("check_daily_lesson_feasibility", callback, { onError });
 };
 
-// Removed saveLessonProgress - use updateLessonState with "pause" action instead
-
 Zeeguu_API.prototype.getAudioLessonGenerationProgress = function (callback, onError) {
-  this.apiLog("GET audio_lesson_generation_progress");
-
-  fetch(this._appendSessionToUrl("audio_lesson_generation_progress"))
-    .then((response) => {
-      if (!response.ok) {
-        return response.json().then(data => {
-          throw new Error(data.error || "Network response was not ok");
-        });
-      }
-      return response.json();
-    })
-    .then((data) => {
-      callback(data.progress); // Returns null if no generation in progress
-    })
-    .catch((error) => {
-      console.error("Error getting generation progress:", error);
-      if (onError) {
-        onError(error);
-      }
-    });
+  this._getJSON("audio_lesson_generation_progress", (data) => callback(data.progress), { onError });
 };

--- a/src/api/dailyAudio.js
+++ b/src/api/dailyAudio.js
@@ -89,6 +89,35 @@ Zeeguu_API.prototype.generateDailyLesson = function (callback, onError, suggesti
     });
 };
 
+Zeeguu_API.prototype.getSharedAudioLesson = function (lessonId, callback, onError) {
+  this.apiLog(`GET shared_audio_lesson/${lessonId}`);
+
+  fetch(`${this.baseAPIurl}/shared_audio_lesson/${lessonId}`)
+    .then((response) => {
+      if (!response.ok) {
+        return response.json().then((data) => {
+          throw new Error(data.error || "Network response was not ok");
+        });
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (data.audio_url) {
+        const audioUrl = `${this.baseAPIurl}${data.audio_url}`;
+        callback({ ...data, audio_url: audioUrl });
+      } else {
+        throw new Error("No audio URL in response");
+      }
+    })
+    .catch((error) => {
+      console.error("Error getting shared audio lesson:", error);
+      Sentry.captureException(error, { tags: { endpoint: "shared_audio_lesson" } });
+      if (onError) {
+        onError(error);
+      }
+    });
+};
+
 Zeeguu_API.prototype.deleteTodaysLesson = function (callback, onError) {
   this.apiLog("DELETE delete_todays_lesson");
   

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -28,7 +28,7 @@ export default function LessonPlaybackView({
     <LessonWrapper>
       <LessonTitle>
         {lessonData.is_completed && <CompletionCheck>✓</CompletionCheck>}
-        {lessonData.title || wordsAsTile(words)}
+        {lessonData.title}
       </LessonTitle>
       {lessonData.canonical_suggestion && (
         <SuggestionSubtitle>{lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b></SuggestionSubtitle>
@@ -44,7 +44,7 @@ export default function LessonPlaybackView({
             lessonData.pause_position_seconds || lessonData.position_seconds || lessonData.progress_seconds || 0
           }
           language={userDetails?.learned_language}
-          title={lessonData.title || wordsAsTile(lessonData.words) || "Daily Audio Lesson"}
+          title={lessonData.title || "Daily Audio Lesson"}
           artist={`${languageNames[userDetails?.learned_language] || "Zeeguu"} Audio Lesson`}
           onPlay={() => {
             if (lessonData.lesson_id) {
@@ -121,7 +121,7 @@ export default function LessonPlaybackView({
         <div style={{ marginTop: "40px", textAlign: "center", display: "flex", justifyContent: "center", gap: "16px" }}>
           {lessonData.lesson_id && (
             <SubtleTextButton
-              onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title || wordsAsTile(lessonData.words))}
+              onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title)}
             >
               Share
             </SubtleTextButton>

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -5,7 +5,7 @@ import { FEEDBACK_OPTIONS, FEEDBACK_CODES_NAME } from "../components/FeedbackCon
 import Word from "../words/Word";
 import { successGreen } from "../components/colors";
 import { AUDIO_STATUS } from "./AudioLessonConstants";
-import { LessonWrapper, LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton, LessonActions } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
 import { shareLessonLink } from "./shareLessonLink";
@@ -118,7 +118,7 @@ export default function LessonPlaybackView({
           </div>
         )}
 
-        <div style={{ marginTop: "40px", textAlign: "center", display: "flex", justifyContent: "center", gap: "16px" }}>
+        <LessonActions>
           {lessonData.lesson_id && (
             <SubtleTextButton
               onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title)}
@@ -143,7 +143,7 @@ export default function LessonPlaybackView({
               Delete lesson
             </SubtleTextButton>
           )}
-        </div>
+        </LessonActions>
 
         <FeedbackModal
           prefixMsg={lessonData

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -5,7 +5,7 @@ import { FEEDBACK_OPTIONS, FEEDBACK_CODES_NAME } from "../components/FeedbackCon
 import Word from "../words/Word";
 import { successGreen } from "../components/colors";
 import { AUDIO_STATUS } from "./AudioLessonConstants";
-import { LessonWrapper, LessonTitle, SuggestionSubtitle, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
 import { shareLessonLink } from "./shareLessonLink";
@@ -31,7 +31,7 @@ export default function LessonPlaybackView({
         {lessonData.title}
       </LessonTitle>
       {lessonData.canonical_suggestion && (
-        <SuggestionSubtitle>{lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b></SuggestionSubtitle>
+        <LessonMetadata>{lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b></LessonMetadata>
       )}
 
       {error && <div style={{ color: "red", marginBottom: "20px" }}>{error}</div>}
@@ -130,7 +130,7 @@ export default function LessonPlaybackView({
             Feedback
           </SubtleTextButton>
           {userDetails?.name === "Mircea" && (
-            <button
+            <SubtleTextButton
               onClick={() => {
                 if (window.confirm("Delete today's lesson?")) {
                   api.deleteTodaysLesson(
@@ -139,18 +139,9 @@ export default function LessonPlaybackView({
                   );
                 }
               }}
-              style={{
-                backgroundColor: "transparent",
-                color: "var(--text-faint)",
-                border: "none",
-                padding: "4px 8px",
-                fontSize: "12px",
-                cursor: "pointer",
-                textDecoration: "underline",
-              }}
             >
               Delete lesson
-            </button>
+            </SubtleTextButton>
           )}
         </div>
 

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -5,7 +5,7 @@ import { FEEDBACK_OPTIONS, FEEDBACK_CODES_NAME } from "../components/FeedbackCon
 import Word from "../words/Word";
 import { successGreen } from "../components/colors";
 import { AUDIO_STATUS } from "./AudioLessonConstants";
-import { LessonWrapper, LessonTitle, SuggestionSubtitle, CompletionCheck } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, SuggestionSubtitle, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
 import { shareLessonLink } from "./shareLessonLink";
@@ -120,37 +120,15 @@ export default function LessonPlaybackView({
 
         <div style={{ marginTop: "40px", textAlign: "center", display: "flex", justifyContent: "center", gap: "16px" }}>
           {lessonData.lesson_id && (
-            <button
+            <SubtleTextButton
               onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title || wordsAsTile(lessonData.words))}
-              style={{
-                backgroundColor: "transparent",
-                color: "var(--text-faint)",
-                border: "none",
-                borderRadius: "0",
-                padding: "4px 8px",
-                fontSize: "12px",
-                cursor: "pointer",
-                textDecoration: "underline",
-              }}
             >
               Share
-            </button>
+            </SubtleTextButton>
           )}
-          <button
-            onClick={() => setOpenFeedback(true)}
-            style={{
-              backgroundColor: "transparent",
-              color: "var(--text-faint)",
-              border: "none",
-              borderRadius: "0",
-              padding: "4px 8px",
-              fontSize: "12px",
-              cursor: "pointer",
-              textDecoration: "underline",
-            }}
-          >
+          <SubtleTextButton onClick={() => setOpenFeedback(true)}>
             Feedback
-          </button>
+          </SubtleTextButton>
           {userDetails?.name === "Mircea" && (
             <button
               onClick={() => {

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -8,6 +8,7 @@ import { AUDIO_STATUS } from "./AudioLessonConstants";
 import { LessonWrapper, LessonTitle, SuggestionSubtitle, CompletionCheck } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
+import { shareLessonLink } from "./shareLessonLink";
 
 export default function LessonPlaybackView({
   lessonData,
@@ -118,6 +119,23 @@ export default function LessonPlaybackView({
         )}
 
         <div style={{ marginTop: "40px", textAlign: "center", display: "flex", justifyContent: "center", gap: "16px" }}>
+          {lessonData.lesson_id && (
+            <button
+              onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title || wordsAsTile(lessonData.words))}
+              style={{
+                backgroundColor: "transparent",
+                color: "var(--text-faint)",
+                border: "none",
+                borderRadius: "0",
+                padding: "4px 8px",
+                fontSize: "12px",
+                cursor: "pointer",
+                textDecoration: "underline",
+              }}
+            >
+              Share
+            </button>
+          )}
           <button
             onClick={() => setOpenFeedback(true)}
             style={{

--- a/src/dailyAudio/LessonView.sc.js
+++ b/src/dailyAudio/LessonView.sc.js
@@ -23,3 +23,14 @@ export const CompletionCheck = styled.span`
   color: ${successGreen};
   font-size: 20px;
 `;
+
+export const SubtleTextButton = styled.button`
+  background-color: transparent;
+  color: var(--text-faint);
+  border: none;
+  border-radius: 0;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: underline;
+`;

--- a/src/dailyAudio/LessonView.sc.js
+++ b/src/dailyAudio/LessonView.sc.js
@@ -34,3 +34,10 @@ export const SubtleTextButton = styled.button`
   cursor: pointer;
   text-decoration: underline;
 `;
+
+export const LessonActions = styled.div`
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+`;

--- a/src/dailyAudio/LessonView.sc.js
+++ b/src/dailyAudio/LessonView.sc.js
@@ -19,6 +19,17 @@ export const SuggestionSubtitle = styled.p`
   margin-bottom: 10px;
 `;
 
+export const LessonLanguageBadge = styled.span`
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background-color: var(--bg-secondary);
+  padding: 2px 10px;
+  border-radius: 12px;
+  margin-bottom: 10px;
+`;
+
 export const CompletionCheck = styled.span`
   color: ${successGreen};
   font-size: 20px;

--- a/src/dailyAudio/LessonView.sc.js
+++ b/src/dailyAudio/LessonView.sc.js
@@ -19,17 +19,6 @@ export const SuggestionSubtitle = styled.p`
   margin-bottom: 10px;
 `;
 
-export const LessonLanguageBadge = styled.span`
-  display: inline-block;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  background-color: var(--bg-secondary);
-  padding: 2px 10px;
-  border-radius: 12px;
-  margin-bottom: 10px;
-`;
-
 export const CompletionCheck = styled.span`
   color: ${successGreen};
   font-size: 20px;

--- a/src/dailyAudio/LessonView.sc.js
+++ b/src/dailyAudio/LessonView.sc.js
@@ -13,7 +13,7 @@ export const LessonTitle = styled.h2`
   gap: 8px;
 `;
 
-export const SuggestionSubtitle = styled.p`
+export const LessonMetadata = styled.p`
   font-size: 0.85rem;
   color: var(--text-secondary);
   margin-bottom: 10px;

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -5,7 +5,7 @@ import { UserContext } from "../contexts/UserContext";
 import LoadingAnimation from "../components/LoadingAnimation";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import useListeningSession from "../hooks/useListeningSession";
-import { SuggestionSubtitle } from "./LessonView.sc";
+import { LessonMetadata } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 
 export default function PastLessons() {
@@ -191,9 +191,9 @@ function PastLessonItem({ lesson, api, userDetails, onLessonCompleted }) {
             : {lesson.title || wordsAsTile(lesson.words)}
           </h3>
           {lesson.canonical_suggestion && (
-            <SuggestionSubtitle>
+            <LessonMetadata>
               {lesson.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lesson.canonical_suggestion}</b>
-            </SuggestionSubtitle>
+            </LessonMetadata>
           )}
           {lesson.is_completed && lesson.completed_at && (
             <span

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -4,7 +4,7 @@ import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import LoadingAnimation from "../components/LoadingAnimation";
-import { LessonWrapper, LessonTitle, SuggestionSubtitle, LessonLanguageBadge } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
 import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
 import { languageNames } from "../utils/languageDetection";
 import useListeningSession from "../hooks/useListeningSession";
@@ -84,12 +84,15 @@ export default function SharedLessonView() {
   return (
     <LessonWrapper>
       <LessonTitle>{titleText}</LessonTitle>
-      {lessonLangName && <LessonLanguageBadge>{lessonLangName}</LessonLanguageBadge>}
-      {lessonData.canonical_suggestion && (
-        <SuggestionSubtitle>
-          {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>
-        </SuggestionSubtitle>
-      )}
+      <SuggestionSubtitle>
+        Language: <b>{lessonLangName}</b>
+        {lessonData.canonical_suggestion && (
+          <>
+            {" · "}
+            {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>
+          </>
+        )}
+      </SuggestionSubtitle>
 
       <CustomAudioPlayer
         src={lessonData.audio_url}

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -4,7 +4,7 @@ import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import LoadingAnimation from "../components/LoadingAnimation";
-import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, LessonMetadata } from "./LessonView.sc";
 import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
 import { languageNames } from "../utils/languageDetection";
 import useListeningSession from "../hooks/useListeningSession";
@@ -84,7 +84,7 @@ export default function SharedLessonView() {
   return (
     <LessonWrapper>
       <LessonTitle>{titleText}</LessonTitle>
-      <SuggestionSubtitle>
+      <LessonMetadata>
         Language: <b>{lessonLangName}</b>
         {lessonData.canonical_suggestion && (
           <>
@@ -92,7 +92,7 @@ export default function SharedLessonView() {
             {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>
           </>
         )}
-      </SuggestionSubtitle>
+      </LessonMetadata>
 
       <CustomAudioPlayer
         src={lessonData.audio_url}

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -1,0 +1,124 @@
+import { useContext, useEffect, useState } from "react";
+import { useParams, useHistory } from "react-router-dom";
+import { APIContext } from "../contexts/APIContext";
+import { UserContext } from "../contexts/UserContext";
+import CustomAudioPlayer from "../components/CustomAudioPlayer";
+import LoadingAnimation from "../components/LoadingAnimation";
+import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
+import { wordsAsTile } from "./audioUtils";
+import { languageNames } from "../utils/languageDetection";
+import { zeeguuOrange } from "../components/colors";
+
+export default function SharedLessonView() {
+  const api = useContext(APIContext);
+  const { userDetails } = useContext(UserContext);
+  const history = useHistory();
+  const { id } = useParams();
+
+  const [lessonData, setLessonData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.getSharedAudioLesson(
+      id,
+      (data) => setLessonData(data),
+      (err) => setError(err.message || "Could not load shared lesson."),
+    );
+  }, [api, id]);
+
+  if (error) {
+    return (
+      <LessonWrapper>
+        <h2>Could not open this lesson</h2>
+        <p>{error}</p>
+      </LessonWrapper>
+    );
+  }
+
+  if (!lessonData) {
+    return (
+      <LessonWrapper>
+        <LoadingAnimation />
+      </LessonWrapper>
+    );
+  }
+
+  const lessonLang = lessonData.language_code;
+  const userLearns = userDetails?.learned_language;
+  const isLearnedByUser = userLearns && lessonLang && userLearns === lessonLang;
+  const lessonLangName = languageNames[lessonLang] || lessonLang;
+
+  return (
+    <LessonWrapper>
+      <LessonTitle>
+        {lessonData.title || wordsAsTile(lessonData.words)}
+      </LessonTitle>
+      {lessonData.canonical_suggestion && (
+        <SuggestionSubtitle>
+          {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>
+        </SuggestionSubtitle>
+      )}
+
+      <CustomAudioPlayer
+        src={lessonData.audio_url}
+        language={lessonLang}
+        title={lessonData.title || wordsAsTile(lessonData.words) || "Shared Audio Lesson"}
+        artist={`${lessonLangName} Audio Lesson`}
+        style={{
+          width: "100%",
+          marginBottom: "20px",
+          maxWidth: "600px",
+          margin: "0 auto 20px auto",
+        }}
+      />
+
+      {isLearnedByUser ? (
+        <ShareBanner
+          message={`Like this lesson? Generate your own ${lessonLangName} audio lesson on a topic you choose.`}
+          actionLabel="Go to Daily Audio"
+          onAction={() => history.push("/daily-audio")}
+        />
+      ) : (
+        <ShareBanner
+          message={`This lesson is in ${lessonLangName}. Add ${lessonLangName} to your learning languages to start your own.`}
+          actionLabel="Manage languages"
+          onAction={() => history.push("/account_settings/language_settings")}
+        />
+      )}
+    </LessonWrapper>
+  );
+}
+
+function ShareBanner({ message, actionLabel, onAction }) {
+  return (
+    <div
+      style={{
+        marginTop: "30px",
+        padding: "16px",
+        backgroundColor: "var(--bg-secondary)",
+        border: `1px solid ${zeeguuOrange}`,
+        borderRadius: "6px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        alignItems: "flex-start",
+      }}
+    >
+      <div style={{ color: "var(--text-primary)", fontSize: "14px" }}>{message}</div>
+      <button
+        onClick={onAction}
+        style={{
+          backgroundColor: zeeguuOrange,
+          color: "white",
+          border: "none",
+          borderRadius: "4px",
+          padding: "8px 16px",
+          fontSize: "14px",
+          cursor: "pointer",
+        }}
+      >
+        {actionLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -6,7 +6,6 @@ import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import LoadingAnimation from "../components/LoadingAnimation";
 import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
 import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
-import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
 import useListeningSession from "../hooks/useListeningSession";
 
@@ -59,7 +58,7 @@ export default function SharedLessonView() {
 
   const lessonLangName = languageNames[lessonLang] || lessonLang;
   const isActiveLanguage = userDetails?.learned_language === lessonLang;
-  const titleText = lessonData.title || wordsAsTile(lessonData.words) || "Shared Audio Lesson";
+  const titleText = lessonData.title || "Shared Audio Lesson";
 
   let banner;
   if (isActiveLanguage) {

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -5,9 +5,9 @@ import { UserContext } from "../contexts/UserContext";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import LoadingAnimation from "../components/LoadingAnimation";
 import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
+import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
-import { zeeguuOrange } from "../components/colors";
 
 export default function SharedLessonView() {
   const api = useContext(APIContext);
@@ -44,15 +44,25 @@ export default function SharedLessonView() {
   }
 
   const lessonLang = lessonData.language_code;
-  const userLearns = userDetails?.learned_language;
-  const isLearnedByUser = userLearns && lessonLang && userLearns === lessonLang;
   const lessonLangName = languageNames[lessonLang] || lessonLang;
+  const isLearnedByUser = userDetails?.learned_language && lessonLang && userDetails.learned_language === lessonLang;
+  const titleText = lessonData.title || wordsAsTile(lessonData.words) || "Shared Audio Lesson";
+
+  const banner = isLearnedByUser
+    ? {
+        message: `Like this lesson? Generate your own ${lessonLangName} audio lesson on a topic you choose.`,
+        actionLabel: "Go to Daily Audio",
+        onAction: () => history.push("/daily-audio"),
+      }
+    : {
+        message: `This lesson is in ${lessonLangName}. Add ${lessonLangName} to your learning languages to start your own.`,
+        actionLabel: "Manage languages",
+        onAction: () => history.push("/account_settings/language_settings"),
+      };
 
   return (
     <LessonWrapper>
-      <LessonTitle>
-        {lessonData.title || wordsAsTile(lessonData.words)}
-      </LessonTitle>
+      <LessonTitle>{titleText}</LessonTitle>
       {lessonData.canonical_suggestion && (
         <SuggestionSubtitle>
           {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>
@@ -62,7 +72,7 @@ export default function SharedLessonView() {
       <CustomAudioPlayer
         src={lessonData.audio_url}
         language={lessonLang}
-        title={lessonData.title || wordsAsTile(lessonData.words) || "Shared Audio Lesson"}
+        title={titleText}
         artist={`${lessonLangName} Audio Lesson`}
         style={{
           width: "100%",
@@ -72,53 +82,16 @@ export default function SharedLessonView() {
         }}
       />
 
-      {isLearnedByUser ? (
-        <ShareBanner
-          message={`Like this lesson? Generate your own ${lessonLangName} audio lesson on a topic you choose.`}
-          actionLabel="Go to Daily Audio"
-          onAction={() => history.push("/daily-audio")}
-        />
-      ) : (
-        <ShareBanner
-          message={`This lesson is in ${lessonLangName}. Add ${lessonLangName} to your learning languages to start your own.`}
-          actionLabel="Manage languages"
-          onAction={() => history.push("/account_settings/language_settings")}
-        />
-      )}
+      <ShareBanner {...banner} />
     </LessonWrapper>
   );
 }
 
 function ShareBanner({ message, actionLabel, onAction }) {
   return (
-    <div
-      style={{
-        marginTop: "30px",
-        padding: "16px",
-        backgroundColor: "var(--bg-secondary)",
-        border: `1px solid ${zeeguuOrange}`,
-        borderRadius: "6px",
-        display: "flex",
-        flexDirection: "column",
-        gap: "12px",
-        alignItems: "flex-start",
-      }}
-    >
-      <div style={{ color: "var(--text-primary)", fontSize: "14px" }}>{message}</div>
-      <button
-        onClick={onAction}
-        style={{
-          backgroundColor: zeeguuOrange,
-          color: "white",
-          border: "none",
-          borderRadius: "4px",
-          padding: "8px 16px",
-          fontSize: "14px",
-          cursor: "pointer",
-        }}
-      >
-        {actionLabel}
-      </button>
-    </div>
+    <BannerContainer>
+      <BannerMessage>{message}</BannerMessage>
+      <BannerButton onClick={onAction}>{actionLabel}</BannerButton>
+    </BannerContainer>
   );
 }

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -8,6 +8,7 @@ import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc"
 import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
+import useListeningSession from "../hooks/useListeningSession";
 
 export default function SharedLessonView() {
   const api = useContext(APIContext);
@@ -17,6 +18,7 @@ export default function SharedLessonView() {
 
   const [lessonData, setLessonData] = useState(null);
   const [error, setError] = useState(null);
+  const [userLanguages, setUserLanguages] = useState(null);
 
   useEffect(() => {
     api.getSharedAudioLesson(
@@ -24,7 +26,19 @@ export default function SharedLessonView() {
       (data) => setLessonData(data),
       (err) => setError(err.message || "Could not load shared lesson."),
     );
+    api.getUserLanguages((langs) => setUserLanguages(langs || []));
   }, [api, id]);
+
+  // Hook before any early return so the hook order stays stable across renders.
+  // Pass null when the user isn't learning this lesson's language → useListeningSession
+  // short-circuits internally and no session is recorded.
+  const lessonLang = lessonData?.language_code;
+  const isLearningLanguage = !!(
+    lessonLang && userLanguages?.some((l) => l.code === lessonLang)
+  );
+  const listeningSession = useListeningSession(
+    isLearningLanguage ? lessonData?.lesson_id : null,
+  );
 
   if (error) {
     return (
@@ -35,7 +49,7 @@ export default function SharedLessonView() {
     );
   }
 
-  if (!lessonData) {
+  if (!lessonData || userLanguages === null) {
     return (
       <LessonWrapper>
         <LoadingAnimation />
@@ -43,22 +57,30 @@ export default function SharedLessonView() {
     );
   }
 
-  const lessonLang = lessonData.language_code;
   const lessonLangName = languageNames[lessonLang] || lessonLang;
-  const isLearnedByUser = userDetails?.learned_language && lessonLang && userDetails.learned_language === lessonLang;
+  const isActiveLanguage = userDetails?.learned_language === lessonLang;
   const titleText = lessonData.title || wordsAsTile(lessonData.words) || "Shared Audio Lesson";
 
-  const banner = isLearnedByUser
-    ? {
-        message: `Like this lesson? Generate your own ${lessonLangName} audio lesson on a topic you choose.`,
-        actionLabel: "Go to Daily Audio",
-        onAction: () => history.push("/daily-audio"),
-      }
-    : {
-        message: `This lesson is in ${lessonLangName}. Add ${lessonLangName} to your learning languages to start your own.`,
-        actionLabel: "Manage languages",
-        onAction: () => history.push("/account_settings/language_settings"),
-      };
+  let banner;
+  if (isActiveLanguage) {
+    banner = {
+      message: `Like this lesson? Generate your own ${lessonLangName} audio lesson on a topic you choose.`,
+      actionLabel: "Go to Daily Audio",
+      onAction: () => history.push("/daily-audio"),
+    };
+  } else if (isLearningLanguage) {
+    banner = {
+      message: `You're learning ${lessonLangName} but it's not your active language. Switch to ${lessonLangName} to make this count toward today's progress.`,
+      actionLabel: "Switch active language",
+      onAction: () => history.push("/account_settings/language_settings"),
+    };
+  } else {
+    banner = {
+      message: `This lesson is in ${lessonLangName}. Add ${lessonLangName} to your learning languages to start your own.`,
+      actionLabel: "Manage languages",
+      onAction: () => history.push("/account_settings/language_settings"),
+    };
+  }
 
   return (
     <LessonWrapper>
@@ -74,6 +96,9 @@ export default function SharedLessonView() {
         language={lessonLang}
         title={titleText}
         artist={`${lessonLangName} Audio Lesson`}
+        onPlay={() => listeningSession.start()}
+        onPause={() => listeningSession.pause()}
+        onEnded={() => listeningSession.end()}
         style={{
           width: "100%",
           marginBottom: "20px",

--- a/src/dailyAudio/SharedLessonView.js
+++ b/src/dailyAudio/SharedLessonView.js
@@ -4,7 +4,7 @@ import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import LoadingAnimation from "../components/LoadingAnimation";
-import { LessonWrapper, LessonTitle, SuggestionSubtitle } from "./LessonView.sc";
+import { LessonWrapper, LessonTitle, SuggestionSubtitle, LessonLanguageBadge } from "./LessonView.sc";
 import { BannerContainer, BannerMessage, BannerButton } from "./SharedLessonView.sc";
 import { languageNames } from "../utils/languageDetection";
 import useListeningSession from "../hooks/useListeningSession";
@@ -84,6 +84,7 @@ export default function SharedLessonView() {
   return (
     <LessonWrapper>
       <LessonTitle>{titleText}</LessonTitle>
+      {lessonLangName && <LessonLanguageBadge>{lessonLangName}</LessonLanguageBadge>}
       {lessonData.canonical_suggestion && (
         <SuggestionSubtitle>
           {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b>

--- a/src/dailyAudio/SharedLessonView.sc.js
+++ b/src/dailyAudio/SharedLessonView.sc.js
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import { zeeguuOrange } from "../components/colors";
+
+export const BannerContainer = styled.div`
+  margin-top: 30px;
+  padding: 16px;
+  background-color: var(--bg-secondary);
+  border: 1px solid ${zeeguuOrange};
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+`;
+
+export const BannerMessage = styled.div`
+  color: var(--text-primary);
+  font-size: 14px;
+`;
+
+export const BannerButton = styled.button`
+  background-color: ${zeeguuOrange};
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+`;

--- a/src/dailyAudio/shareLessonLink.js
+++ b/src/dailyAudio/shareLessonLink.js
@@ -1,0 +1,31 @@
+export function shareLessonUrl(lessonId) {
+  return `${window.location.origin}/shared-lesson/${lessonId}`;
+}
+
+export async function shareLessonLink(lessonId, title) {
+  const url = shareLessonUrl(lessonId);
+  const shareTitle = title ? `Zeeguu Audio: ${title}` : "Zeeguu Audio Lesson";
+
+  if (navigator.share) {
+    try {
+      await navigator.share({ title: shareTitle, url });
+      return;
+    } catch (e) {
+      // User dismissed the system share sheet — not an error worth surfacing.
+      if (e?.name === "AbortError") return;
+      // Other failures (permission, unsupported content) → fall through to copy.
+    }
+  }
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(url);
+      alert("Lesson link copied to clipboard.");
+      return;
+    } catch (e) {
+      // Fall through to prompt.
+    }
+  }
+
+  window.prompt("Copy this lesson link:", url);
+}

--- a/src/dailyAudio/shareLessonLink.js
+++ b/src/dailyAudio/shareLessonLink.js
@@ -11,9 +11,7 @@ export async function shareLessonLink(lessonId, title) {
       await navigator.share({ title: shareTitle, url });
       return;
     } catch (e) {
-      // User dismissed the system share sheet — not an error worth surfacing.
       if (e?.name === "AbortError") return;
-      // Other failures (permission, unsupported content) → fall through to copy.
     }
   }
 
@@ -23,7 +21,7 @@ export async function shareLessonLink(lessonId, title) {
       alert("Lesson link copied to clipboard.");
       return;
     } catch (e) {
-      // Fall through to prompt.
+      // intentionally swallowed; fall through
     }
   }
 


### PR DESCRIPTION
## Summary

End-to-end share-lesson flow plus a few related polish items:

- **Share button** on the daily audio lesson view. Web Share API → clipboard → manual prompt fallback chain.
- **`/shared-lesson/:id` route** + `SharedLessonView` component. Renders `CustomAudioPlayer` with **no** owner-only tracking calls (`updateLessonState` and friends).
- **Three-state banner** based on whether the recipient learns the lesson's language: active match → "Generate your own" / configured-but-not-active → "Switch active language" / not in set → "Add this language."
- **Listening session for shared lessons.** When the recipient is learning the language (active *or* configured), a `UserListeningSession` is created against the lesson so playback time counts toward their daily-time. UserWord/SRS progression stays disabled — that's owner-only.
- **iOS Universal Links + Android App Links** path entries for `/shared-lesson/*` so share links open the native app on installed devices.
- **Drop `wordsAsTile` fallback** in `SharedLessonView` and `LessonPlaybackView`; backend now sends a definitive `title` (see API pair).
- **`_getJSON` migration** for the GET methods in `dailyAudio.js` (`getTodaysLesson`, `getPastDailyLessons`, `checkDailyLessonFeasibility`, `getAudioLessonGenerationProgress`, `getSharedAudioLesson`). Each shrank from ~25-40 lines to ~3-10 by reusing the existing `classDef._getJSON` helper.

## Why preview-style instead of full playback

Tracking is woven through several places in the regular playback path (`updateLessonState`, completion event → badges/streaks, SRS writes via `_progress_words_from_completed_lesson`). For a recipient who isn't the lesson owner, none of that should fire — even if they learn the same language, the lesson belongs to the owner and the SRS rows belong to the owner's UserWord set. Easier and safer to render share-mode as a separate component that just doesn't call any of those endpoints, with the listening-session hook attached only when the recipient learns the language.

## Backend pairs

- zeeguu/api#595 (merged) — added the public `/shared_audio_lesson/:id` endpoint.
- **zeeguu/api#597** — adds `DailyAudioLesson.display_title()` and ensures `title` is always sent in lesson responses. **This PR depends on #597 merging first** — the `wordsAsTile` fallback removal here means a non-dialogue lesson would render an empty title until the API change ships.

## Test plan

- [ ] Click Share on a lesson — system share sheet appears (mobile/macOS) or clipboard receives `https://zeeguu.org/shared-lesson/<id>`.
- [ ] Open the share URL. Audio plays. No `update_lesson_state` calls in network tab.
- [ ] Open the share URL while learning the lesson's language as ACTIVE → "Go to Daily Audio" banner. Listening session is recorded.
- [ ] Open the share URL while learning it but it's NOT your active language → "Switch active language" banner. Session still recorded.
- [ ] Open the share URL while not learning it at all → "Add this language" banner. NO session recorded.
- [ ] Daily-time counter reflects the recipient's listening time.
- [ ] iOS/Android: share link opens the native app on installed devices (post-deploy + reinstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)