### PR TITLE
Theme SessionHistory + Translate styles for dark mode

### DIFF
--- a/src/translate/Translate.sc.js
+++ b/src/translate/Translate.sc.js
@@ -19,7 +19,7 @@ export const LanguageLabel = styled.span`
 
 export const SwapButton = styled.button`
   background: none;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 50%;
   width: 36px;
   height: 36px;
@@ -116,8 +116,8 @@ export const SpeakButton = styled.button`
 `;
 
 export const TranslationCard = styled.div`
-  background: white;
-  border: 1px solid #e0e0e0;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
   border-radius: 0.5rem;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -152,7 +152,7 @@ export const TranslationText = styled.div`
 
 export const TranslationSource = styled.div`
   font-size: 0.8rem;
-  color: #888;
+  color: var(--text-muted);
 `;
 
 export const AddButton = styled.button`
@@ -198,12 +198,12 @@ export const CardInfo = styled.div`
 
 export const CardExplanation = styled.div`
   font-size: 0.9rem;
-  color: #555;
+  color: var(--text-secondary);
   line-height: 1.4;
 `;
 
 export const ExamplesLoading = styled.div`
-  color: #888;
+  color: var(--text-muted);
   font-size: 0.9rem;
   font-style: italic;
   padding: 0.5rem 0;
@@ -216,17 +216,17 @@ export const ExampleRow = styled.div`
   padding: 0.5rem;
   margin: 0.25rem 0;
   border-radius: 0.25rem;
-  background: #f9f9f9;
+  background: var(--bg-secondary);
 `;
 
 export const ExampleText = styled.span`
   font-size: 0.95rem;
-  color: #444;
+  color: var(--text-primary);
   line-height: 1.4;
 `;
 
 export const NoExamples = styled.div`
-  color: #888;
+  color: var(--text-muted);
   font-size: 0.9rem;
   font-style: italic;
   padding: 0.5rem 0;
@@ -240,7 +240,7 @@ export const ErrorMessage = styled.div`
 
 export const NoResults = styled.div`
   text-align: center;
-  color: #666;
+  color: var(--text-secondary);
   padding: 2rem;
   font-style: italic;
 `;
@@ -250,18 +250,18 @@ export const ReportButton = styled.button`
   border: none;
   padding: 0.25rem;
   cursor: pointer;
-  color: #ccc;
+  color: var(--text-faint);
   display: flex;
   align-items: center;
   margin-top: 0.5rem;
 
   &:hover {
-    color: #999;
+    color: var(--text-secondary);
   }
 `;
 
 export const ReportedBadge = styled.span`
-  color: #999;
+  color: var(--text-faint);
   font-size: 0.8rem;
   display: flex;
   align-items: center;

--- a/src/words/SessionHistory.js
+++ b/src/words/SessionHistory.js
@@ -16,11 +16,11 @@ import { isTextInSentence } from "../utils/text/expressions";
 import { validateWordInContext } from "../utils/validation/wordContextValidation";
 
 const SessionCard = styled.div`
-  background: white;
+  background: var(--card-bg);
   border-radius: 8px;
   padding: 1em;
   margin: 0.5em 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-color);
 `;
 
 const SessionHeader = styled.div`
@@ -32,12 +32,12 @@ const SessionHeader = styled.div`
 
 const SessionTime = styled.span`
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 `;
 
 const SessionDuration = styled.span`
   font-size: 0.9em;
-  color: #666;
+  color: var(--text-secondary);
 `;
 
 const SessionType = styled.span`
@@ -75,9 +75,10 @@ const ArticleTitle = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5em;
+  color: var(--text-primary);
 
   a {
-    color: #1976d2;
+    color: var(--link-color);
     text-decoration: none;
     &:hover {
       text-decoration: underline;
@@ -109,16 +110,16 @@ const WordList = styled.div`
   gap: 0.6em;
   margin-top: 0.75em;
   padding-top: 0.5em;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--border-light);
 `;
 
 const WordChip = styled.span`
-  background: white;
+  background: var(--card-bg);
   padding: 0.5em 0.8em;
   border-radius: 6px;
   font-size: 1em;
