### PR TITLE
Read: simplified version supersedes the original everywhere

### DIFF
--- a/src/api/classDef.js
+++ b/src/api/classDef.js
@@ -41,6 +41,21 @@ const Zeeguu_API = class {
     return null;
   }
 
+  // Drop cached responses whose endpoint starts with `endpointPrefix`.
+  // Use after mutations that should make the user see fresh data
+  // immediately (e.g. simplifying an article → feed should drop the
+  // original).
+  invalidateCache(endpointPrefix) {
+    for (const key of this._cache.keys()) {
+      // Keys are `${lang}:${endpoint}` — match against the endpoint half.
+      const colonIdx = key.indexOf(":");
+      const endpoint = colonIdx === -1 ? key : key.slice(colonIdx + 1);
+      if (endpoint.startsWith(endpointPrefix)) {
+        this._cache.delete(key);
+      }
+    }
+  }
+
   apiLog(what) {
     console.log("➡️ " + what);
   }

--- a/src/articles/ArticleListBrowser.js
+++ b/src/articles/ArticleListBrowser.js
@@ -200,8 +200,16 @@ export default function ArticleListBrowser({ content, searchQuery, searchPublish
     );
   }
 
+  // Pull-to-refresh should always hit the network — otherwise a cached
+  // recommendations response (5-min TTL) keeps serving stale data and
+  // the user can't see fresh results without restarting the app.
+  const refreshFromNetwork = async () => {
+    api.invalidateCache("user_articles/recommended");
+    await loadArticles();
+  };
+
   return (
-    <PullToRefresh onRefresh={loadArticles} pullingContent="">
+    <PullToRefresh onRefresh={refreshFromNetwork} pullingContent="">
       <>
       {!searchQuery && (
         <>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -161,19 +161,23 @@ export default function ArticlePreview({
 
   const is_saved = article.has_personal_copy || article.has_uploader || isArticleSaved === true;
   const externalUrl = article.parent_url || article.url;
+  // If the user has already simplified this article, the in-app reader has
+  // a readable version (the child) — open that instead of bouncing externally.
+  const inAppArticleId = article.user_simplified_article_id || article.id;
   const should_open_in_zeeguu = Feature.always_open_externally()
     ? is_saved
     : article.video ||
       (!Feature.extension_experiment1() && !hasExtension) ||
       is_saved ||
-      article.parent_article_id; // Simplified articles (with parent_article_id) always open in Zeeguu reader
+      article.parent_article_id || // Simplified articles (with parent_article_id) always open in Zeeguu reader
+      article.user_simplified_article_id; // Original whose simplified child the user already has
   const should_open_with_modal = doNotShowRedirectionModal_UserPreference === false;
 
   function imageLink() {
     const img = <img alt="" src={article.img_url} style={{ cursor: "pointer" }} />;
     if (should_open_in_zeeguu) {
       return (
-        <Link to={`/read/article?id=${article.id}`} onClick={handleArticleClick}>
+        <Link to={`/read/article?id=${inAppArticleId}`} onClick={handleArticleClick}>
           {img}
         </Link>
       );
@@ -205,7 +209,7 @@ export default function ArticlePreview({
   }
 
   function titleLink(article) {
-    let linkToRedirect = `/read/article?id=${article.id}`;
+    let linkToRedirect = `/read/article?id=${inAppArticleId}`;
 
     let open_in_zeeguu = (
       <ActionButton as={Link} to={linkToRedirect} onClick={handleArticleClick}>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -34,11 +34,15 @@ export default function ArticlePreview({
   onArticleHidden,
   onUnhideArticle,
   isHiddenView = false,
+  inSavedView = false,
 }) {
   const api = useContext(APIContext);
   const getBrowsingSessionId = useContext(BrowsingSessionContext);
   const [isRedirectionModalOpen, setIsRedirectionModaOpen] = useState(false);
-  const [isArticleSaved, setIsArticleSaved] = useState(article.has_personal_copy);
+  // In a saved view (My Articles, Classroom, etc.) the article is in the
+  // list precisely because it's saved — treat it as such even if the
+  // article's has_personal_copy flag hasn't propagated correctly.
+  const [isArticleSaved, setIsArticleSaved] = useState(article.has_personal_copy || inSavedView);
   const [showInferredTopic, setShowInferredTopic] = useState(true);
   const [interactiveSummary, setInteractiveSummary] = useState(null);
   const [interactiveTitle, setInteractiveTitle] = useState(null);

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -161,16 +161,18 @@ export default function ArticlePreview({
 
   const is_saved = article.has_personal_copy || article.has_uploader || isArticleSaved === true;
   const externalUrl = article.parent_url || article.url;
-  // If the user has already simplified this article, the in-app reader has
-  // a readable version (the child) — open that instead of bouncing externally.
+  // Either flavor of simplification gives us a Zeeguu-readable body —
+  // a simplified article (parent_article_id set) or an original whose
+  // simplified child this user already has (user_simplified_article_id).
+  // The Link target in either case is the simplified id.
+  const hasInAppSimplification = !!(article.parent_article_id || article.user_simplified_article_id);
   const inAppArticleId = article.user_simplified_article_id || article.id;
   const should_open_in_zeeguu = Feature.always_open_externally()
-    ? is_saved
+    ? is_saved || hasInAppSimplification
     : article.video ||
       (!Feature.extension_experiment1() && !hasExtension) ||
       is_saved ||
-      article.parent_article_id || // Simplified articles (with parent_article_id) always open in Zeeguu reader
-      article.user_simplified_article_id; // Original whose simplified child the user already has
+      hasInAppSimplification;
   const should_open_with_modal = doNotShowRedirectionModal_UserPreference === false;
 
   function imageLink() {

--- a/src/articles/BookmarkedArticles.js
+++ b/src/articles/BookmarkedArticles.js
@@ -28,7 +28,12 @@ export default function BookmarkedArticles() {
   return (
     <>
       {articleList.map((each) => (
-        <ArticlePreview key={each.id} article={each} dontShowPublishingTime={true} />
+        <ArticlePreview
+          key={each.id}
+          article={each}
+          dontShowPublishingTime={true}
+          inSavedView={true}
+        />
       ))}
     </>
   );

--- a/src/articles/BookmarkedArticles.js
+++ b/src/articles/BookmarkedArticles.js
@@ -1,4 +1,5 @@
 import { useContext, useState } from "react";
+import PullToRefresh from "react-simple-pull-to-refresh";
 import LoadingAnimation from "../components/LoadingAnimation";
 import { setTitle } from "../assorted/setTitle";
 import strings from "../i18n/definitions";
@@ -11,30 +12,40 @@ export default function BookmarkedArticles() {
   const api = useContext(APIContext);
   const [articleList, setArticleList] = useState(null);
 
-  if (articleList == null) {
-    api.getBookmarkedArticles((articles) => {
-      setArticleList(articles);
+  const fetchBookmarked = () =>
+    new Promise((resolve) => {
+      api.getBookmarkedArticles((articles) => {
+        setArticleList(articles);
+        resolve();
+      });
     });
 
+  if (articleList == null) {
+    fetchBookmarked();
     setTitle("Bookmarked Articles");
-
     return <LoadingAnimation />;
   }
 
   if (articleList.length === 0) {
-    return <s.YellowMessageBox>{strings.noBookmarksYet}</s.YellowMessageBox>;
+    return (
+      <PullToRefresh onRefresh={fetchBookmarked} pullingContent="">
+        <s.YellowMessageBox>{strings.noBookmarksYet}</s.YellowMessageBox>
+      </PullToRefresh>
+    );
   }
 
   return (
-    <>
-      {articleList.map((each) => (
-        <ArticlePreview
-          key={each.id}
-          article={each}
-          dontShowPublishingTime={true}
-          inSavedView={true}
-        />
-      ))}
-    </>
+    <PullToRefresh onRefresh={fetchBookmarked} pullingContent="">
+      <>
+        {articleList.map((each) => (
+          <ArticlePreview
+            key={each.id}
+            article={each}
+            dontShowPublishingTime={true}
+            inSavedView={true}
+          />
+        ))}
+      </>
+    </PullToRefresh>
   );
 }

--- a/src/articles/_ArticlesRouter.js
+++ b/src/articles/_ArticlesRouter.js
@@ -47,14 +47,14 @@ export default function ArticlesRouter({ hasExtension, isChrome }) {
 
   const tabs = [
     !hideRecommendations && { text: "Discover", link: "/articles" },
+    { text: strings.myArticles, link: "/articles/bookmarked" },
+    isStudent && { text: strings.classroomTab, link: "/articles/classroom" },
     !hideRecommendations && {
       text: searchIcon,
       link: "/articles/mySearches",
       // Stay active on /search too — results are conceptually the search tab.
       isActive: (_, loc) => loc.pathname === "/articles/mySearches" || loc.pathname === "/search",
     },
-    { text: strings.myArticles, link: "/articles/bookmarked" },
-    isStudent && { text: strings.classroomTab, link: "/articles/classroom" },
   ].filter(Boolean);
 
   const swipeRef = useTabbedRoute(

--- a/src/articles/_ArticlesRouter.js
+++ b/src/articles/_ArticlesRouter.js
@@ -40,8 +40,8 @@ export default function ArticlesRouter({ hasExtension, isChrome }) {
   }, [location.pathname]);
 
   const searchIcon = (
-    <span style={{ display: "inline-flex", alignItems: "center", padding: "0 0.25em" }}>
-      <SearchRoundedIcon style={{ fontSize: "1.25rem" }} />
+    <span style={{ display: "inline-block", padding: "0 0.25em", verticalAlign: "middle" }}>
+      <SearchRoundedIcon style={{ fontSize: "1.25rem", verticalAlign: "middle" }} />
     </span>
   );
 

--- a/src/components/modal_shared/Modal.sc.js
+++ b/src/components/modal_shared/Modal.sc.js
@@ -60,8 +60,8 @@ const ModalWrapper = styled(Box)`
   }
 
   @media (max-width: 576px) {
-    padding: 24px 24px;
-    width: 80%;
+    padding: 20px 16px;
+    width: 92%;
   }
 `;
 

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -122,6 +122,16 @@ export default function ArticleReader({ teacherArticleID }) {
     uploadScrollActivity();
   }
 
+  // Leaving the reader invalidates the Discover cache. Reading an article
+  // can flip its has_personal_copy state (simplify, save) or the original
+  // can be superseded by a simplified child — and the feed's 5-min cache
+  // would otherwise keep showing the pre-read view until it expires.
+  useEffect(() => {
+    return () => {
+      api.invalidateCache("user_articles/recommended");
+    };
+  }, [api]);
+
   useEffect(() => {
     // Reset state when articleID changes (e.g., deep link to new article)
     setArticleInfo(undefined);

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -345,6 +345,10 @@ export default function ArticleReader({ teacherArticleID }) {
       // "already_done" (existing version at user's level) — handle both.
       const simplified = result.levels?.find((l) => !l.is_original);
       if (simplified) {
+        // Drop the cached Discover feed so the original (now superseded
+        // by the simplified child) doesn't keep appearing for up to 5
+        // minutes after the user simplifies.
+        api.invalidateCache("user_articles/recommended");
         history.replace("/read/article?id=" + simplified.id);
         return;
       }


### PR DESCRIPTION
## Summary

Frontend half of the simplified-supersedes-original fix. After a user simplifies an article, the original used to keep appearing in Discover and My Articles with its old "Open ↗" external button — because the original has no in-app readable body and the frontend didn't know a simplified child existed for this user. The [api PR](https://github.com/zeeguu/api/pull/612) adds server-side dedup + a new \`user_simplified_article_id\` field on originals; this PR consumes the field and invalidates the cached feed after a simplify.

- **\`ArticlePreview\`**: \`should_open_in_zeeguu\` now also flips on for \`article.user_simplified_article_id\`, and the \`Link\` target uses that id when present. So even if an original ever surfaces, "Open" goes to the readable child instead of the publisher.
- **\`Zeeguu_API.invalidateCache(endpointPrefix)\`**: drops cached \`_cache\` entries whose endpoint starts with the prefix. Language-agnostic, so we don't have to know which language was active when a stale entry was written.
- **\`ArticleReader.handleSimplify\`**: invalidates \`user_articles/recommended\` after a successful simplify. Without this, the 5-min TTL would keep the original visible in Discover for up to 5 more minutes.

## Test plan

- [ ] Open Discover → tap an article → Simplify → return to Discover → original no longer appears (was previously stuck for up to 5 min due to API cache)
- [ ] Same flow but go to My Articles → only the simplified version listed, with the "Simplified" tag
- [ ] Articles without simplifications behave exactly as before (Open external for non-saved, in-app for saved)
- [ ] Pair with [zeeguu/api#612](https://github.com/zeeguu/api/pull/612) — UI fallback works alone, but the API PR is what makes the feed actually drop the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)