### PR TITLE
Show lesson title on audio sessions in activity history

### DIFF
--- a/src/words/SessionHistory.js
+++ b/src/words/SessionHistory.js
@@ -639,6 +639,10 @@ function SessionItem({ session, onEditWord }) {
         </ArticleTitle>
       )}
 
+      {session.session_type === "audio" && session.lesson_title && (
+        <ArticleTitle>{session.lesson_title}</ArticleTitle>
+      )}
+
       {session.session_type === "exercise" && (
         <ExerciseStats>
           {session.word_count} words practiced - {session.accuracy}% correct


### PR DESCRIPTION
## Summary

Audio (listening) session cards in activity history now render `lesson_title` under the session header — same shape as how reading rows render `article_title`. Previously the card only showed "Listening", duration, and word count, with no way to tell which lesson it was.

## Backend pair

zeeguu/api#596 — adds `lesson_title` and `lesson_id` to the `/session_history` audio entries.

## Test plan

- [ ] Activity history shows a title for each audio row (dialogue lesson, topic-based, and word-list-based all render).
- [ ] No layout regression for reading/exercise/browsing rows.
- [ ] Old audio rows (before backend deploy) gracefully render without a title (the `&& session.lesson_title` guard handles missing field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)