### PR TITLE
Add Share button to past lesson cards

### DIFF
--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -5,8 +5,9 @@ import { UserContext } from "../contexts/UserContext";
 import LoadingAnimation from "../components/LoadingAnimation";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import useListeningSession from "../hooks/useListeningSession";
-import { LessonMetadata } from "./LessonView.sc";
+import { LessonMetadata, SubtleTextButton } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
+import { shareLessonLink } from "./shareLessonLink";
 
 export default function PastLessons() {
   const api = useContext(APIContext);
@@ -207,6 +208,11 @@ function PastLessonItem({ lesson, api, userDetails, onLessonCompleted }) {
             </span>
           )}
         </div>
+        {lesson.lesson_id && (
+          <SubtleTextButton onClick={() => shareLessonLink(lesson.lesson_id, lesson.title)}>
+            Share
+          </SubtleTextButton>
+        )}
       </div>
 
       {lesson.audio_url && (


### PR DESCRIPTION
## Summary

Mirrors the Share affordance on the today's-lesson view. Each past-lesson card now has a Share button in the title row's right slot (the flex container was already `justify-content: space-between`, set up for a right-aligned element).

Reuses `shareLessonLink` and `SubtleTextButton` from the share-audio-lesson feature — no new infrastructure.

## Test plan

- [ ] Past Lessons tab shows a Share button on each lesson card.
- [ ] Clicking it opens the system share sheet (mobile/macOS) or copies the `/shared-lesson/<id>` URL to clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)