### PR TITLE
Public share page for audio lessons (UUID-based)

### DIFF
--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -49,7 +49,7 @@ import ExercisesForArticle from "./exercises/ExercisesForArticle";
 import { WEB_READER } from "./reader/ArticleReader";
 import VideoPlayer from "./videos/VideoPlayer";
 import DailyAudioRouter from "./dailyAudio/_DailyAudioRouter";
-import SharedLessonView from "./dailyAudio/SharedLessonView";
+import SharedLessonRouteEntry from "./dailyAudio/SharedLessonRouteEntry";
 import IndividualExercise from "./pages/IndividualExercise";
 import Swiper from "./swiper/Swiper";
 import KeyboardTest from "./pages/KeyboardTest";
@@ -131,7 +131,7 @@ export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
       <PrivateRouteWithLayout path="/exercises" component={ExercisesRouter} />
       <PrivateRouteWithLayout path="/verbalFlashcards" component={VerbalFlashcardsRouter} />    
       <PrivateRouteWithLayout path="/daily-audio" component={DailyAudioRouter} />
-      <PrivateRouteWithLayout path="/shared-lesson/:id" component={SharedLessonView} />
+      <Route path="/shared-lesson/:id" component={SharedLessonRouteEntry} />
       <PrivateRouteWithLayout path="/translate" component={TranslateRouter} />
       <Redirect from="/my-articles/hidden" to="/articles/bookmarked/hidden" />
       <Redirect from="/my-articles" to="/articles/bookmarked" />

--- a/src/api/dailyAudio.js
+++ b/src/api/dailyAudio.js
@@ -64,12 +64,25 @@ Zeeguu_API.prototype.generateDailyLesson = function (callback, onError, suggesti
     });
 };
 