-  border: 1px solid #ddd;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 1px 2px var(--shadow-color);
 
   .origin {
     font-weight: 600;
@@ -130,12 +131,12 @@ const WordChip = styled.span`
   }
 
   .separator {
-    color: #999;
+    color: var(--text-faint);
     margin: 0 0.4em;
   }
 
   .translation {
-    color: #333;
+    color: var(--text-primary);
     font-weight: 600;
 
     &.clickable:hover {
@@ -187,7 +188,7 @@ const WordChip = styled.span`
 
 const ExerciseStats = styled.div`
   font-size: 0.9em;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 0.5em;
 `;
 
@@ -217,7 +218,7 @@ const FocusBadge = styled.span`
 
 const InfoNote = styled.div`
   font-size: 0.85em;
-  color: #666;
+  color: var(--text-secondary);
   font-style: italic;
   text-align: center;
   padding: 0.5em;
@@ -229,24 +230,24 @@ const DateHeader = styled.div`
   font-weight: 600;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
-  color: #555;
-  border-bottom: 1px solid #eee;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-light);
   padding-bottom: 0.3em;
 `;
 
 const SummaryCard = styled.div`
-  background: white;
+  background: var(--card-bg);
   border-radius: 8px;
   padding: 1.2em;
   margin-bottom: 1.5em;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-color);
 `;
 
 const SummaryTitle = styled.div`
   font-weight: 600;
   font-size: 1.1em;
   margin-bottom: 1em;
-  color: #333;
+  color: var(--text-primary);
 `;
 
 const StatsRow = styled.div`
@@ -264,20 +265,20 @@ const StatItem = styled.div`
   .label {
     font-size: 0.85em;
     font-weight: 600;
-    color: ${(props) => props.color || "#333"};
+    color: ${(props) => props.color || "var(--text-primary)"};
     margin-bottom: 0.2em;
   }
 
   .time {
     font-size: 1.4em;
     font-weight: 700;
-    color: ${(props) => props.color || "#333"};
+    color: ${(props) => props.color || "var(--text-primary)"};
   }
 
   .words {
     font-size: 0.9em;
     font-weight: 600;
-    color: ${(props) => props.color || "#333"};
+    color: ${(props) => props.color || "var(--text-primary)"};
     opacity: 0.7;
     margin-top: 0.1em;
   }
@@ -295,13 +296,13 @@ const BarRow = styled.div`
   .label {
     width: 80px;
     font-size: 0.85em;
-    color: #555;
+    color: var(--text-secondary);
   }
 
   .bar-wrapper {
     flex: 1;
     height: 20px;
-    background: #f0f0f0;
+    background: var(--bg-tertiary);
     border-radius: 4px;
     overflow: hidden;
   }
@@ -332,7 +333,7 @@ const BarRow = styled.div`
     width: 70px;
     text-align: right;
     font-size: 0.85em;
-    color: #666;
+    color: var(--text-secondary);
     margin-left: 0.5em;
   }
 `;


### PR DESCRIPTION
## Summary

Activity history (`/activity-history`) and Translate / Translation history (`/translate`, `/translate/history`) were rendering with nearly-illegible faint text in dark mode. Both files (`SessionHistory.js` and `Translate.sc.js`) predated the project's CSS-variable theme system and used hardcoded colors (`background: white`, `color: #333` / `#555` / `#666` / `#888` / `#999`, hardcoded borders and shadows).

Refactored the styled components to use the existing theme tokens already defined in `index.css`:

- `--card-bg`, `--text-primary` / `--text-secondary` / `--text-muted` / `--text-faint`
- `--border-color` / `--border-light`
- `--shadow-color`
- `--bg-secondary` / `--bg-tertiary`
- `--link-color`

Type-specific badge colors (Reading / Exercise / Listening / Browsing markers, focus levels, success/error) are kept as-is — their light-tint palette is intentional and stays readable in dark mode.

Also adds explicit `color: var(--text-primary)` on `ArticleTitle` in `SessionHistory.js` so the audio-row plain-text title is visible. Reading rows already worked because the `<Link>` child carries its own color.

## Test plan

- [ ] Dark mode: activity history rows have legible title, time, duration, word chips. Date headers visible. Cards have appropriate dark background.
- [ ] Dark mode: translate page + translation history rows are legible. Card hover still highlights with the orange border.
- [ ] Light mode: no visual regression — all the variable mappings are close enough to the original hex values.
- [ ] Reading session card: link still uses the primary link color (now `var(--link-color)` which is brand orange in both modes).

## Out of scope

- Type-badge color tints (`#e3f2fd`, `#e8f5e9`, etc.) are intentionally light and read fine in dark mode.
- Status colors (success green `#28a745`, error red `#dc3545`) — semantic, not theme-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)