### PR TITLE
Skip stale single-word bookmark on MWE-tagged tokens

### DIFF
--- a/src/reader/bookmarkRestoration.js
+++ b/src/reader/bookmarkRestoration.js
@@ -235,6 +235,16 @@ export function updateTokensWithBookmarks(bookmarks, paragraphs) {
       continue;
     }
 
+    // Skip stale single-word bookmark on a token that's now part of an MWE
+    // group (e.g. an old `en` bookmark when the tokenizer now flags `en
+    // kikkert` as MWE). Letting the bookmark paint would block the MWE chip
+    // from rendering. The bookmark stays in the DB but is invisible until
+    // the user re-taps and creates a fresh MWE-aware bookmark.
+    if (!bookmark["is_mwe"] && targetToken.mwe_group_id) {
+      MWE_DEBUG && console.log("[Bookmark] Single-word bookmark on MWE token, skipping:", bookmark["origin"]);
+      continue;
+    }
+
     if (bookmark["is_mwe"]) {
       const validation = validateMweBookmark(bookmark, targetToken, sentenceTokens);
       MWE_DEBUG && console.log("[Bookmark] MWE validation:", validation);


### PR DESCRIPTION
## Summary
Pairs with zeeguu/api#605 (article+noun auto-MWE). Bookmarks created before that PR — e.g. a single-word `en → part` — reference tokens that the new tokenization now flags as part of an `article_noun` MWE group. The previous restoration order painted the stale single-word chip first, blocking the new MWE chip from rendering for the whole `en del` phrase.

Add a guard in `updateTokensWithBookmarks`: if a non-MWE bookmark targets a token that now carries `mwe_group_id`, skip the restoration. The bookmark stays in the DB but is invisible; the next tap on either token in the MWE creates a fresh MWE-aware bookmark via the standard flow.

This is the cheapest fix on the table from the architecture options I discussed in chat (A). It doesn't mutate user data, doesn't require a migration, and self-heals on user interaction.

## What this does not do
- It does not delete the stale bookmarks. They remain in the DB. A one-off migration tool to bulk-clean ghost bookmarks is a separate (optional) follow-up.
- It only handles the most common direction (single-word bookmark inside new MWE group). The reverse — an MWE bookmark whose group is no longer detected — is not handled and is rare since this change *adds* detection.

## Test plan
- [ ] User has an existing single-word `en → part` bookmark on a Danish article (created before yesterday's deploy). Open the article in the reader. The `en del` MWE chip should render and the old `en` chip should not appear.
- [ ] User has an existing MWE bookmark (e.g. `lyser ... op`). Open the article. Chip still renders normally (the guard's condition is `!bookmark.is_mwe`).
- [ ] User has a single-word bookmark on a token that's NOT in any MWE group (e.g. tapped `Venus`). Open the article. Chip renders as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)