### PR TITLE
Auto-open alternatives menu when MT providers disagree

### DIFF
--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -77,21 +77,20 @@ export default function AlterMenu({
 
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
+  const headerBandStyle = {
+    whiteSpace: "nowrap",
+    backgroundColor: "rgba(139, 90, 43, 0.08)",
+    borderBottom: "1px solid rgba(139, 90, 43, 0.25)",
+    padding: "0.4rem 0.6rem",
+    margin: "-0.3em -0.3em 0.4rem -0.3em",
+  };
   const header = word.disagreement ? (
-    <div style={{
-      color: "crimson",
-      fontWeight: "bold",
-      whiteSpace: "nowrap",
-      backgroundColor: "rgba(220, 20, 60, 0.08)",
-      borderBottom: "1px solid rgba(220, 20, 60, 0.25)",
-      padding: "0.4rem 0.6rem",
-      margin: "-0.3em -0.3em 0.4rem -0.3em",
-    }}>
+    <div style={{ ...headerBandStyle, color: "crimson", fontWeight: "bold" }}>
       <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
       Bots disagree
     </div>
   ) : (
-    <div style={{ color: "orange", fontSize: "small" }}>Choose alternative</div>
+    <div style={{ ...headerBandStyle, color: "orange" }}>Alternatives</div>
   );
 
   return (

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -78,9 +78,9 @@ export default function AlterMenu({
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
-    <div style={{ color: "crimson", fontWeight: "bold" }}>
-      <span style={{ fontSize: "1.6em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
-      The bots disagree...
+    <div style={{ color: "crimson", fontWeight: "bold", whiteSpace: "nowrap" }}>
+      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
+      Bots disagree...
     </div>
   ) : (
     <div style={{ color: "orange", fontSize: "small" }}>Choose alternative</div>

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -1,5 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from "react";
-import { useClickOutside } from "react-click-outside-hook";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AlterMenuSC } from "./AlterMenu.sc";
 import LoadingAnimation from "../components/LoadingAnimation";
 
@@ -12,7 +11,7 @@ export default function AlterMenu({
   clickedOutsideTranslation,
   alternativesLoaded,
 }) {
-  const [refToAlterMenu, clickedOutsideAlterMenu] = useClickOutside();
+  const refToAlterMenu = useRef(null);
   const [inputValue, setInputValue] = useState("");
 
   useLayoutEffect(() => {
@@ -27,11 +26,31 @@ export default function AlterMenu({
     }
   }, [alternativesLoaded]);
 
+  // Modal-style outside-click handling: a capture-phase document listener
+  // fires before any target's own click handler, so we can stopPropagation
+  // BEFORE the tapped word's clickOnWord runs. This way a tap outside the
+  // menu just closes the menu — it doesn't translate the new word.
   useEffect(() => {
-    if (clickedOutsideAlterMenu && clickedOutsideTranslation) {
-      hideAlterMenu();
+    function handleCapture(e) {
+      const el = refToAlterMenu.current;
+      if (el && !el.contains(e.target)) {
+        // stopPropagation kills React's delegated onClick before it dispatches
+        // (so the tapped word doesn't translate). preventDefault on touchend
+        // also stops the browser from synthesizing the click that would
+        // otherwise slip through after our menu unmounts.
+        e.stopPropagation();
+        e.preventDefault();
+        hideAlterMenu();
+      }
     }
-  }, [clickedOutsideAlterMenu, clickedOutsideTranslation, hideAlterMenu]);
+    const opts = { capture: true, passive: false };
+    document.addEventListener("click", handleCapture, opts);
+    document.addEventListener("touchend", handleCapture, opts);
+    return () => {
+      document.removeEventListener("click", handleCapture, opts);
+      document.removeEventListener("touchend", handleCapture, opts);
+    };
+  }, [hideAlterMenu]);
 
   function handleKeyDown(e) {
     if (e.code === "Enter") {

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -78,12 +78,12 @@ export default function AlterMenu({
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
-    <>
-      <span style={{ fontSize: "2em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
+    <div style={{ color: "orange" }}>
+      <span style={{ fontSize: "1.6em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
       The bots disagree...
-    </>
+    </div>
   ) : (
-    "Choose alternative"
+    <div style={{ color: "orange", fontSize: "small" }}>Choose alternative</div>
   );
 
   return (
@@ -91,7 +91,7 @@ export default function AlterMenu({
       {/* Alternatives section - streams as they arrive */}
       {hasAlternatives && (
         <>
-          <div style={{ color: "orange", fontSize: "small" }}>{header}</div>
+          {header}
           {filteredAlternatives.map((each, index) => (
             <div
               key={`${each.translation}-${each.source}-${index}`}
@@ -112,8 +112,10 @@ export default function AlterMenu({
           ))}
         </>
       )}
-      {/* Show spinner while still loading */}
-      {!alternativesLoaded && (
+      {/* Spinner only when we have nothing to show yet — competing_translations
+          from the bookmark response already populate the list immediately, so
+          showing a spinner under them looks like a stray "extra option". */}
+      {!alternativesLoaded && !hasAlternatives && (
         <LoadingAnimation specificStyle={{ transform: "scale(0.4)", height: "2rem", margin: "0.5rem 0 -0.5rem 0" }} delay={0}></LoadingAnimation>
       )}
       {/* Only show "no alternatives" when done loading and none found */}

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -86,7 +86,7 @@ export default function AlterMenu({
       paddingBottom: "0.4rem",
       marginBottom: "0.4rem",
     }}>
-      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊</span>{" "}
+      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
       Bots disagree
     </div>
   ) : (

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -79,7 +79,7 @@ export default function AlterMenu({
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
     <div style={{ color: "crimson", fontWeight: "bold", whiteSpace: "nowrap" }}>
-      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
+      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊</span>{" "}
       Bots disagree...
     </div>
   ) : (

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -79,8 +79,8 @@ export default function AlterMenu({
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
     <>
-      <span style={{ fontSize: "1.8em", verticalAlign: "middle" }}>🤖🥊🤖</span>{" "}
-      The bots disagree...
+      The bots disagree...{" "}
+      <span style={{ fontSize: "1.8em", verticalAlign: "middle" }}>🤖🥊🤖</span>
     </>
   ) : (
     "Choose alternative"

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -77,7 +77,7 @@ export default function AlterMenu({
 
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
-  const headerText = word.disagreement ? "🤖 The bots disagree" : "Choose alternative";
+  const headerText = word.disagreement ? "🤖🥊🤖 The bots disagree" : "Choose alternative";
 
   return (
     <AlterMenuSC ref={refToAlterMenu}>

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -78,7 +78,7 @@ export default function AlterMenu({
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
-    <div style={{ color: "orange" }}>
+    <div style={{ color: "crimson", fontWeight: "bold" }}>
       <span style={{ fontSize: "1.6em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
       The bots disagree...
     </div>

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -39,25 +39,43 @@ export default function AlterMenu({
     }
   }
 
-  function shortenSource(word) {
-    if (word.source === "Microsoft - without context") {
-      return "Azure";
-    }
-    if (word.source === "Microsoft - with context") {
-      return "Azure (contextual)";
-    }
+  // Merge competing_translations (known immediately from the bookmark
+  // response, when providers disagree) with word.alternatives (streamed
+  // in lazily by AlterMenu open). Dedupe by normalised translation text
+  // and drop anything equal to the current primary translation.
+  function buildAlternatives(word) {
+    const seen = new Set();
+    const list = [];
+    const normaliseKey = (t) => (t || "").toLowerCase().trim();
+    const primaryKey = normaliseKey(word.translation);
+    if (primaryKey) seen.add(primaryKey);
 
-    if (word.source === "Google - without context") {
-      return "Google";
+    const sources = [word.competing_translations, word.alternatives];
+    for (const src of sources) {
+      if (!src) continue;
+      for (const entry of src) {
+        const key = normaliseKey(entry?.translation);
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        list.push(entry);
+      }
     }
-    if (word.source === "Google - with context") {
-      return "Google (contextual)";
-    }
-
-    return word.source;
+    return list;
   }
 
-  const filteredAlternatives = word.alternatives?.filter((each) => each.translation !== word.translation) || [];
+  function shortenSource(word) {
+    const labels = {
+      "Microsoft - without context": "Azure",
+      "Microsoft - with context": "Azure (contextual)",
+      "Microsoft - alignment": "Azure (alignment)",
+      "Google - without context": "Google",
+      "Google - with context": "Google (contextual)",
+      "DeepL - with context": "DeepL",
+    };
+    return labels[word.source] || word.source;
+  }
+
+  const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
 
   return (

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -77,14 +77,21 @@ export default function AlterMenu({
 
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
-  const headerText = word.disagreement ? "🤖🥊🤖 The bots disagree" : "Choose alternative";
+  const header = word.disagreement ? (
+    <>
+      <span style={{ fontSize: "1.8em", verticalAlign: "middle" }}>🤖🥊🤖</span>{" "}
+      The bots disagree...
+    </>
+  ) : (
+    "Choose alternative"
+  );
 
   return (
     <AlterMenuSC ref={refToAlterMenu}>
       {/* Alternatives section - streams as they arrive */}
       {hasAlternatives && (
         <>
-          <div style={{ color: "orange", fontSize: "small" }}>{headerText}</div>
+          <div style={{ color: "orange", fontSize: "small" }}>{header}</div>
           {filteredAlternatives.map((each, index) => (
             <div
               key={`${each.translation}-${each.source}-${index}`}

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -77,13 +77,14 @@ export default function AlterMenu({
 
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
+  const headerText = word.disagreement ? "🤖 The bots disagree" : "Choose alternative";
 
   return (
     <AlterMenuSC ref={refToAlterMenu}>
       {/* Alternatives section - streams as they arrive */}
       {hasAlternatives && (
         <>
-          <div style={{ color: "orange", fontSize: "small" }}>Choose alternative</div>
+          <div style={{ color: "orange", fontSize: "small" }}>{headerText}</div>
           {filteredAlternatives.map((each, index) => (
             <div
               key={`${each.translation}-${each.source}-${index}`}

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -82,9 +82,10 @@ export default function AlterMenu({
       color: "crimson",
       fontWeight: "bold",
       whiteSpace: "nowrap",
+      backgroundColor: "rgba(220, 20, 60, 0.08)",
       borderBottom: "1px solid rgba(220, 20, 60, 0.25)",
-      paddingBottom: "0.4rem",
-      marginBottom: "0.4rem",
+      padding: "0.4rem 0.6rem",
+      margin: "-0.3em -0.3em 0.4rem -0.3em",
     }}>
       <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
       Bots disagree

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -79,18 +79,19 @@ export default function AlterMenu({
   const hasAlternatives = filteredAlternatives.length > 0;
   const headerBandStyle = {
     whiteSpace: "nowrap",
-    backgroundColor: "rgba(139, 90, 43, 0.08)",
+    backgroundColor: "#ffe59e",
     borderBottom: "1px solid rgba(139, 90, 43, 0.25)",
     padding: "0.4rem 0.6rem",
     margin: "-0.3em -0.3em 0.4rem -0.3em",
+    fontWeight: 800,
   };
   const header = word.disagreement ? (
-    <div style={{ ...headerBandStyle, color: "crimson", fontWeight: "bold" }}>
+    <div style={{ ...headerBandStyle, color: "crimson" }}>
       <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
       Bots disagree
     </div>
   ) : (
-    <div style={{ ...headerBandStyle, color: "orange" }}>Alternatives</div>
+    <div style={{ ...headerBandStyle, color: "#01345d" }}>Alternatives</div>
   );
 
   return (

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -79,8 +79,8 @@ export default function AlterMenu({
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
     <>
-      The bots disagree...{" "}
-      <span style={{ fontSize: "1.8em", verticalAlign: "middle" }}>🤖🥊🤖</span>
+      <span style={{ fontSize: "2em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊🤖</span>{" "}
+      The bots disagree...
     </>
   ) : (
     "Choose alternative"

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -78,9 +78,16 @@ export default function AlterMenu({
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
   const header = word.disagreement ? (
-    <div style={{ color: "crimson", fontWeight: "bold", whiteSpace: "nowrap" }}>
+    <div style={{
+      color: "crimson",
+      fontWeight: "bold",
+      whiteSpace: "nowrap",
+      borderBottom: "1px solid rgba(220, 20, 60, 0.25)",
+      paddingBottom: "0.4rem",
+      marginBottom: "0.4rem",
+    }}>
       <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1 }}>🤖🥊</span>{" "}
-      Bots disagree...
+      Bots disagree
     </div>
   ) : (
     <div style={{ color: "orange", fontSize: "small" }}>Choose alternative</div>

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -1,6 +1,53 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AlterMenuSC } from "./AlterMenu.sc";
 import LoadingAnimation from "../components/LoadingAnimation";
+import { zeeguuLightYellow } from "../components/colors";
+
+const HEADER_BAND_STYLE = {
+  whiteSpace: "nowrap",
+  backgroundColor: zeeguuLightYellow,
+  borderBottom: "1px solid rgba(139, 90, 43, 0.25)",
+  padding: "0.4rem 0.6rem",
+  margin: "-0.3em -0.3em 0.4rem -0.3em",
+  fontWeight: 800,
+};
+
+const PROVIDER_LABELS = {
+  "Microsoft - without context": "Azure",
+  "Microsoft - with context": "Azure (contextual)",
+  "Microsoft - alignment": "Azure (alignment)",
+  "Google - without context": "Google",
+  "Google - with context": "Google (contextual)",
+  "DeepL - with context": "DeepL",
+};
+
+function shortenSource(alt) {
+  return PROVIDER_LABELS[alt.source] || alt.source;
+}
+
+// Merge competing_translations (known immediately from the bookmark
+// response, when providers disagree) with word.alternatives (streamed
+// in lazily by AlterMenu open). Dedupe by normalised translation text
+// and drop anything equal to the current primary translation.
+function buildAlternatives(word) {
+  const seen = new Set();
+  const list = [];
+  const normaliseKey = (t) => (t || "").toLowerCase().trim();
+  const primaryKey = normaliseKey(word.translation);
+  if (primaryKey) seen.add(primaryKey);
+
+  const sources = [word.competing_translations, word.alternatives];
+  for (const src of sources) {
+    if (!src) continue;
+    for (const entry of src) {
+      const key = normaliseKey(entry?.translation);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      list.push(entry);
+    }
+  }
+  return list;
+}
 
 export default function AlterMenu({
   word,
@@ -8,7 +55,6 @@ export default function AlterMenu({
   selectAlternative,
   deleteTranslation,
   ungroupMwe,
-  clickedOutsideTranslation,
   alternativesLoaded,
 }) {
   const refToAlterMenu = useRef(null);
@@ -58,64 +104,19 @@ export default function AlterMenu({
     }
   }
 
-  // Merge competing_translations (known immediately from the bookmark
-  // response, when providers disagree) with word.alternatives (streamed
-  // in lazily by AlterMenu open). Dedupe by normalised translation text
-  // and drop anything equal to the current primary translation.
-  function buildAlternatives(word) {
-    const seen = new Set();
-    const list = [];
-    const normaliseKey = (t) => (t || "").toLowerCase().trim();
-    const primaryKey = normaliseKey(word.translation);
-    if (primaryKey) seen.add(primaryKey);
-
-    const sources = [word.competing_translations, word.alternatives];
-    for (const src of sources) {
-      if (!src) continue;
-      for (const entry of src) {
-        const key = normaliseKey(entry?.translation);
-        if (!key || seen.has(key)) continue;
-        seen.add(key);
-        list.push(entry);
-      }
-    }
-    return list;
-  }
-
-  function shortenSource(word) {
-    const labels = {
-      "Microsoft - without context": "Azure",
-      "Microsoft - with context": "Azure (contextual)",
-      "Microsoft - alignment": "Azure (alignment)",
-      "Google - without context": "Google",
-      "Google - with context": "Google (contextual)",
-      "DeepL - with context": "DeepL",
-    };
-    return labels[word.source] || word.source;
-  }
-
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
-  const headerBandStyle = {
-    whiteSpace: "nowrap",
-    backgroundColor: "#ffe59e",
-    borderBottom: "1px solid rgba(139, 90, 43, 0.25)",
-    padding: "0.4rem 0.6rem",
-    margin: "-0.3em -0.3em 0.4rem -0.3em",
-    fontWeight: 800,
-  };
   const header = word.disagreement ? (
-    <div style={{ ...headerBandStyle, color: "crimson" }}>
+    <div style={{ ...HEADER_BAND_STYLE, color: "crimson" }}>
       <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
       Bots disagree
     </div>
   ) : (
-    <div style={{ ...headerBandStyle, color: "#01345d" }}>Alternatives</div>
+    <div style={{ ...HEADER_BAND_STYLE, color: "#01345d" }}>Alternatives</div>
   );
 
   return (
     <AlterMenuSC ref={refToAlterMenu}>
-      {/* Alternatives section - streams as they arrive */}
       {hasAlternatives && (
         <>
           {header}
@@ -145,7 +146,6 @@ export default function AlterMenu({
       {!alternativesLoaded && !hasAlternatives && (
         <LoadingAnimation specificStyle={{ transform: "scale(0.4)", height: "2rem", margin: "0.5rem 0 -0.5rem 0" }} delay={0}></LoadingAnimation>
       )}
-      {/* Only show "no alternatives" when done loading and none found */}
       {alternativesLoaded && !hasAlternatives && (
         <div className="noAlternatives">No alternative found</div>
       )}

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -6,12 +6,17 @@ const AlterMenuSC = styled.div`
   font-size: medium;
   z-index: 1000;
   text-align: left;
-  /* Reset the dashed translation-indicator underline that cascades in
-     from the parent z-orig / z-tag (article word styling). Without this
-     the underline shows under emoji / text inside the menu. */
-  text-decoration: none;
 
   position: absolute;
+
+  /* Cancel the dashed translation-indicator border-bottom that
+     TranslatableText.sc.js applies to every <span> inside <z-orig>.
+     The menu is rendered inside <z-orig>, so emoji / text spans inside
+     the menu otherwise inherit that orange dashed underline. */
+  span {
+    border-bottom: none;
+  }
+
   min-width: 14em;
   max-width: 30em;
   background-color: ${zeeguuVeryLightYellow};

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -8,15 +8,6 @@ const AlterMenuSC = styled.div`
   text-align: left;
 
   position: absolute;
-
-  /* Cancel the dashed translation-indicator border-bottom that
-     TranslatableText.sc.js applies to every <span> inside <z-orig>.
-     The menu is rendered inside <z-orig>, so emoji / text spans inside
-     the menu otherwise inherit that orange dashed underline. */
-  span {
-    border-bottom: none;
-  }
-
   min-width: 14em;
   max-width: 30em;
   background-color: ${zeeguuVeryLightYellow};

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -6,6 +6,10 @@ const AlterMenuSC = styled.div`
   font-size: medium;
   z-index: 1000;
   text-align: left;
+  /* Reset the dashed translation-indicator underline that cascades in
+     from the parent z-orig / z-tag (article word styling). Without this
+     the underline shows under emoji / text inside the menu. */
+  text-decoration: none;
 
   position: absolute;
   min-width: 14em;

--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -142,12 +142,19 @@ export default class InteractiveText {
       )
       .then((response) => response.data)
       .then((data) => {
+        // Dev/QA hook: localStorage.force_disagreement = "true" forces the
+        // disagreement UI on every tap so the auto-open + bots-disagree
+        // header are testable without waiting for a real provider split.
+        const forceDisagreement = localStorage.getItem("force_disagreement") === "true";
+        const competing = forceDisagreement
+          ? [{ translation: "(forced test alternative)", source: "DeepL - with context" }]
+          : (data.competing_translations || null);
         word.updateTranslation(
           data.translation,
           data.service_name,
           data.bookmark_id,
-          data.competing_translations || null,
-          data.disagreement === true,
+          competing,
+          forceDisagreement || data.disagreement === true,
         );
         // Mark word's translation as visible so the component renders it
         // This is especially important for MWEs where clicking any word

--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -2,6 +2,7 @@ import LinkedWordList from "./LinkedWordListClass";
 import ZeeguuSpeech from "../speech/APIBasedSpeech";
 import { EXERCISE_TYPES } from "../exercises/ExerciseTypeConstants";
 import { updateTokensWithBookmarks } from "./bookmarkRestoration";
+import { isDev } from "../config";
 
 // Set to true to enable verbose MWE/bookmark debugging
 const MWE_DEBUG = false;
@@ -142,10 +143,11 @@ export default class InteractiveText {
       )
       .then((response) => response.data)
       .then((data) => {
-        // Dev/QA hook: localStorage.force_disagreement = "true" forces the
-        // disagreement UI on every tap so the auto-open + bots-disagree
-        // header are testable without waiting for a real provider split.
-        const forceDisagreement = localStorage.getItem("force_disagreement") === "true";
+        // Dev/QA hook: in dev builds, localStorage.force_disagreement = "true"
+        // forces the disagreement UI on every tap so the auto-open + bots-
+        // disagree header are testable without waiting for a real split.
+        // Stripped from prod builds by Vite's import.meta.env.DEV tree-shake.
+        const forceDisagreement = isDev && localStorage.getItem("force_disagreement") === "true";
         const competing = forceDisagreement
           ? [{ translation: "(forced test alternative)", source: "DeepL - with context" }]
           : (data.competing_translations || null);

--- a/src/reader/InteractiveText.js
+++ b/src/reader/InteractiveText.js
@@ -142,7 +142,13 @@ export default class InteractiveText {
       )
       .then((response) => response.data)
       .then((data) => {
-        word.updateTranslation(data.translation, data.service_name, data.bookmark_id);
+        word.updateTranslation(
+          data.translation,
+          data.service_name,
+          data.bookmark_id,
+          data.competing_translations || null,
+          data.disagreement === true,
+        );
         // Mark word's translation as visible so the component renders it
         // This is especially important for MWEs where clicking any word
         // applies translation to the first word

--- a/src/reader/LinkedWordListClass.js
+++ b/src/reader/LinkedWordListClass.js
@@ -63,10 +63,12 @@ export class Word extends Item {
     }
   }
 
-  updateTranslation(translation, service_name, bookmark_id) {
+  updateTranslation(translation, service_name, bookmark_id, competing_translations = null, disagreement = false) {
     this.translation = translation;
     this.service_name = service_name;
     this.bookmark_id = bookmark_id;
+    this.competing_translations = competing_translations;
+    this.disagreement = disagreement;
   }
 
   splitIntoComponents() {

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -395,7 +395,7 @@ export default function TranslatableWord({
               <span className="arrow" onClick={(e) => toggleAlterMenu(e, word)}>
                 {showingAlterMenu ? "▲" : "▼"}
               </span>
-              {word.mergedTokens.length > 1 && (
+              {word.mergedTokens.length > 1 && !word.mweExpression && (
                 <span className="unlink low-oppacity translation-icon">
                   <LinkOffIcon
                     fontSize="8px"

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -417,16 +417,34 @@ export default function TranslatableWord({
             </span>
           )}
           {showingAlterMenu && (
-            <AlterMenu
-              word={word}
-              setShowingAlternatives={setShowingAlterMenu}
-              selectAlternative={selectAlternative}
-              hideAlterMenu={hideAlterMenu}
-              clickedOutsideTranslation={clickedOutsideTranslation}
-              deleteTranslation={deleteTranslation}
-              ungroupMwe={ungroupMwe}
-              alternativesLoaded={hasFetchedAlternatives}
-            />
+            <>
+              {/* Modal backdrop: captures clicks outside the menu so they
+                  close the menu instead of triggering a translation on the
+                  word that happened to be tapped. Sits below the menu
+                  (z-index 999 vs AlterMenuSC's 1000). */}
+              <div
+                onClick={hideAlterMenu}
+                style={{
+                  position: "fixed",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  zIndex: 999,
+                  background: "transparent",
+                }}
+              />
+              <AlterMenu
+                word={word}
+                setShowingAlternatives={setShowingAlterMenu}
+                selectAlternative={selectAlternative}
+                hideAlterMenu={hideAlterMenu}
+                clickedOutsideTranslation={clickedOutsideTranslation}
+                deleteTranslation={deleteTranslation}
+                ungroupMwe={ungroupMwe}
+                alternativesLoaded={hasFetchedAlternatives}
+              />
+            </>
           )}
         </z-orig>
       </z-tag>

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -417,34 +417,16 @@ export default function TranslatableWord({
             </span>
           )}
           {showingAlterMenu && (
-            <>
-              {/* Modal backdrop: captures clicks outside the menu so they
-                  close the menu instead of triggering a translation on the
-                  word that happened to be tapped. Sits below the menu
-                  (z-index 999 vs AlterMenuSC's 1000). */}
-              <div
-                onClick={hideAlterMenu}
-                style={{
-                  position: "fixed",
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  zIndex: 999,
-                  background: "transparent",
-                }}
-              />
-              <AlterMenu
-                word={word}
-                setShowingAlternatives={setShowingAlterMenu}
-                selectAlternative={selectAlternative}
-                hideAlterMenu={hideAlterMenu}
-                clickedOutsideTranslation={clickedOutsideTranslation}
-                deleteTranslation={deleteTranslation}
-                ungroupMwe={ungroupMwe}
-                alternativesLoaded={hasFetchedAlternatives}
-              />
-            </>
+            <AlterMenu
+              word={word}
+              setShowingAlternatives={setShowingAlterMenu}
+              selectAlternative={selectAlternative}
+              hideAlterMenu={hideAlterMenu}
+              clickedOutsideTranslation={clickedOutsideTranslation}
+              deleteTranslation={deleteTranslation}
+              ungroupMwe={ungroupMwe}
+              alternativesLoaded={hasFetchedAlternatives}
+            />
           )}
         </z-orig>
       </z-tag>

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -43,7 +43,26 @@ export default function TranslatableWord({
     if (word.translation) setIsTranslationVisible(false);
   }, [word]);
 
+  // Register a "close me" callback on the shared interactiveText while this
+  // word's AlterMenu is open, so a click on any other word can close it
+  // (see clickOnWord's early-return below) instead of triggering a translation.
+  useEffect(() => {
+    if (!showingAlterMenu) return;
+    interactiveText.closeOpenAlterMenu = hideAlterMenu;
+    return () => {
+      if (interactiveText.closeOpenAlterMenu === hideAlterMenu) {
+        interactiveText.closeOpenAlterMenu = null;
+      }
+    };
+  }, [showingAlterMenu, interactiveText]);
+
   function clickOnWord(e, word) {
+    // If any AlterMenu is open elsewhere, the user's first click should
+    // dismiss it — not translate / toggle a new word. Matches modal UX.
+    if (interactiveText.closeOpenAlterMenu) {
+      interactiveText.closeOpenAlterMenu();
+      return;
+    }
     if (word.token.is_like_num || (word.token.is_punct && word.word.length === 1)) return;
 
     // Compute MWE expression BEFORE any fusion happens (for pronunciation)

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -91,6 +91,11 @@ export default function TranslatableWord({
           if (mweGroupId && setLoadingMWEGroupId) {
             setLoadingMWEGroupId(null);
           }
+          // Backend flagged a 3-way provider disagreement; surface the
+          // alternatives menu so the user can pick the right answer.
+          if (word.disagreement) {
+            openAlterMenu(word);
+          }
         }, onFusionComplete);
       } else {
         // For non-translatable words in exercises, track the click
@@ -105,11 +110,7 @@ export default function TranslatableWord({
     }
   }
 
-  function toggleAlterMenu(e, word) {
-    if (showingAlterMenu) {
-      setShowingAlterMenu(false);
-      return;
-    }
+  function openAlterMenu(word) {
     setShowingAlterMenu(true);
     if (!hasFetchedAlternatives)
       interactiveText.alternativeTranslations(
@@ -117,6 +118,14 @@ export default function TranslatableWord({
         () => wordUpdated(word), // Called for each translation as it arrives
         () => setHasFetchedAlternatives(true), // Called when all done
       );
+  }
+
+  function toggleAlterMenu(e, word) {
+    if (showingAlterMenu) {
+      setShowingAlterMenu(false);
+      return;
+    }
+    openAlterMenu(word);
   }
 
   function unlinkLastWord(e, word) {

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -43,26 +43,7 @@ export default function TranslatableWord({
     if (word.translation) setIsTranslationVisible(false);
   }, [word]);
 
-  // Register a "close me" callback on the shared interactiveText while this
-  // word's AlterMenu is open, so a click on any other word can close it
-  // (see clickOnWord's early-return below) instead of triggering a translation.
-  useEffect(() => {
-    if (!showingAlterMenu) return;
-    interactiveText.closeOpenAlterMenu = hideAlterMenu;
-    return () => {
-      if (interactiveText.closeOpenAlterMenu === hideAlterMenu) {
-        interactiveText.closeOpenAlterMenu = null;
-      }
-    };
-  }, [showingAlterMenu, interactiveText]);
-
   function clickOnWord(e, word) {
-    // If any AlterMenu is open elsewhere, the user's first click should
-    // dismiss it — not translate / toggle a new word. Matches modal UX.
-    if (interactiveText.closeOpenAlterMenu) {
-      interactiveText.closeOpenAlterMenu();
-      return;
-    }
     if (word.token.is_like_num || (word.token.is_punct && word.word.length === 1)) return;
 
     // Compute MWE expression BEFORE any fusion happens (for pronunciation)

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -1,5 +1,4 @@
-import { useState, useEffect } from "react";
-import { useClickOutside } from "react-click-outside-hook";
+import { useState, useEffect, useRef } from "react";
 import AlterMenu from "./AlterMenu";
 import extractDomain from "../utils/web/extractDomain";
 import addProtocolToLink from "../utils/web/addProtocolToLink";
@@ -27,7 +26,7 @@ export default function TranslatableWord({
   setHighlightSolutionExpression,
 }) {
   const [showingAlterMenu, setShowingAlterMenu] = useState(false);
-  const [refToTranslation, clickedOutsideTranslation] = useClickOutside();
+  const refToTranslation = useRef(null);
   const [isClickedToPronounce, setIsClickedToPronounce] = useState(false);
   const [isWordTranslating, setIsWordTranslating] = useState(false);
   const [prevWord, setPreviousWord] = useState("");
@@ -112,11 +111,16 @@ export default function TranslatableWord({
 
   function openAlterMenu(word) {
     setShowingAlterMenu(true);
-    if (!hasFetchedAlternatives)
+    // Skip the SSE alternatives call when the bookmark response already
+    // carries competing translations (the disagreement auto-open path) —
+    // the menu has enough to show. If the user dismisses and reopens via
+    // the dropdown arrow, the call fires then (hasFetchedAlternatives
+    // is still false, no competing on this re-open).
+    if (!hasFetchedAlternatives && !word.competing_translations?.length)
       interactiveText.alternativeTranslations(
         word,
-        () => wordUpdated(word), // Called for each translation as it arrives
-        () => setHasFetchedAlternatives(true), // Called when all done
+        () => wordUpdated(word),
+        () => setHasFetchedAlternatives(true),
       );
   }
 
@@ -422,7 +426,6 @@ export default function TranslatableWord({
               setShowingAlternatives={setShowingAlterMenu}
               selectAlternative={selectAlternative}
               hideAlterMenu={hideAlterMenu}
-              clickedOutsideTranslation={clickedOutsideTranslation}
               deleteTranslation={deleteTranslation}
               ungroupMwe={ungroupMwe}
               alternativesLoaded={hasFetchedAlternatives}


### PR DESCRIPTION
## Summary

- Threads the new `competing_translations` + `disagreement` fields from `/get_one_translation` (server-side voter in zeeguu/api#607) through `InteractiveText.translate` → `Word.updateTranslation` → the Word object.
- When `word.disagreement` is `true` (the rare all-providers-disagreed case), auto-opens the alternatives menu on translation arrival so the user can resolve the ambiguity in one tap.
- Merges `word.competing_translations` (known immediately from the bookmark response) with the later-streamed `word.alternatives` in the `AlterMenu`, deduped against the primary and against each other.
- Adds `DeepL` and `Azure (alignment)` labels to `AlterMenu.shortenSource`'s lookup so the new provider sources render nicely.

## UX

| Server state | Result |
| --- | --- |
| Providers unanimous | Primary shown, no menu, no UI difference from before. |
| 2-of-3 majority, 1 dissenter | Primary shown silently. Menu, if user opens it manually, shows the dissenter at the top alongside the SSE-streamed alternatives. |
| All providers disagreed (no majority) | Primary shown, **menu auto-opens** with all candidate translations at the top — competing first (immediate), streamed alternatives appended as they arrive. User picks. |

No regression for words where providers agree (~95% of taps); the auto-open path only fires on the explicit disagreement flag.

## Files

- `src/reader/LinkedWordListClass.js` — `updateTranslation` now stores `competing_translations` + `disagreement` on the Word.
- `src/reader/InteractiveText.js` — passes those two fields from the API response into `updateTranslation`.
- `src/reader/TranslatableWord.js` — extracts `openAlterMenu(word)` (shared with `toggleAlterMenu`), called from the translate-success callback when `word.disagreement` is true.
- `src/reader/AlterMenu.js` — new `buildAlternatives(word)` merges/dedupes the two sources; `shortenSource` extended with DeepL + alignment labels.

## Test plan

- [ ] Server-side disagreement: tap a word where the backend logs `[TRANSLATION-DISAGREE] disagreement=True` — menu should auto-open with both/all candidate translations listed.
- [ ] Picking any alternative writes to the bookmark as before (no regression in the existing `selectAlternative` flow).
- [ ] Tap a word where all providers agree — menu does NOT auto-open, badge looks identical to before.
- [ ] 2-of-3 majority case (competing_translations present but `disagreement: false`): menu does NOT auto-open; opening it manually shows the dissenter at the top.
- [ ] DeepL alternative in the menu reads "DeepL", not "DeepL - with context".

## Related

- Server PR: zeeguu/api#607 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)