### PR TITLE
Reader: simplify navigates to existing version when already simplified

### DIFF
--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -330,16 +330,14 @@ export default function ArticleReader({ teacherArticleID }) {
     api.simplifyArticle(articleInfo.id, (result) => {
       setIsProcessingArticle(false);
       setShowLanguageModal(false);
-      if (result.status === "success" && result.levels) {
-        // Navigate to the simplified version (non-original with matching or lower level)
-        const simplified = result.levels.find((l) => !l.is_original);
-        if (simplified) {
-          history.replace("/read/article?id=" + simplified.id);
-          return;
-        }
-      } else {
-        console.error("Simplification failed:", result.message);
+      // Backend returns levels for both "success" (just simplified) and
+      // "already_done" (existing version at user's level) — handle both.
+      const simplified = result.levels?.find((l) => !l.is_original);
+      if (simplified) {
+        history.replace("/read/article?id=" + simplified.id);
+        return;
       }
+      console.error("Simplification failed:", result.message || result.error || result.status);
     });
   };
 

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -156,14 +156,17 @@ export default function SharedArticleHandler() {
       (result) => {
         const artinfo = typeof result === "string" ? JSON.parse(result) : result;
         api.simplifyArticle(artinfo.id, (simplifyResult) => {
-          if (simplifyResult.status === "success" && simplifyResult.levels) {
-            const simplified = simplifyResult.levels.find((l) => !l.is_original);
-            if (simplified) {
-              navigateToArticle(simplified.id);
-              return;
-            }
+          // Backend returns levels for both "success" (just simplified) and
+          // "already_done" (existing version at user's level) — handle both.
+          const simplified = simplifyResult.levels?.find((l) => !l.is_original);
+          if (simplified) {
+            navigateToArticle(simplified.id);
+            return;
           }
-          console.error("Simplification failed:", simplifyResult.message);
+          console.error(
+            "Simplification failed:",
+            simplifyResult.message || simplifyResult.error || simplifyResult.status,
+          );
           navigateToArticle(artinfo.id);
         });
       },


### PR DESCRIPTION
## Summary

- The `/simplify_article/<id>` backend returns `status: "already_done"` (with the full `levels` array) when a simplified version at the user's CEFR level already exists.
- Both `handleSimplify` call sites in the web reader only treated `status === "success"` as valid:
  - `SharedArticleHandler.js` fell through to `navigateToArticle(artinfo.id)` — landing on the **original** article. This reproduces as: "I send an article to Zeeguu, click Simplify, but still see the original" when re-sharing an article you'd previously simplified.
  - `ArticleReader.js` silently did nothing — the modal closed and the user stayed on whatever they were viewing.
- Fix drives navigation off the `levels` array directly. Both `success` and `already_done` populate it; failure paths don't.

## Test plan

- [ ] Share a fresh article (not previously simplified) → click Simplify → land on the simplified version.
- [ ] Re-share the same article (now `already_done`) → click Simplify → land on the simplified version (was: original).
- [ ] Open a simplifiable article via deeplink, click Simplify in the modal → land on the simplified version (covers `ArticleReader.handleSimplify`).
- [ ] Force a backend error (e.g. break the LLM call) → console logs the error reason; no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)