### PR TITLE
Session: route writes through api.setSession, mirror in React state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ import { API_ENDPOINT, APP_DOMAIN } from "./appConstants";
 import { AUDIO_STATUS, GENERATION_PROGRESS } from "./dailyAudio/AudioLessonConstants";
 
 import {
-  getSharedSession,
+  getStoredSession,
   removeSharedUserInfo,
   saveSharedUserInfo,
   initializeSession,
@@ -68,7 +68,18 @@ function LocationTrackingWrapper({ children }) {
 }
 
 function App() {
-  const [api] = useState(new Zeeguu_API(API_ENDPOINT));
+  // Lazy init: set api.session synchronously before any effect runs, so hooks
+  // declared above the main session-loading effect (e.g. useTranslationOnboarding)
+  // don't fire requests with session=undefined on first mount.
+  const [api] = useState(() => {
+    const a = new Zeeguu_API(API_ENDPOINT);
+    a.session = getStoredSession();
+    return a;
+  });
+  // React-state mirror of api.session. Updated via api.onSessionChange below so
+  // every imperative api.setSession call (login, logout, anon restore, polling)
+  // propagates to consumers of UserContext.
+  const [session, setSession] = useState(() => getStoredSession());
   const themeValue = useTheme();
 
   useUILanguage();
@@ -84,12 +95,18 @@ function App() {
   const translationModal = useTranslationOnboarding(api, userDetails);
 
   const [systemLanguages, setSystemLanguages] = useState();
-  // Initialize session from native storage (for Capacitor) before doing anything else
+  // Initialize session from native storage (for Capacitor) before doing anything else.
+  // On Capacitor, getStoredSession() returns null until Preferences resolves — push
+  // the resolved value through api.setSession so it lands in both api and React state.
   useEffect(() => {
-    initializeSession().then(() => {
+    initializeSession().then((storedSession) => {
+      if (storedSession) api.setSession(storedSession);
       setSessionInitialized(true);
     });
-  }, []);
+  }, [api]);
+
+  // Bridge imperative api.session mutations into React state.
+  useEffect(() => api.onSessionChange(setSession), [api]);
 
   useEffect(() => {
     api.getSystemLanguages((languages) => {
@@ -181,7 +198,10 @@ function App() {
     // we get the latest feature flags for this user and save
     // them in the LocalStorage
 
-    api.session = getSharedSession();
+    // api.session was already initialized synchronously (web) or via the
+    // initializeSession effect above (Capacitor). Re-read here as a defensive
+    // sync in case storage changed between mount and this effect.
+    api.setSession(getStoredSession());
 
     // Only validate if there is a session.
     if (api.session !== undefined && api.session !== null) {
@@ -216,7 +236,7 @@ function App() {
           anonCredentials.password,
           (session) => {
             console.log("Anonymous login successful");
-            api.session = session;
+            api.setSession(session);
             saveSharedUserInfo({ name: "Guest", native_language: "en" }, session);
             loadUserDetails();
           },
@@ -237,9 +257,13 @@ function App() {
       }
     }
 
-    // Log out user on zeeguu.org if they log out of the extension
+    // Log out user on zeeguu.org if they log out of the extension.
+    // Detect storage-side session loss and propagate to api + React state so
+    // PrivateRoute redirects to /log_in. Guard on api.session being set so we
+    // don't fire setState every tick after we've already cleared.
     const interval = setInterval(() => {
-      if (!getSharedSession()) {
+      if (!getStoredSession() && api.session) {
+        api.setSession(undefined);
         setUserDetails({});
         setUserPreferences({});
       }
@@ -257,11 +281,12 @@ function App() {
     setUserPreferences({});
 
     removeSharedUserInfo();
+    api.setSession(undefined);
   }
 
   function handleSuccessfulLogIn(userInfo, sessionId, redirectToArticle = true) {
     console.log("HANDLE SUCCESSFUL SIGN IN");
-    api.session = sessionId;
+    api.setSession(sessionId);
     LocalStorage.setUserInfo(userInfo);
     LocalStorage.clearAnonCredentials(); // Clear anonymous credentials on real login
 
@@ -325,7 +350,7 @@ function App() {
                     setUserDetails,
                     userPreferences,
                     setUserPreferences,
-                    session: getSharedSession(),
+                    session,
                     logoutMethod: logout,
                   }}
                 >

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -26,7 +26,7 @@ import MyArticlesRouter from "./myArticles/_MyArticlesRouter";
 import ArticleReader from "./reader/ArticleReader";
 import SharedArticleHandler from "./reader/SharedArticleHandler";
 import LoadingAnimation from "./components/LoadingAnimation";
-import { getSharedSession } from "./utils/cookies/userInfo";
+import { getStoredSession } from "./utils/cookies/userInfo";
 import LocalStorage from "./assorted/LocalStorage";
 import { Capacitor } from "@capacitor/core";
 import useAnonymousUpgrade from "./hooks/useAnonymousUpgrade";
@@ -66,7 +66,7 @@ const isCapacitor = () => {
 // Component to handle mobile app homepage redirect
 function HomePage() {
   // Check if user is logged in first
-  const session = getSharedSession();
+  const session = getStoredSession();
   if (session) {
     // User is logged in - redirect to articles (or last visited page)
     const lastVisitedPage = LocalStorage.getLastVisitedPage();

--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -34,7 +34,7 @@ Zeeguu_API.prototype.addUser = function (invite_code, password, userInfo, onSucc
     .then((response) => {
       if (response.ok) {
         response.text().then((session) => {
-          this.session = session;
+          this.setSession(session);
           onSuccess(session);
         });
       } else if (response.status === 400) {
@@ -65,7 +65,7 @@ Zeeguu_API.prototype.addBasicUser = function (invite_code, password, userInfo, o
     .then((response) => {
       if (response.ok) {
         response.text().then((session) => {
-          this.session = session;
+          this.setSession(session);
           onSuccess(session);
         });
       } else if (response.status === 400) {
@@ -95,7 +95,7 @@ Zeeguu_API.prototype.logIn = function (email, password, onError, onSuccess) {
       response.json().then((data) => {
         if (response.status === 200) {
           console.log("GOT SESSOIN: " + data);
-          this.session = data.session;
+          this.setSession(data.session);
           onSuccess(data.session);
           return;
         }
@@ -147,7 +147,7 @@ Zeeguu_API.prototype.addAnonUser = function (uuid, password, invite_code, langua
     .then((response) => {
       if (response.ok) {
         response.text().then((session) => {
-          this.session = session;
+          this.setSession(session);
           onSuccess(session);
         });
       } else if (response.status === 400) {
@@ -175,7 +175,7 @@ Zeeguu_API.prototype.logInAnon = function (uuid, password, onSuccess, onError) {
     .then((response) => {
       if (response.ok) {
         response.text().then((session) => {
-          this.session = session;
+          this.setSession(session);
           onSuccess(session);
         });
       } else {

--- a/src/api/classDef.js
+++ b/src/api/classDef.js
@@ -83,8 +83,7 @@ const Zeeguu_API = class {
     // Without this guard, `this.session` being undefined produced literal
     // `session=undefined` in the URL — auth endpoints then 401 in a loop
     // instead of failing cleanly so the caller can route to login.
-    const hasSession = this.session !== undefined && this.session !== null && this.session !== "";
-    if (!hasSession) {
+    if (!this.session) {
       return `${this.baseAPIurl}/${endpointName}`;
     }
     const separator = endpointName.includes("?") ? "&" : "?";

--- a/src/api/classDef.js
+++ b/src/api/classDef.js
@@ -22,7 +22,22 @@ const Zeeguu_API = class {
   constructor(baseAPIurl) {
     this.baseAPIurl = baseAPIurl;
     this._cache = new Map();
+    this._sessionListeners = new Set();
     //this.session = currentSession; is instantiated in App when the user logs in (causes error to actually instantiate it here).
+  }
+
+  // Single mutation point for the session. Direct assignment (`api.session = X`)
+  // is the historic pattern but bypasses listeners — App-level React state and
+  // imperative API mutation drift apart, producing `session=undefined` URLs and
+  // stale-session bugs. All new code should go through here.
+  setSession(value) {
+    this.session = value || undefined;
+    this._sessionListeners.forEach((fn) => fn(this.session));
+  }
+
+  onSessionChange(fn) {
+    this._sessionListeners.add(fn);
+    return () => this._sessionListeners.delete(fn);
   }
 
   // Cache keys include the learned language so switching languages
@@ -65,10 +80,15 @@ const Zeeguu_API = class {
   }
 
   _appendSessionToUrl(endpointName) {
-    if (endpointName.includes("?")) {
-      return `${this.baseAPIurl}/${endpointName}&session=${this.session}`;
+    // Without this guard, `this.session` being undefined produced literal
+    // `session=undefined` in the URL — auth endpoints then 401 in a loop
+    // instead of failing cleanly so the caller can route to login.
+    const hasSession = this.session !== undefined && this.session !== null && this.session !== "";
+    if (!hasSession) {
+      return `${this.baseAPIurl}/${endpointName}`;
     }
-    return `${this.baseAPIurl}/${endpointName}?session=${this.session}`;
+    const separator = endpointName.includes("?") ? "&" : "?";
+    return `${this.baseAPIurl}/${endpointName}${separator}session=${this.session}`;
   }
 
   _getPlainText(endpoint, callback, onError) {

--- a/src/components/TopNav/TopBar.js
+++ b/src/components/TopNav/TopBar.js
@@ -4,7 +4,6 @@ import {zeeguuOrange} from "../colors";
 import { useEffect, useState, useContext} from "react";
 import {getTopBarData, DEFAULT_TOPBAR_PREFS} from "../../utils/progressTracking/progressData";
 import ProgressModal from "../progress_tracking/ProgressModal";
-import { getSharedSession } from "../../utils/cookies/userInfo";
 import { APIContext } from "../../contexts/APIContext";
 import { ProgressContext } from "../../contexts/ProgressContext";
 import { calculateWeeklyReadingMinutes } from "../../utils/progressTracking/progressHelpers";
@@ -50,7 +49,6 @@ export default function TopBar() {
     });
   };
 
-  api.session = getSharedSession();
   if (!api.session) return null;
 
   // Only show progress icons on the homepage (articles route)

--- a/src/extension/src/background/background.js
+++ b/src/extension/src/background/background.js
@@ -128,7 +128,7 @@ async function startReader() {
   try {
     const api = new Zeeguu_API(API_URL);
     const userData = await getUserInfoDictFromCookies(WEB_URL);
-    api.session = userData.session;
+    api.setSession(userData.session);
     await api.logUserActivity(api.OPEN_CONTEXT, "", tab.url, EXTENSION_SOURCE);
     const upload = await sendTabToZeeguu(api, tab);
     BROWSER_API.tabs.create({

--- a/src/extension/src/popup/Popup.js
+++ b/src/extension/src/popup/Popup.js
@@ -34,7 +34,7 @@ export default function Popup({ loggedIn }) {
         setErrorMessage("Session expired. Please close this popup and click the Zeeguu icon again.");
         return;
       }
-      api.session = user.session;
+      api.setSession(user.session);
 
       const [tab] = await BROWSER_API.tabs.query({ active: true, currentWindow: true });
       if (isUnsupportedTab(tab)) {

--- a/src/landingPage/LandingPage.js
+++ b/src/landingPage/LandingPage.js
@@ -2,7 +2,7 @@ import { useEffect, useContext } from "react";
 import { useHistory } from "react-router-dom/cjs/react-router-dom";
 import { Redirect } from "react-router-dom";
 import { setTitle } from "../assorted/setTitle";
-import { getSharedSession } from "../utils/cookies/userInfo";
+import { getStoredSession } from "../utils/cookies/userInfo";
 import LocalStorage from "../assorted/LocalStorage";
 import { SystemLanguagesContext } from "../contexts/SystemLanguagesContext.js";
 import InstallationInstructions from "./InstallationInstructions.js";
@@ -23,7 +23,7 @@ export default function LandingPage() {
     setTitle(strings.landingPageTitle);
   }, []);
 
-  if (getSharedSession()) {
+  if (getStoredSession()) {
     const lastVisitedPage = LocalStorage.getLastVisitedPage();
     const redirectTo = lastVisitedPage || "/articles";
     return <Redirect to={{ pathname: redirectTo }} />;

--- a/src/pages/onboarding/ExtensionInstalled.js
+++ b/src/pages/onboarding/ExtensionInstalled.js
@@ -1,4 +1,4 @@
-import { getSharedSession } from "../../utils/cookies/userInfo";
+import { getStoredSession } from "../../utils/cookies/userInfo";
 import { useContext, useEffect } from "react";
 import { useHistory } from "react-router-dom/cjs/react-router-dom";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
@@ -37,7 +37,7 @@ export default function ExtensionInstalled() {
       </Main>
       <Footer>
         <ButtonContainer className={"padding-large"}>
-          {getSharedSession() ? (
+          {getStoredSession() ? (
             <Button className={"full-width-btn"} onClick={() => history.push("/articles")}>
               {strings.goToZeeguuApp}
             </Button>

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -148,7 +148,7 @@ export default function LanguagePreferences() {
 
         // Set the session
         setUserSession(session);
-        api.session = session;
+        api.setSession(session);
 
         saveSharedUserInfo({ name: "Guest", native_language: translationLanguage }, session);
 

--- a/src/utils/cookies/userInfo.js
+++ b/src/utils/cookies/userInfo.js
@@ -33,7 +33,7 @@ function removeSharedUserInfoFromCookies() {
   Cookies.remove("name");
 }
 
-function getSharedSessionFromCookies() {
+function getSessionFromCookies() {
   return Cookies.get("sessionID");
 }
 
@@ -54,7 +54,7 @@ async function removeSharedUserInfoFromPreferences() {
   cachedSession = null; // Clear cache
 }
 
-async function getSharedSessionFromPreferences() {
+async function getSessionFromPreferences() {
   const result = await Preferences.get({ key: "sessionID" });
   return result.value;
 }
@@ -62,7 +62,7 @@ async function getSharedSessionFromPreferences() {
 // Initialize session from Preferences at app startup (call this before rendering)
 async function initializeSession() {
   if (isCapacitor()) {
-    cachedSession = await getSharedSessionFromPreferences();
+    cachedSession = await getSessionFromPreferences();
   }
   sessionLoaded = true;
   return cachedSession;
@@ -89,15 +89,18 @@ function removeSharedUserInfo() {
   }
 }
 
-function getSharedSession() {
+// Read the persisted session from the platform storage layer (cookies on web /
+// extension, Capacitor Preferences on mobile). After App boot this is the slow
+// path — runtime code should read the React session state instead.
+function getStoredSession() {
   if (isCapacitor()) {
     // Return cached session (must call initializeSession first)
     if (!sessionLoaded) {
-      console.warn("getSharedSession called before initializeSession - session may be undefined");
+      console.warn("getStoredSession called before initializeSession - session may be undefined");
     }
     return cachedSession;
   } else {
-    return getSharedSessionFromCookies();
+    return getSessionFromCookies();
   }
 }
 
@@ -115,16 +118,16 @@ export {
   // These handle minimal user info shared between web app and browser extension
   saveSharedUserInfo,
   removeSharedUserInfo,
-  getSharedSession,
+  getStoredSession,
   setUserSession,
-  // Initialization (must be called before getSharedSession on Capacitor)
+  // Initialization (must be called before getStoredSession on Capacitor)
   initializeSession,
   // Cookie-specific functions (for web/extension communication)
   saveSharedUserInfoToCookies,
   removeSharedUserInfoFromCookies,
-  getSharedSessionFromCookies,
+  getSessionFromCookies,
   // Preferences-specific functions (for Capacitor native storage)
   saveSharedUserInfoToPreferences,
   removeSharedUserInfoFromPreferences,
-  getSharedSessionFromPreferences,
+  getSessionFromPreferences,
 };


### PR DESCRIPTION
## Summary

- Fix `session=undefined` 401s observed in API logs (referer `https://www.zeeguu.org/`, `/get_onboarding_message_status?onboarding_message_id=1&session=undefined`).
- Make session state reactive so `PrivateRoute` redirects to `/log_in` reliably on any loss path — explicit logout, server-side expiry, or cross-tab cookie clear.

## Root cause

Two layered bugs:

1. `_appendSessionToUrl` (classDef.js) serialized `this.session` into the URL even when undefined, producing literal `session=undefined`.

2. `api.session` was mutated imperatively from ~10 call sites with no observer. App-level React state and `api.session` drifted:
   - Cross-tab logout: polling cleared `userDetails` but left `api.session` firing the stale string.
   - App-level `useTranslationOnboarding` ran its `useEffect` before the session-loading `useEffect` set `api.session` — fetch fired with `undefined`. Deps `[api, messageId]` never changed, so it never re-ran with the real session either.

## Changes

**Mechanism** — `Zeeguu_API.setSession(value)` and `onSessionChange(fn)`. Single mutation point; all writes route through the method.

**App.js** — 
- Lazy `useState` initializes `api.session = getStoredSession()` synchronously, before any effect runs.
- New `[session, setSession] = useState(() => getStoredSession())` mirrors `api.session`, bridged via `api.onSessionChange(setSession)`.
- `UserContext.session` reads from the React state (was `getSharedSession()` called every App render).
- `logout()` now calls `api.setSession(undefined)` — previously left api stale.
- Polling tick calls `api.setSession(undefined)` when storage clears (guarded on `api.session` so it fires once, not every second).
- Capacitor `initializeSession()` resolver pushes the value through `api.setSession`.

**Direct write migrations** — `accounts.js` (5 login/signup paths), `LanguagePreferences.js`, both extension entry points. `TopBar.js` had a per-render `api.session = getSharedSession()` that's no longer needed; removed.

**Rename** — `getSharedSession` → `getStoredSession` (and `FromCookies`/`FromPreferences` variants) to signal it's the persistence layer, not the runtime source of truth. `saveSharedUserInfo`/`removeSharedUserInfo` kept the \"shared\" prefix — those still describe cookies shared with the extension.

## Test plan

- [ ] Clean visit to `/` (no session cookie) — Network tab shows no `session=undefined` request; LandingPage renders.
- [ ] Log in → land on `/articles`; no spurious 401s in flight.
- [ ] DevTools → clear `sessionID` cookie → app redirects to `/log_in` within ~1s (cross-tab logout simulation).
- [ ] Explicit logout → redirected away; no further authed requests in Network panel.
- [ ] iOS/Android (if testable): `initializeSession()` resolves → onboarding hooks see the correct session.
- [ ] Extension popup/background still work (no React state to mirror, but `setSession` works equivalently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)