### PR TITLE
AlterMenu: dark-mode pass + cleaner layout

### DIFF
--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -1,23 +1,24 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AlterMenuSC } from "./AlterMenu.sc";
 import LoadingAnimation from "../components/LoadingAnimation";
-import { zeeguuLightYellow } from "../components/colors";
 
 const HEADER_BAND_STYLE = {
   whiteSpace: "nowrap",
-  backgroundColor: zeeguuLightYellow,
-  borderBottom: "1px solid rgba(139, 90, 43, 0.25)",
-  padding: "0.4rem 0.6rem",
-  margin: "-0.3em -0.3em 0.4rem -0.3em",
-  fontWeight: 800,
+  padding: "0.1rem 0 0.2rem",
+  fontSize: "0.7em",
+  fontWeight: 500,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  opacity: 0.7,
 };
 
 const PROVIDER_LABELS = {
   "Microsoft - without context": "Azure",
-  "Microsoft - with context": "Azure (contextual)",
-  "Microsoft - alignment": "Azure (alignment)",
+  "Microsoft - with context": "Azure",
+  "Microsoft - alignment": "Azure",
   "Google - without context": "Google",
-  "Google - with context": "Google (contextual)",
+  "Google - with context": "Google",
+  "Google - MWE phrase": "Google",
   "DeepL - with context": "DeepL",
 };
 
@@ -58,19 +59,33 @@ export default function AlterMenu({
   alternativesLoaded,
 }) {
   const refToAlterMenu = useRef(null);
+  const inputRef = useRef(null);
   const [inputValue, setInputValue] = useState("");
+  const [showOwnInput, setShowOwnInput] = useState(false);
+
+  useEffect(() => {
+    if (showOwnInput && inputRef.current) inputRef.current.focus();
+  }, [showOwnInput]);
 
   useLayoutEffect(() => {
     const el = refToAlterMenu.current;
-    if (el) {
-      // Reset to default (left-aligned) to measure natural position
-      el.style.right = "";
-      const rect = el.getBoundingClientRect();
-      if (rect.right > window.innerWidth) {
-        el.style.right = "0";
-      }
+    const trigger = el?.parentElement;
+    if (!el || !trigger) return;
+    const triggerRect = trigger.getBoundingClientRect();
+    const margin = 8;
+    el.style.position = "fixed";
+    el.style.margin = "0";
+    el.style.top = `${triggerRect.bottom + 4}px`;
+    // Measure the menu's intrinsic width once positioned
+    el.style.left = "0";
+    const elWidth = el.offsetWidth;
+    let left = triggerRect.left;
+    if (left + elWidth > window.innerWidth - margin) {
+      left = window.innerWidth - elWidth - margin;
     }
-  }, [alternativesLoaded]);
+    if (left < margin) left = margin;
+    el.style.left = `${left}px`;
+  });
 
   // Modal-style outside-click handling: a capture-phase document listener
   // fires before any target's own click handler, so we can stopPropagation
