### PR TITLE
ArticleLanguageModal: redesign level-mismatch decision

### DIFF
--- a/src/components/modal_shared/ChoiceModal.js
+++ b/src/components/modal_shared/ChoiceModal.js
@@ -11,18 +11,20 @@ const Content = styled.div`
 
 const HeroImage = styled.img`
   width: 100%;
-  height: 160px;
+  height: ${(props) => (props.$slim ? "110px" : "160px")};
   object-fit: cover;
   border-radius: 0.5em;
   margin-bottom: 1.2em;
 `;
 
 const Title = styled.h3`
-  color: ${zeeguuOrange};
-  margin: 0 0 2.2em 0;
-  font-size: 1.05rem;
+  /* Near-black (light) / near-white (dark) for AA contrast against the
+     modal background. Orange is reserved for the brand accent. */
+  color: var(--text-primary, #1a1a2e);
+  margin: 0 0 1.4em 0;
+  font-size: 1.1rem;
   line-height: 1.35;
-  font-weight: 600;
+  font-weight: 500;
   overflow-wrap: break-word;
 `;
 
@@ -39,6 +41,26 @@ const ButtonStack = styled.div`
   flex-direction: column;
   gap: 0.7em;
   align-items: center;
+`;
+
+const SecondaryLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0.5em 0.75em;
+  color: ${zeeguuOrange};
+  font-size: 0.95rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 `;
 
 const ActionButton = styled.button`
@@ -100,11 +122,23 @@ export default function ChoiceModal({
   loadingLabel,
   primaryFirst = true,
   heroImage,
+  slimHero = false,
+  secondaryAsLink = false,
 }) {
+  const secondary = secondaryAsLink ? (
+    <SecondaryLink onClick={onSecondary} disabled={isLoading}>
+      {secondaryLabel}
+    </SecondaryLink>
+  ) : (
+    <ActionButton $primary={!primaryFirst} onClick={onSecondary}>
+      {secondaryLabel}
+    </ActionButton>
+  );
+
   return (
     <Modal open={true} onClose={onSecondary}>
       <Content>
-        {heroImage && <HeroImage src={heroImage} alt="" />}
+        {heroImage && <HeroImage src={heroImage} alt="" $slim={slimHero} />}
         {title && <Title>{title}</Title>}
         <Message>{message}</Message>
         <ButtonStack>
@@ -116,9 +150,7 @@ export default function ChoiceModal({
             {isLoading && <Spinner />}
             {isLoading ? loadingLabel : primaryLabel}
           </ActionButton>
-          <ActionButton $primary={!primaryFirst} onClick={onSecondary}>
-            {secondaryLabel}
-          </ActionButton>
+          {secondary}
         </ButtonStack>
       </Content>
     </Modal>

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,8 @@
 
   --player-icon-color: #1a1a2e;
 
+  --cefr-bar-color: #16a34a;
+
   color-scheme: light;
 }
 
@@ -147,6 +149,8 @@
   --orange-btn-text: #3d2800;
 
   --player-icon-color: #ffbb54;
+
+  --cefr-bar-color: #22c55e;
 
   --exercise-btn-border: hsl(54, 100%, 95%);
   --exercise-btn-focus: rgba(255, 187, 84, 0.6);

--- a/src/index.css
+++ b/src/index.css
@@ -306,3 +306,4 @@ a {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -306,4 +306,3 @@ a {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
-

--- a/src/reader/ArticleLanguageModal.js
+++ b/src/reader/ArticleLanguageModal.js
@@ -18,18 +18,19 @@ function LevelBars({ level }) {
   const filled = Math.min(CEFR_ORDINAL[level] ?? CEFR_BAR_COUNT, CEFR_BAR_COUNT);
   return (
     <svg
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 16 16"
+      style={{ color: "var(--cefr-bar-color)" }}
       fill="currentColor"
       aria-hidden="true"
     >
       {CEFR_BAR_GEOMETRY.map((bar, i) => (
         <rect
           key={i}
-          x={bar.x}
+          x={bar.x - 0.25}
           y={bar.y}
-          width={2}
+          width={2.5}
           height={bar.h}
           rx={0.5}
           opacity={i < filled ? 1 : 0.3}

--- a/src/reader/ArticleLanguageModal.js
+++ b/src/reader/ArticleLanguageModal.js
@@ -1,49 +1,104 @@
 import ChoiceModal from "../components/modal_shared/ChoiceModal";
 import { LANGUAGE_CODE_TO_NAME } from "../utils/misc/languageCodeToName";
-import { getStaticPath } from "../utils/misc/staticPath";
 
 function langName(code) {
   return LANGUAGE_CODE_TO_NAME[code] || code;
 }
 
-function LevelChip({ level }) {
+const CEFR_BARS_FILLED = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 4, C2: 4 };
+const CEFR_BAR_GEOMETRY = [
+  { x: 1, y: 12, h: 3 },
+  { x: 5, y: 9, h: 6 },
+  { x: 9, y: 6, h: 9 },
+  { x: 13, y: 3, h: 12 },
+];
+
+function LevelBars({ level }) {
+  const filled = CEFR_BARS_FILLED[level] ?? 4;
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      {CEFR_BAR_GEOMETRY.map((bar, i) => (
+        <rect
+          key={i}
+          x={bar.x}
+          y={bar.y}
+          width={2}
+          height={bar.h}
+          rx={0.5}
+          opacity={i < filled ? 1 : 0.3}
+        />
+      ))}
+    </svg>
+  );
+}
+
+function LevelChip({ level, caption }) {
   return (
     <span
       style={{
         display: "inline-flex",
+        flexDirection: "column",
         alignItems: "center",
-        gap: "0.35em",
-        padding: "0.3em 0.85em",
-        borderRadius: "999px",
-        border: "1px solid var(--text-secondary)",
-        fontSize: "0.95rem",
-        fontWeight: 600,
+        gap: "0.3em",
       }}
     >
-      <img
-        src={getStaticPath("icons", `${level}-level-icon.png`)}
-        alt=""
-        style={{ width: "16px", height: "16px" }}
-      />
-      {level}
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.35em",
+          padding: "0.3em 0.85em",
+          borderRadius: "999px",
+          border: "1px solid var(--text-secondary)",
+          fontSize: "0.95rem",
+          fontWeight: 600,
+        }}
+      >
+        <LevelBars level={level} />
+        {level}
+      </span>
+      <span
+        style={{
+          fontSize: "0.75rem",
+          color: "var(--text-secondary)",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+          fontWeight: 600,
+        }}
+      >
+        {caption}
+      </span>
     </span>
   );
 }
 
-function LevelTransition({ from, to }) {
+function LevelTransition({ articleLevel, userLevel }) {
   return (
     <div
       style={{
         display: "flex",
         justifyContent: "center",
-        alignItems: "center",
-        gap: "0.7em",
-        marginBottom: "0.6em",
+        alignItems: "flex-start",
+        gap: "0.9em",
       }}
     >
-      <LevelChip level={from} />
-      <span style={{ fontSize: "1.4rem", color: "var(--text-secondary)" }}>→</span>
-      <LevelChip level={to} />
+      <LevelChip level={articleLevel} caption="Article" />
+      <span
+        style={{
+          fontSize: "1.4rem",
+          color: "var(--text-secondary)",
+          paddingTop: "0.15em",
+        }}
+      >
+        →
+      </span>
+      <LevelChip level={userLevel} caption="You" />
     </div>
   );
 }
@@ -70,22 +125,24 @@ export default function ArticleLanguageModal({
     const canShowTransition = articleCefrLevel && userCefrLevel;
     const message = canShowTransition ? (
       <>
-        <LevelTransition from={articleCefrLevel} to={userCefrLevel} />
-        <div style={{ color: "var(--text-secondary)" }}>Make this fit your level</div>
+        <div style={{ marginBottom: "0.9em" }}>Article is above your level</div>
+        <LevelTransition articleLevel={articleCefrLevel} userLevel={userCefrLevel} />
       </>
     ) : articleCefrLevel ? (
       `This article is${levelClause}. Do you want it simplified to your level?`
     ) : (
       "Do you want it simplified to your level?"
     );
-    const simplifyLabel = userCefrLevel ? `Simplify to ${userCefrLevel}` : "Simplify";
+    const simplifyLabel = "Adapt to my level";
     return (
       <ChoiceModal
         title={articleTitle}
         heroImage={articleImage}
+        slimHero
         message={message}
         primaryLabel={simplifyLabel}
-        secondaryLabel="Read as is"
+        secondaryLabel="or read the original"
+        secondaryAsLink
         loadingLabel="Simplifying..."
         onPrimary={onSimplify}
         onSecondary={onReadAsIs}

--- a/src/reader/ArticleLanguageModal.js
+++ b/src/reader/ArticleLanguageModal.js
@@ -1,11 +1,12 @@
 import ChoiceModal from "../components/modal_shared/ChoiceModal";
 import { LANGUAGE_CODE_TO_NAME } from "../utils/misc/languageCodeToName";
+import { CEFR_ORDINAL } from "../utils/misc/cefrHelpers";
 
 function langName(code) {
   return LANGUAGE_CODE_TO_NAME[code] || code;
 }
 
-const CEFR_BARS_FILLED = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 4, C2: 4 };
+const CEFR_BAR_COUNT = 4;
 const CEFR_BAR_GEOMETRY = [
   { x: 1, y: 12, h: 3 },
   { x: 5, y: 9, h: 6 },
@@ -14,7 +15,7 @@ const CEFR_BAR_GEOMETRY = [
 ];
 
 function LevelBars({ level }) {
-  const filled = CEFR_BARS_FILLED[level] ?? 4;
+  const filled = Math.min(CEFR_ORDINAL[level] ?? CEFR_BAR_COUNT, CEFR_BAR_COUNT);
   return (
     <svg
       width="14"
@@ -123,27 +124,29 @@ export default function ArticleLanguageModal({
 
   if (isSameLanguage) {
     const canShowTransition = articleCefrLevel && userCefrLevel;
-    const message = canShowTransition ? (
-      <>
-        <div style={{ marginBottom: "0.9em" }}>Article is above your level</div>
-        <LevelTransition articleLevel={articleCefrLevel} userLevel={userCefrLevel} />
-      </>
-    ) : articleCefrLevel ? (
-      `This article is${levelClause}. Do you want it simplified to your level?`
-    ) : (
-      "Do you want it simplified to your level?"
-    );
-    const simplifyLabel = "Adapt to my level";
+    let message;
+    if (canShowTransition) {
+      message = (
+        <>
+          <div style={{ marginBottom: "0.9em" }}>Article is above your level</div>
+          <LevelTransition articleLevel={articleCefrLevel} userLevel={userCefrLevel} />
+        </>
+      );
+    } else if (articleCefrLevel) {
+      message = `This article is${levelClause}. Do you want it adapted to your level?`;
+    } else {
+      message = "Do you want it adapted to your level?";
+    }
     return (
       <ChoiceModal
         title={articleTitle}
         heroImage={articleImage}
         slimHero
         message={message}
-        primaryLabel={simplifyLabel}
+        primaryLabel="Adapt to my level"
         secondaryLabel="or read the original"
         secondaryAsLink
-        loadingLabel="Simplifying..."
+        loadingLabel="Adapting..."
         onPrimary={onSimplify}
         onSecondary={onReadAsIs}
         isLoading={isLoading}

--- a/src/utils/misc/cefrHelpers.js
+++ b/src/utils/misc/cefrHelpers.js
@@ -8,7 +8,7 @@ const NUMERIC_TO_CEFR = {
   6: "C2",
 };
 
-const CEFR_ORDINAL = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 5, C2: 6 };
+export const CEFR_ORDINAL = { A1: 1, A2: 2, B1: 3, B2: 4, C1: 5, C2: 6 };
 
 /**
  * Read the user's CEFR level (1-6) for a given language code from the


### PR DESCRIPTION
## Summary

Refresh of the modal that appears when opening an article whose CEFR level is above the user's level. Tightens visual hierarchy, fixes a dark-mode accessibility issue, and reframes the primary action.

### Changes

- **Title contrast**: article title shifts from orange to near-black (`var(--text-primary)`). Orange is now reserved for the brand accent (primary CTA, link).
- **Reading order**: short context label sits *above* the chips ("Article is above your level"), so the chips frame meaningful data rather than appearing without context.
- **Labeled chips**: chip pair now reads `Article [B2] → You [A2]` with `ARTICLE` / `YOU` captions beneath each chip — the arrow is now self-explanatory.
- **Dark-mode icons fixed**: the CEFR level icons were dark-navy PNGs that disappeared on the dark navy modal background. Replaced with inline SVG bars that use `currentColor` and inherit the chip text color — adapts cleanly to both themes.
- **Secondary as text-link**: "or read the original" is now an underlined text link rather than an outlined button matching the primary CTA in size. The decision feels less binary-equal, escape hatch is still discoverable.
- **Slimmer hero image**: optional `slimHero` prop on `ChoiceModal` reduces banner from 160px → 110px so more of the modal is the decision, not decoration.
- **Title weight**: 600 → 500, so the article title stops competing with the action.
- **Microcopy**: primary CTA "Simplify to A2" → **"Adapt to my level"**. "Adapt" reframes the action as personalisation rather than dumbing-down, and the chip pair already conveys the target level visually.

`ChoiceModal`'s other caller (`useGuardedLanguageSwitch`) is untouched — the new props are opt-in.

## Test plan

- [ ] Open an article whose CEFR level is above your level (same learned language). Modal shows label → chips → captions → primary "Adapt to my level" → "or read the original" link.
- [ ] Toggle dark mode: level bar icons stay readable in both themes (filled bars solid, empty bars at lower opacity).
- [ ] "Adapt to my level" triggers simplification.
- [ ] "or read the original" / X close both fall back to read-as-is.
- [ ] Switch-language confirm modal (`useGuardedLanguageSwitch`) renders unchanged.