-Zeeguu_API.prototype.getSharedAudioLesson = function (lessonId, callback, onError) {
+Zeeguu_API.prototype.getSharedAudioLesson = function (shareUuid, callback, onError) {
   this._getJSON(
-    `shared_audio_lesson/${lessonId}`,
+    `shared_audio_lesson/${shareUuid}`,
     (data) => callback({ ...data, audio_url: `${this.baseAPIurl}${data.audio_url}` }),
     { onError },
   );
+};
+
+Zeeguu_API.prototype.createLessonShareLink = function (lessonId) {
+  return fetch(this._appendSessionToUrl(`create_lesson_share_link/${lessonId}`), {
+    method: "POST",
+  }).then((response) => {
+    if (!response.ok) {
+      return response.json().then((data) => {
+        throw new Error(data.error || `Failed to create share link (${response.status})`);
+      });
+    }
+    return response.json();
+  });
 };
 
 Zeeguu_API.prototype.deleteTodaysLesson = function (callback, onError) {

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -121,7 +121,7 @@ export default function LessonPlaybackView({
         <LessonActions>
           {lessonData.lesson_id && (
             <SubtleTextButton
-              onClick={() => shareLessonLink(lessonData.lesson_id, lessonData.title)}
+              onClick={() => shareLessonLink(api, lessonData.lesson_id, lessonData.title)}
             >
               Share
             </SubtleTextButton>

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -382,7 +382,7 @@ function InlineLessonPlayer({ lesson, api, userDetails, onLessonCompleted, onPro
       />
       {lesson.lesson_id && (
         <div style={{ marginTop: "12px", textAlign: "center" }}>
-          <SubtleTextButton onClick={() => shareLessonLink(lesson.lesson_id, lesson.title)}>
+          <SubtleTextButton onClick={() => shareLessonLink(api, lesson.lesson_id, lesson.title)}>
             Share
           </SubtleTextButton>
         </div>

--- a/src/dailyAudio/PublicSharedLessonPage.js
+++ b/src/dailyAudio/PublicSharedLessonPage.js
@@ -17,7 +17,6 @@ const PageWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 24px 16px 48px;
-  background-color: var(--page-bg, #fafafa);
 `;
 
 const Brand = styled.a`
@@ -31,9 +30,9 @@ const Brand = styled.a`
 const Card = styled.div`
   width: 100%;
   max-width: 640px;
-  background: var(--card-bg, #fff);
+  background: var(--card-bg);
   border-radius: 16px;
-  box-shadow: 0 2px 12px var(--shadow-color, rgba(0, 0, 0, 0.08));
+  box-shadow: 0 2px 12px var(--shadow-color);
   padding: 24px;
   margin-bottom: 24px;
 `;
@@ -42,16 +41,10 @@ const CTA = styled.div`
   width: 100%;
   max-width: 640px;
   text-align: center;
+  color: var(--text-secondary);
 
-  h2 {
-    font-size: 1.2rem;
-    margin: 0 0 8px;
-  }
-
-  p {
-    color: var(--text-secondary);
-    margin: 0 0 16px;
-  }
+  h2 { font-size: 1.2rem; margin: 0 0 8px; }
+  p { margin: 0 0 16px; }
 `;
 
 const ButtonRow = styled.div`
@@ -59,12 +52,6 @@ const ButtonRow = styled.div`
   gap: 12px;
   justify-content: center;
   flex-wrap: wrap;
-`;
-
-const ErrorBox = styled.div`
-  padding: 24px;
-  text-align: center;
-  color: var(--text-secondary);
 `;
 
 export default function PublicSharedLessonPage() {
@@ -82,88 +69,78 @@ export default function PublicSharedLessonPage() {
     );
   }, [api, shareUuid]);
 
+  let body;
   if (error) {
-    return (
-      <PageWrapper>
-        <Brand href="/">Zeeguu</Brand>
+    body = (
+      <Card>
+        <h2>Could not open this lesson</h2>
+        <p>{error}</p>
+      </Card>
+    );
+  } else if (!lessonData) {
+    body = <LoadingAnimation />;
+  } else {
+    const lessonLang = lessonData.language_code;
+    const lessonLangName = languageNames[lessonLang] || lessonLang;
+    const titleText = lessonData.title || "Shared Audio Lesson";
+    const metadata = (
+      <>
+        Language: <b>{lessonLangName}</b>
+        {lessonData.canonical_suggestion && (
+          <>
+            {" · "}
+            {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}:{" "}
+            <b>{lessonData.canonical_suggestion}</b>
+          </>
+        )}
+      </>
+    );
+    body = (
+      <>
         <Card>
-          <ErrorBox>
-            <h2>Could not open this lesson</h2>
-            <p>{error}</p>
-          </ErrorBox>
+          <LessonPlayerCard
+            title={titleText}
+            metadata={metadata}
+            audioProps={{
+              src: lessonData.audio_url,
+              language: lessonLang,
+              title: titleText,
+              artist: `${lessonLangName} Audio Lesson`,
+            }}
+          />
         </Card>
-      </PageWrapper>
+        <CTA>
+          <h2>Want your own personalized {lessonLangName} lessons?</h2>
+          <p>Install Zeeguu to generate audio lessons tailored to your level and the words you're learning.</p>
+          <ButtonRow>
+            <Button
+              as="a"
+              href="https://apps.apple.com/dk/app/zeeguu-news-for-learners/id6756917355"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <AppleIcon />
+              iOS
+            </Button>
+            <Button
+              as="a"
+              href="https://play.google.com/store/apps/details?id=org.zeeguu.app"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <AndroidIcon />
+              Android
+            </Button>
+          </ButtonRow>
+        </CTA>
+      </>
     );
   }
-
-  if (!lessonData) {
-    return (
-      <PageWrapper>
-        <Brand href="/">Zeeguu</Brand>
-        <LoadingAnimation />
-      </PageWrapper>
-    );
-  }
-
-  const lessonLang = lessonData.language_code;
-  const lessonLangName = languageNames[lessonLang] || lessonLang;
-  const titleText = lessonData.title || "Shared Audio Lesson";
-
-  const metadata = (
-    <>
-      Language: <b>{lessonLangName}</b>
-      {lessonData.canonical_suggestion && (
-        <>
-          {" · "}
-          {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}:{" "}
-          <b>{lessonData.canonical_suggestion}</b>
-        </>
-      )}
-    </>
-  );
 
   return (
     <PageWrapper>
       <Brand href="/">Zeeguu</Brand>
-      <Card>
-        <LessonPlayerCard
-          title={titleText}
-          metadata={metadata}
-          audioProps={{
-            src: lessonData.audio_url,
-            language: lessonLang,
-            title: titleText,
-            artist: `${lessonLangName} Audio Lesson`,
-          }}
-        />
-      </Card>
-      <CTA>
-        <h2>Want your own personalized {lessonLangName} lessons?</h2>
-        <p>
-          Install Zeeguu to generate audio lessons tailored to your level and the
-          words you're learning.
-        </p>
-        <ButtonRow>
-          <Button
-            as="a"
-            href="https://apps.apple.com/dk/app/zeeguu-news-for-learners/id6756917355"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <AppleIcon />
-            iOS
-          </Button>
-          <Button
-            as="a"
-            href="https://play.google.com/store/apps/details?id=org.zeeguu.app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <AndroidIcon />
-            Android
-          </Button>
-        </ButtonRow>
-      </CTA>
+      {body}
     </PageWrapper>
   );
 }

--- a/src/dailyAudio/PublicSharedLessonPage.js
+++ b/src/dailyAudio/PublicSharedLessonPage.js
@@ -1,0 +1,169 @@
+import { useContext, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import AppleIcon from "@mui/icons-material/Apple";
+import AndroidIcon from "@mui/icons-material/Android";
+
+import { APIContext } from "../contexts/APIContext";
+import LoadingAnimation from "../components/LoadingAnimation";
+import LessonPlayerCard from "./LessonPlayerCard";
+import { languageNames } from "../utils/languageDetection";
+import Button from "../pages/_pages_shared/Button.sc";
+import { zeeguuOrange } from "../components/colors";
+
+const PageWrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px 48px;
+  background-color: var(--page-bg, #fafafa);
+`;
+
+const Brand = styled.a`
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: ${zeeguuOrange};
+  text-decoration: none;
+  margin-bottom: 16px;
+`;
+
+const Card = styled.div`
+  width: 100%;
+  max-width: 640px;
+  background: var(--card-bg, #fff);
+  border-radius: 16px;
+  box-shadow: 0 2px 12px var(--shadow-color, rgba(0, 0, 0, 0.08));
+  padding: 24px;
+  margin-bottom: 24px;
+`;
+
+const CTA = styled.div`
+  width: 100%;
+  max-width: 640px;
+  text-align: center;
+
+  h2 {
+    font-size: 1.2rem;
+    margin: 0 0 8px;
+  }
+
+  p {
+    color: var(--text-secondary);
+    margin: 0 0 16px;
+  }
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+const ErrorBox = styled.div`
+  padding: 24px;
+  text-align: center;
+  color: var(--text-secondary);
+`;
+
+export default function PublicSharedLessonPage() {
+  const api = useContext(APIContext);
+  const { id: shareUuid } = useParams();
+
+  const [lessonData, setLessonData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.getSharedAudioLesson(
+      shareUuid,
+      (data) => setLessonData(data),
+      (err) => setError(err?.message || "Could not load shared lesson."),
+    );
+  }, [api, shareUuid]);
+
+  if (error) {
+    return (
+      <PageWrapper>
+        <Brand href="/">Zeeguu</Brand>
+        <Card>
+          <ErrorBox>
+            <h2>Could not open this lesson</h2>
+            <p>{error}</p>
+          </ErrorBox>
+        </Card>
+      </PageWrapper>
+    );
+  }
+
+  if (!lessonData) {
+    return (
+      <PageWrapper>
+        <Brand href="/">Zeeguu</Brand>
+        <LoadingAnimation />
+      </PageWrapper>
+    );
+  }
+
+  const lessonLang = lessonData.language_code;
+  const lessonLangName = languageNames[lessonLang] || lessonLang;
+  const titleText = lessonData.title || "Shared Audio Lesson";
+
+  const metadata = (
+    <>
+      Language: <b>{lessonLangName}</b>
+      {lessonData.canonical_suggestion && (
+        <>
+          {" · "}
+          {lessonData.lesson_type === "situation" ? "Situation" : "Topic"}:{" "}
+          <b>{lessonData.canonical_suggestion}</b>
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <PageWrapper>
+      <Brand href="/">Zeeguu</Brand>
+      <Card>
+        <LessonPlayerCard
+          title={titleText}
+          metadata={metadata}
+          audioProps={{
+            src: lessonData.audio_url,
+            language: lessonLang,
+            title: titleText,
+            artist: `${lessonLangName} Audio Lesson`,
+          }}
+        />
+      </Card>
+      <CTA>
+        <h2>Want your own personalized {lessonLangName} lessons?</h2>
+        <p>
+          Install Zeeguu to generate audio lessons tailored to your level and the
+          words you're learning.
+        </p>
+        <ButtonRow>
+          <Button
+            as="a"
+            href="https://apps.apple.com/dk/app/zeeguu-news-for-learners/id6756917355"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <AppleIcon />
+            iOS
+          </Button>
+          <Button
+            as="a"
+            href="https://play.google.com/store/apps/details?id=org.zeeguu.app"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <AndroidIcon />
+            Android
+          </Button>
+        </ButtonRow>
+      </CTA>
+    </PageWrapper>
+  );
+}

--- a/src/dailyAudio/SharedLessonRouteEntry.js
+++ b/src/dailyAudio/SharedLessonRouteEntry.js
@@ -1,0 +1,24 @@
+import { useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+import AppLayout from "../AppLayout";
+import SharedLessonView from "./SharedLessonView";
+import PublicSharedLessonPage from "./PublicSharedLessonPage";
+
+// Single entry for /shared-lesson/:id.
+// Logged-in users get the rich in-app view (banners, listening sessions);
+// anonymous visitors (friends with a share link) get the standalone public
+// page with install CTAs. Keeping one URL means a friend who happens to be
+// logged in lands in the right place without any redirect dance.
+export default function SharedLessonRouteEntry() {
+  const { session } = useContext(UserContext);
+
+  if (session) {
+    return (
+      <AppLayout>
+        <SharedLessonView />
+      </AppLayout>
+    );
+  }
+
+  return <PublicSharedLessonPage />;
+}

--- a/src/dailyAudio/SharedLessonRouteEntry.js
+++ b/src/dailyAudio/SharedLessonRouteEntry.js
@@ -4,11 +4,8 @@ import AppLayout from "../AppLayout";
 import SharedLessonView from "./SharedLessonView";
 import PublicSharedLessonPage from "./PublicSharedLessonPage";
 
-// Single entry for /shared-lesson/:id.
-// Logged-in users get the rich in-app view (banners, listening sessions);
-// anonymous visitors (friends with a share link) get the standalone public
-// page with install CTAs. Keeping one URL means a friend who happens to be
-// logged in lands in the right place without any redirect dance.
+// Logged-in users get the in-app view; anonymous visitors get the public
+// page with install CTAs. One URL works for both.
 export default function SharedLessonRouteEntry() {
   const { session } = useContext(UserContext);
 

--- a/src/dailyAudio/shareLessonLink.js
+++ b/src/dailyAudio/shareLessonLink.js
@@ -1,11 +1,19 @@
 import { WEB_URL } from "../config";
 
-export function shareLessonUrl(lessonId) {
-  return `${WEB_URL}/shared-lesson/${lessonId}`;
+export function shareLessonUrlForUuid(shareUuid) {
+  return `${WEB_URL}/shared-lesson/${shareUuid}`;
 }
 
-export async function shareLessonLink(lessonId, title) {
-  const url = shareLessonUrl(lessonId);
+export async function shareLessonLink(api, lessonId, title) {
+  let url;
+  try {
+    const { share_uuid } = await api.createLessonShareLink(lessonId);
+    url = shareLessonUrlForUuid(share_uuid);
+  } catch (e) {
+    alert("Could not create share link. Please try again.");
+    return;
+  }
+
   const shareTitle = title ? `Zeeguu Audio: ${title}` : "Zeeguu Audio Lesson";
 
   if (navigator.share) {

--- a/src/dailyAudio/shareLessonLink.js
+++ b/src/dailyAudio/shareLessonLink.js
@@ -1,14 +1,10 @@
 import { WEB_URL } from "../config";
 
-export function shareLessonUrlForUuid(shareUuid) {
-  return `${WEB_URL}/shared-lesson/${shareUuid}`;
-}
-
 export async function shareLessonLink(api, lessonId, title) {
   let url;
   try {
     const { share_uuid } = await api.createLessonShareLink(lessonId);
-    url = shareLessonUrlForUuid(share_uuid);
+    url = `${WEB_URL}/shared-lesson/${share_uuid}`;
   } catch (e) {
     alert("Could not create share link. Please try again.");
     return;


### PR DESCRIPTION
## Summary
- \`/shared-lesson/:id\` is now a public route. Logged-in users get the existing in-app \`SharedLessonView\` inside \`AppLayout\`; anonymous visitors get a new \`PublicSharedLessonPage\` with the audio player and App Store / Play Store install CTAs.
- The share button now calls a new owner-only API endpoint to mint a \`share_uuid\` before forming the URL. Old integer-based share links no longer work — the API endpoint stops accepting integers (see companion: zeeguu/api#623).

## Why
You can now share an audio lesson with a friend who doesn't have a Zeeguu account: they land on a clean public page, can play the lesson, and see how to install the app. The UUID-based token also prevents catalogue enumeration via guessable integer IDs.

## Notes
- \`shareLessonLink\` is now async (it awaits the mint call); both call-sites in \`PastLessons\` and \`LessonPlaybackView\` pass the API instance through.
- The \`:id\` URL param is kept as-is for minimal route churn — its value just happens to be a UUID now.

## Test plan
- [ ] Click Share on a daily/past lesson → URL contains a UUID
- [ ] Open the URL in a private window (no session) → public page renders with install buttons
- [ ] Open the URL while logged in → in-app view with language-aware banner renders
- [ ] Try \`/shared-lesson/1\` or other guessed integers → "Could not open this lesson"
- [ ] App Store / Play Store buttons open the correct store pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)