@@ -106,60 +121,63 @@ export default function AlterMenu({
 
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
-  const header = word.disagreement ? (
-    <div style={{ ...HEADER_BAND_STYLE, color: "crimson" }}>
-      <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
-      Bots disagree
-    </div>
-  ) : (
-    <div style={{ ...HEADER_BAND_STYLE, color: "#01345d" }}>Alternatives</div>
-  );
+  const showEmptyHeader = alternativesLoaded && !hasAlternatives;
+  let header = null;
+  if (word.disagreement) {
+    header = (
+      <div style={{ ...HEADER_BAND_STYLE, color: "var(--altermenu-header-text-disagreement)" }}>
+        <span style={{ fontSize: "1.4em", verticalAlign: "middle", lineHeight: 1, borderBottom: "none" }}>🤖🥊</span>{" "}
+        Bots disagree
+      </div>
+    );
+  } else if (hasAlternatives) {
+    header = (
+      <div style={{ ...HEADER_BAND_STYLE, color: "var(--altermenu-header-text)" }}>Alternatives</div>
+    );
+  } else if (showEmptyHeader) {
+    header = (
+      <div style={{ ...HEADER_BAND_STYLE, color: "var(--altermenu-header-text)" }}>No alternatives found</div>
+    );
+  }
 
   return (
     <AlterMenuSC ref={refToAlterMenu}>
-      {hasAlternatives && (
-        <>
-          {header}
-          {filteredAlternatives.map((each, index) => (
-            <div
-              key={`${each.translation}-${each.source}-${index}`}
-              onClick={(e) => selectAlternative(each.translation, shortenSource(each))}
-              className="additionalTrans"
-            >
-              {each.translation}
-              <div
-                style={{
-                  marginTop: "-4px",
-                  fontSize: 8,
-                  color: "rgb(240,204,160)",
-                }}
-              >
-                {shortenSource(each)}
-              </div>
-            </div>
-          ))}
-        </>
-      )}
+      {header}
+      {hasAlternatives && filteredAlternatives.map((each, index) => (
+        <div
+          key={`${each.translation}-${each.source}-${index}`}
+          onClick={(e) => selectAlternative(each.translation, shortenSource(each))}
+          className="additionalTrans"
+        >
+          {each.translation}
+          <div className="altermenuSourceLabel">{shortenSource(each)}</div>
+        </div>
+      ))}
       {/* Spinner only when we have nothing to show yet — competing_translations
           from the bookmark response already populate the list immediately, so
           showing a spinner under them looks like a stray "extra option". */}
       {!alternativesLoaded && !hasAlternatives && (
         <LoadingAnimation specificStyle={{ transform: "scale(0.4)", height: "2rem", margin: "0.5rem 0 -0.5rem 0" }} delay={0}></LoadingAnimation>
       )}
-      {alternativesLoaded && !hasAlternatives && (
-        <div className="noAlternatives">No alternative found</div>
+      {showOwnInput && (
+        <input
+          ref={inputRef}
+          autoComplete="off"
+          className="ownTranslationInput matchWidth"
+          type="text"
+          id="#userAlternative"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => handleKeyDown(e)}
+          placeholder="Type your translation and press Enter"
+        />
       )}
-      <input
-        autoComplete="off"
-        className="ownTranslationInput matchWidth"
-        type="text"
-        id="#userAlternative"
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={(e) => handleKeyDown(e)}
-        placeholder="Add own translation..."
-      />
       <div className="actionsSection">
+        {!showOwnInput && (
+          <div className="addOwnLink" onClick={() => setShowOwnInput(true)}>
+            Add own translation
+          </div>
+        )}
         {word.mweExpression && ungroupMwe && (
           <div className="removeLink" onClick={(e) => ungroupMwe(e, word)}>
             Ungroup expression

--- a/src/reader/AlterMenu.js
+++ b/src/reader/AlterMenu.js
@@ -12,18 +12,15 @@ const HEADER_BAND_STYLE = {
   opacity: 0.7,
 };
 
-const PROVIDER_LABELS = {
-  "Microsoft - without context": "Azure",
-  "Microsoft - with context": "Azure",
-  "Microsoft - alignment": "Azure",
-  "Google - without context": "Google",
-  "Google - with context": "Google",
-  "Google - MWE phrase": "Google",
-  "DeepL - with context": "DeepL",
+const PROVIDER_NAME_OVERRIDES = {
+  Microsoft: "Azure",
 };
 
 function shortenSource(alt) {
-  return PROVIDER_LABELS[alt.source] || alt.source;
+  // Source comes in as "Provider - variant" (e.g. "Microsoft - with context",
+  // "Google - MWE phrase"); collapse to just the provider name.
+  const provider = (alt.source || "").split(" - ")[0];
+  return PROVIDER_NAME_OVERRIDES[provider] || provider || alt.source;
 }
 
 // Merge competing_translations (known immediately from the bookmark
@@ -67,26 +64,6 @@ export default function AlterMenu({
     if (showOwnInput && inputRef.current) inputRef.current.focus();
   }, [showOwnInput]);
 
-  useLayoutEffect(() => {
-    const el = refToAlterMenu.current;
-    const trigger = el?.parentElement;
-    if (!el || !trigger) return;
-    const triggerRect = trigger.getBoundingClientRect();
-    const margin = 8;
-    el.style.position = "fixed";
-    el.style.margin = "0";
-    el.style.top = `${triggerRect.bottom + 4}px`;
-    // Measure the menu's intrinsic width once positioned
-    el.style.left = "0";
-    const elWidth = el.offsetWidth;
-    let left = triggerRect.left;
-    if (left + elWidth > window.innerWidth - margin) {
-      left = window.innerWidth - elWidth - margin;
-    }
-    if (left < margin) left = margin;
-    el.style.left = `${left}px`;
-  });
-
   // Modal-style outside-click handling: a capture-phase document listener
   // fires before any target's own click handler, so we can stopPropagation
   // BEFORE the tapped word's clickOnWord runs. This way a tap outside the
@@ -122,6 +99,28 @@ export default function AlterMenu({
   const filteredAlternatives = buildAlternatives(word);
   const hasAlternatives = filteredAlternatives.length > 0;
   const showEmptyHeader = alternativesLoaded && !hasAlternatives;
+
+  // Reposition only when something that can change menu dimensions changes;
+  // otherwise re-runs on every keystroke in the input force a reflow.
+  useLayoutEffect(() => {
+    const el = refToAlterMenu.current;
+    const trigger = el?.parentElement;
+    if (!el || !trigger) return;
+    const triggerRect = trigger.getBoundingClientRect();
+    const margin = 8;
+    el.style.position = "fixed";
+    el.style.margin = "0";
+    el.style.top = `${triggerRect.bottom + 4}px`;
+    el.style.left = "0";
+    const elWidth = el.offsetWidth;
+    let left = triggerRect.left;
+    if (left + elWidth > window.innerWidth - margin) {
+      left = window.innerWidth - elWidth - margin;
+    }
+    if (left < margin) left = margin;
+    el.style.left = `${left}px`;
+  }, [alternativesLoaded, hasAlternatives, showOwnInput, filteredAlternatives.length]);
+
   let header = null;
   if (word.disagreement) {
     header = (

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -3,6 +3,34 @@ import styled from "styled-components";
 import { almostBlack, zeeguuDarkRed, zeeguuLightYellow, zeeguuVeryLightYellow } from "../components/colors";
 
 const AlterMenuSC = styled.div`
+  --altermenu-bg: ${zeeguuVeryLightYellow};
+  --altermenu-text: ${almostBlack};
+  --altermenu-border: ${zeeguuLightYellow};
+  --altermenu-input-bg: white;
+  --altermenu-input-focus-border: ${almostBlack};
+  --altermenu-source-text: rgb(240, 204, 160);
+  --altermenu-action-text: ${zeeguuDarkRed};
+  --altermenu-action-border: ${zeeguuDarkRed};
+  --altermenu-link-text: hsl(216, 100%, 48%);
+  --altermenu-header-bg: ${zeeguuLightYellow};
+  --altermenu-header-text: #01345d;
+  --altermenu-header-text-disagreement: crimson;
+
+  :root[data-theme="dark"] & {
+    --altermenu-bg: rgb(50, 40, 30);
+    --altermenu-text: rgb(255, 240, 220);
+    --altermenu-border: rgb(90, 70, 40);
+    --altermenu-input-bg: rgb(35, 28, 20);
+    --altermenu-input-focus-border: rgb(255, 240, 220);
+    --altermenu-source-text: rgb(160, 130, 90);
+    --altermenu-action-text: #ff7a7a;
+    --altermenu-action-border: rgb(120, 60, 60);
+    --altermenu-link-text: hsl(216, 100%, 74%);
+    --altermenu-header-bg: rgb(70, 55, 35);
+    --altermenu-header-text: #ffcc66;
+    --altermenu-header-text-disagreement: #ff7a7a;
+  }
+
   font-size: medium;
   z-index: 1000;
   text-align: left;
@@ -10,22 +38,21 @@ const AlterMenuSC = styled.div`
   position: absolute;
   min-width: 14em;
   max-width: 30em;
-  background-color: ${zeeguuVeryLightYellow};
+  background-color: var(--altermenu-bg);
   border-radius: 0.5em;
   margin-top: 0.5em;
-  padding: 0.3em;
+  padding: 0.3em 0.8em 0.6em 0.8em;
   filter: drop-shadow(0 0 0.2rem rgb(0 0 0 / 50%));
 
   .additionalTrans {
     height: 100%;
     white-space: normal;
-    border-bottom: 1px solid ${zeeguuLightYellow} !important;
-    color: ${almostBlack};
+    color: var(--altermenu-text);
     line-height: 1em;
     cursor: pointer;
-    margin-top: 0.2em;
-    margin-left: 0.2em;
-    font-weight: 500;
+    margin-top: 0.4em;
+    margin-left: 0.8em;
+    font-weight: 600;
 
     &:hover {
       filter: brightness(90%);
@@ -45,15 +72,15 @@ const AlterMenuSC = styled.div`
 
   .ownTranslationInput {
     all: unset;
-    border: 0.17em solid ${zeeguuLightYellow};
+    border: 0.17em solid var(--altermenu-border);
     padding: 0.125em;
     padding-left: 0.5em;
     padding-right: 5px;
     height: 2em;
     width: 100%;
     box-sizing: border-box;
-    background: white;
-    color: ${almostBlack};
+    background: var(--altermenu-input-bg);
+    color: var(--altermenu-text);
     border-radius: 0.4em;
     font-weight: 400;
     font-size: 16px;
@@ -63,7 +90,7 @@ const AlterMenuSC = styled.div`
     }
 
     &:focus {
-      border: 0.17em solid ${almostBlack};
+      border: 0.17em solid var(--altermenu-input-focus-border);
       font-weight: 500;
     }
   }
@@ -71,7 +98,7 @@ const AlterMenuSC = styled.div`
   .alterMenuLink {
     //text-decoration: underline;
     margin-top: 0.2em;
-    border-top: 1px solid ${zeeguuLightYellow} !important;
+    border-top: 1px solid var(--altermenu-border) !important;
     color: orange;
     &:hover {
       filter: brightness(110%);
@@ -79,18 +106,33 @@ const AlterMenuSC = styled.div`
   }
 
   .actionsSection {
-    margin-top: 0.4rem;
-    padding-top: 0.3rem;
-    border-top: 1px solid ${zeeguuDarkRed};
+    margin-top: 0.8rem;
   }
 
   .removeLink {
     margin-top: 0.2rem;
-    color: ${zeeguuDarkRed};
+    color: var(--altermenu-action-text);
+    cursor: pointer;
 
     &:hover {
       filter: brightness(110%);
     }
+  }
+
+  .addOwnLink {
+    margin-top: 0.2rem;
+    color: var(--altermenu-link-text);
+    cursor: pointer;
+
+    &:hover {
+      filter: brightness(110%);
+    }
+  }
+
+  .altermenuSourceLabel {
+    margin-top: 2px;
+    font-size: 0.7em;
+    color: var(--altermenu-source-text);
   }
 `;
 

--- a/src/reader/AlterMenu.sc.js
+++ b/src/reader/AlterMenu.sc.js
@@ -109,9 +109,9 @@ const AlterMenuSC = styled.div`
     margin-top: 0.8rem;
   }
 
-  .removeLink {
+  .removeLink,
+  .addOwnLink {
     margin-top: 0.2rem;
-    color: var(--altermenu-action-text);
     cursor: pointer;
 
     &:hover {
@@ -119,14 +119,12 @@ const AlterMenuSC = styled.div`
     }
   }
 
-  .addOwnLink {
-    margin-top: 0.2rem;
-    color: var(--altermenu-link-text);
-    cursor: pointer;
+  .removeLink {
+    color: var(--altermenu-action-text);
+  }
 
-    &:hover {
-      filter: brightness(110%);
-    }
+  .addOwnLink {
+    color: var(--altermenu-link-text);
   }
 
   .altermenuSourceLabel {

--- a/src/reader/ToolbarButtons.js
+++ b/src/reader/ToolbarButtons.js
@@ -50,16 +50,22 @@ export default function ToolbarButtons({
           position: "absolute",
           top: "100%",
           right: "0",
-          backgroundColor: "white",
-          border: "1px solid #ccc",
+          backgroundColor: "var(--card-bg)",
+          color: "var(--text-primary)",
+          border: "1px solid var(--border-color)",
           borderRadius: "4px",
-          boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+          boxShadow: "0 2px 8px var(--shadow-color)",
           zIndex: 1000,
           padding: "1rem",
           minWidth: "200px"
         }}>
           <ThemeProvider theme={t}>
-            <FormGroup>
+            <FormGroup
+              sx={{
+                "& .MuiFormControlLabel-label": { color: "var(--text-primary)" },
+                "& .MuiFormHelperText-root": { color: "var(--text-secondary)" },
+              }}
+            >
               <FormHelperText>{"Click word(s) to:"}</FormHelperText>
               <FormControlLabel
                 checked={translating}

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -5,12 +5,10 @@ const TranslatableText = styled.div`
   /* MWE adjacent color - matches single-word zeeguuOrange */
   --mwe-adjacent-color: ${zeeguuOrange};
   --mwe-adjacent-bg: rgb(255, 240, 220);
-  --translation-chip-text: ${almostBlack};
 
-  /* Dark mode: invert the chip — dark bg, pale text */
+  /* Dark mode: invert the chip — dark bg, light text */
   :root[data-theme="dark"] & {
     --mwe-adjacent-bg: rgb(50, 40, 30);
-    --translation-chip-text: rgb(255, 240, 220);
   }
 
   /* ========================================================================
@@ -264,7 +262,7 @@ const TranslatableText = styled.div`
     line-height: 1.1rem;
     max-width: 100%;
     font-weight: 600;
-    color: var(--translation-chip-text);
+    color: var(--text-primary);
     text-align: left;
     display: flex;
   }

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -5,6 +5,13 @@ const TranslatableText = styled.div`
   /* MWE adjacent color - matches single-word zeeguuOrange */
   --mwe-adjacent-color: ${zeeguuOrange};
   --mwe-adjacent-bg: rgb(255, 240, 220);
+  --translation-chip-text: ${almostBlack};
+
+  /* Dark mode: invert the chip — dark bg, pale text */
+  :root[data-theme="dark"] & {
+    --mwe-adjacent-bg: rgb(50, 40, 30);
+    --translation-chip-text: rgb(255, 240, 220);
+  }
 
   /* ========================================================================
    * BASE Z-TAG STYLES
@@ -257,7 +264,7 @@ const TranslatableText = styled.div`
     line-height: 1.1rem;
     max-width: 100%;
     font-weight: 600;
-    color: ${almostBlack};
+    color: var(--translation-chip-text);
     text-align: left;
     display: flex;
   }


### PR DESCRIPTION
## Summary

A polish pass on the alternative-translations menu, focused on dark-mode legibility and tightening the layout.

### Dark mode
- Route AlterMenu colors through CSS variables that flip under `:root[data-theme="dark"]` — warm dark bg, pale cream text/borders, amber accents, coral red for destructive, lighter blue for the custom-translation action.
- Same flip for the translation chip on words (`z-tran`): dark bg + pale text in dark mode, replacing the eye-burning cream chip.

### Layout cleanup
- Drop the row-by-row borders inside the menu and the red separator above the action links; rely on whitespace + indentation instead.
- Turn "Alternatives" / "Bots disagree" / empty state into a single thin uppercase section label; the bulky italic "No alternative found" message is now just `NO ALTERNATIVES FOUND` in the same slot.
- Indent the alternative rows under the section header; keep the action links flush left.
- Bump alternative-row weight to 600 so they hold primacy against the saturated blue/red action colors.

### Input + actions
- Hide the "Add own translation" input behind a blue link; revealing it focuses the input. The inline always-shown input was visual noise for a rarely-used escape hatch.

### Provider labels
- Strip parenthetical suffixes ("contextual", "alignment", "MWE phrase") — users only need to know Azure vs Google vs DeepL.
- Bump source-label font size from 8px to 0.7em so it's actually legible.

### Positioning
- Switch the menu from `position: absolute` to `position: fixed` with a viewport-clamped `left` so it never overflows the right edge on small viewports — the parent-relative `right: 0` trick wasn't reliable when the trigger word was wide or right-leaning.

## Test plan

- [ ] Light mode: tap a translated word with multiple alternatives — menu is cream with dark text, "ALTERNATIVES" label is dim navy, source labels readable
- [ ] Dark mode: same flow — menu is warm-dark with cream text, no eye-burning bright surfaces
- [ ] Word near the right edge of viewport — menu clamps inside the viewport, doesn't overflow
- [ ] Empty state — tap a word with no alternatives, "NO ALTERNATIVES FOUND" label shown
- [ ] "Add own translation" — clicking reveals the input focused; Enter submits
- [ ] Bots-disagree path — auto-opened menu still shows the 🤖🥊 "Bots disagree" header
- [ ] Provider labels read as "Azure" / "Google" / "DeepL" / "LLM" (no parentheticals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)