### PR TITLE
Daily audio lesson: fresh lesson waiting, just listen (Listen redesign)

### DIFF
--- a/src/components/CustomAudioPlayer.js
+++ b/src/components/CustomAudioPlayer.js
@@ -99,6 +99,7 @@ export default function CustomAudioPlayer({
   title = "Audio Lesson",
   artist = "Zeeguu",
   autoPlay = false,
+  children,
 }) {
   const getStoredSpeed = () => {
     if (!language) return 1.0;
@@ -804,6 +805,8 @@ export default function CustomAudioPlayer({
           {formatTime(duration, true)}
         </div>
       </div>
+
+      {children}
     </div>
   );
 }

--- a/src/components/DailyAudioNotificationDot.js
+++ b/src/components/DailyAudioNotificationDot.js
@@ -43,8 +43,13 @@ const Dot = styled.div`
 `;
 
 export default function DailyAudioNotificationDot({ status, isActive, sidebar }) {
-  // Only show for generating (spinner) or ready (new lesson waiting)
-  if (!status || status === AUDIO_STATUS.COMPLETED || status === AUDIO_STATUS.IN_PROGRESS) return null;
+  // Show the dot only when there's something actionable: a fresh unlistened
+  // lesson waiting (ready) or one being generated (spinner). Everything else —
+  // no lesson yet ("available", the backend default before generation),
+  // already listened (completed), or mid-listen (in_progress) — shows nothing.
+  // Listing the two positive cases (rather than excluding a few) keeps stray
+  // backend statuses like "available" from leaking through the default branch.
+  if (status !== AUDIO_STATUS.GENERATING && status !== AUDIO_STATUS.READY) return null;
 
   return <Dot $status={status} $isActive={isActive} $sidebar={sidebar} />;
 }

--- a/src/components/DialogWrapper.js
+++ b/src/components/DialogWrapper.js
@@ -3,7 +3,9 @@ import * as RadixDialog from "@radix-ui/react-dialog";
 import styled from "styled-components";
 
 const Overlay = styled(RadixDialog.Overlay)`
-  background: hsla(0, 0%, 0%, 0.33);
+  background: hsla(0, 0%, 0%, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   position: fixed;
   top: 0;
   right: 0;

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from "react";
+import { Dialog } from "../components/DialogWrapper";
+import SuggestionSelector, { pillToBackend, backendToPill } from "./SuggestionSelector";
+import { SubtleTextButton } from "./LessonView.sc";
+import { BannerButton } from "./SharedLessonView.sc";
+
+/**
+ * Setup / "Change daily topic" dialog. Hosts the lesson-type selector and
+ * persists the per-language daily-lesson preference. The dialog never
+ * generates audio itself — it hands the chosen (type, suggestion) back to the
+ * parent via onSubmit, which owns the generation state machine and progress UI.
+ *
+ * onSubmit(backendType, verbatimSuggestion, regenerate):
+ *   regenerate=true  → apply now (parent regenerates today's lesson)
+ *   regenerate=false → save for tomorrow only (keeps today's existing lesson)
+ */
+export default function DailyLessonSettingsDialog({
+  api,
+  initialType,
+  initialSuggestion,
+  todaysLessonExists,
+  onSubmit,
+  onDismiss,
+}) {
+  const [pillType, setPillType] = useState(initialType ? backendToPill(initialType) : "topic");
+  const [suggestion, setSuggestion] = useState(initialSuggestion || "");
+  const [autoDisabled, setAutoDisabled] = useState(false);
+
+  // Vocabulary needs enough study words; disable the pill when there aren't.
+  useEffect(() => {
+    api.checkDailyLessonFeasibility(
+      (data) => {
+        setAutoDisabled(!data.feasible);
+        if (!data.feasible) setPillType((t) => (t === "auto" ? "topic" : t));
+      },
+      () => setAutoDisabled(false),
+    );
+  }, [api]);
+
+  const needsSubject = pillType === "topic" || pillType === "situation";
+  const canSubmit = !needsSubject || suggestion.trim().length > 0;
+
+  const submit = (regenerate) => {
+    if (!canSubmit) return;
+    // Store the subject exactly as typed; Vocabulary carries no subject.
+    onSubmit(pillToBackend(pillType), needsSubject ? suggestion : "", regenerate);
+  };
+
+  return (
+    <Dialog
+      onDismiss={onDismiss}
+      aria-label="Daily lesson settings"
+      style={{
+        background: "var(--card-bg)",
+        color: "var(--text-primary)",
+        borderRadius: "16px",
+        width: "min(90vw, 360px)",
+        padding: "1.5rem",
+      }}
+    >
+      <h2 style={{ margin: "0 0 4px", fontSize: "1.25rem", color: "var(--text-primary)" }}>
+        Your daily lesson
+      </h2>
+      <p style={{ margin: "0 0 16px", fontSize: "0.9rem", color: "var(--text-secondary)" }}>
+        Every morning we'll have a fresh one ready for you. What kind?
+      </p>
+
+      <SuggestionSelector
+        suggestionType={pillType}
+        setSuggestionType={setPillType}
+        suggestion={suggestion}
+        setSuggestion={setSuggestion}
+        autoDisabled={autoDisabled}
+      />
+
+      <div style={{ marginTop: "20px", display: "flex", flexDirection: "column", alignItems: "center", gap: "10px" }}>
+        <BannerButton
+          onClick={() => submit(true)}
+          disabled={!canSubmit}
+          style={{
+            width: "100%",
+            padding: "12px",
+            fontSize: "1rem",
+            fontWeight: 600,
+            opacity: canSubmit ? 1 : 0.5,
+            cursor: canSubmit ? "pointer" : "not-allowed",
+          }}
+        >
+          {todaysLessonExists ? "Generate today's lesson" : "Start my daily lessons"}
+        </BannerButton>
+
+        {todaysLessonExists && (
+          <SubtleTextButton onClick={() => submit(false)} disabled={!canSubmit}>
+            Save for tomorrow instead
+          </SubtleTextButton>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -101,7 +101,7 @@ export default function DailyLessonSettingsDialog({
       }}
     >
       <h2 style={{ margin: "0 0 16px", fontSize: "1.25rem", color: zeeguuOrange }}>
-        Daily lesson type
+        Daily lesson settings
       </h2>
 
       <SuggestionSelector

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -24,7 +24,12 @@ export default function DailyLessonSettingsDialog({
   onDismiss,
 }) {
   const [pillType, setPillType] = useState(initialType ? backendToPill(initialType) : "topic");
-  const [suggestion, setSuggestion] = useState(initialSuggestion || "");
+  // Per-type subject so switching pills — or to Vocabulary and back — never
+  // clobbers what was typed for Topic vs Situation.
+  const [subjectByType, setSubjectByType] = useState(() => ({
+    topic: initialType === "topic" ? initialSuggestion || "" : "",
+    situation: initialType === "situation" ? initialSuggestion || "" : "",
+  }));
   const [autoDisabled, setAutoDisabled] = useState(false);
   const [confirmRegen, setConfirmRegen] = useState(false);
 
@@ -40,26 +45,32 @@ export default function DailyLessonSettingsDialog({
   }, [api]);
 
   const needsSubject = pillType === "topic" || pillType === "situation";
-  const canSubmit = !needsSubject || suggestion.trim().length > 0;
+  const currentSubject = needsSubject ? subjectByType[pillType] : "";
+  const setCurrentSubject = (val) => setSubjectByType((prev) => ({ ...prev, [pillType]: val }));
+  const canSubmit = !needsSubject || currentSubject.trim().length > 0;
 
   const submit = (regenerate) => {
     if (!canSubmit) return;
     // Store the subject exactly as typed; Vocabulary carries no subject.
-    onSubmit(pillToBackend(pillType), needsSubject ? suggestion : "", regenerate);
+    onSubmit(pillToBackend(pillType), needsSubject ? currentSubject : "", regenerate);
   };
 
   // Did the user actually pick something different from their current setup?
+  // Save stays disabled until they do.
+  const initialSubject =
+    initialType === "topic" || initialType === "situation" ? (initialSuggestion || "").trim() : "";
   const changed =
-    pillToBackend(pillType) !== initialType ||
-    (needsSubject ? suggestion.trim() : "") !== (initialSuggestion || "").trim();
+    pillToBackend(pillType) !== (initialType || null) ||
+    (needsSubject ? currentSubject.trim() : "") !== initialSubject;
+  const canSave = canSubmit && changed;
 
-  // Saving a *changed* setting while today's lesson already exists asks whether
-  // to apply it now or from tomorrow. Otherwise just save — generating right
-  // away when there's no lesson for today yet (first run / cron miss).
+  // Saving a changed setting while today's lesson already exists asks whether to
+  // apply it now or from tomorrow. Otherwise just save — generating right away
+  // when there's no lesson for today yet (first run / cron miss).
   const handleSaveClick = () => {
-    if (!canSubmit) return;
-    if (todaysLessonExists && changed) setConfirmRegen(true);
-    else submit(!todaysLessonExists);
+    if (!canSave) return;
+    if (todaysLessonExists) setConfirmRegen(true);
+    else submit(true);
   };
 
   const buttonStyle = { width: "100%", padding: "12px", fontSize: "1rem", fontWeight: 600 };
@@ -67,8 +78,8 @@ export default function DailyLessonSettingsDialog({
   const saveButton = (
     <BannerButton
       onClick={handleSaveClick}
-      disabled={!canSubmit}
-      style={{ ...buttonStyle, opacity: canSubmit ? 1 : 0.5, cursor: canSubmit ? "pointer" : "not-allowed" }}
+      disabled={!canSave}
+      style={{ ...buttonStyle, opacity: canSave ? 1 : 0.5, cursor: canSave ? "pointer" : "not-allowed" }}
     >
       Save settings
     </BannerButton>
@@ -107,8 +118,8 @@ export default function DailyLessonSettingsDialog({
       <SuggestionSelector
         suggestionType={pillType}
         setSuggestionType={setPillType}
-        suggestion={suggestion}
-        setSuggestion={setSuggestion}
+        suggestion={currentSubject}
+        setSuggestion={setCurrentSubject}
         autoDisabled={autoDisabled}
       />
 

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -100,14 +100,9 @@ export default function DailyLessonSettingsDialog({
         boxShadow: "0 16px 48px rgba(0, 0, 0, 0.6)",
       }}
     >
-      <h2 style={{ margin: "0 0 4px", fontSize: "1.25rem", color: zeeguuOrange }}>
-        {todaysLessonExists ? "Change your daily lesson" : "Set up your daily lessons"}
+      <h2 style={{ margin: "0 0 16px", fontSize: "1.25rem", color: zeeguuOrange }}>
+        Daily lesson type
       </h2>
-      <p style={{ margin: "0 0 16px", fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-        {todaysLessonExists
-          ? "A new lesson, ready for you daily. Pick what you'd like instead."
-          : "A new lesson, ready for you daily. Pick what kind — we'll make your first one right now."}
-      </p>
 
       <SuggestionSelector
         suggestionType={pillType}

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -26,6 +26,7 @@ export default function DailyLessonSettingsDialog({
   const [pillType, setPillType] = useState(initialType ? backendToPill(initialType) : "topic");
   const [suggestion, setSuggestion] = useState(initialSuggestion || "");
   const [autoDisabled, setAutoDisabled] = useState(false);
+  const [confirmRegen, setConfirmRegen] = useState(false);
 
   // Vocabulary needs enough study words; disable the pill when there aren't.
   useEffect(() => {
@@ -47,6 +48,44 @@ export default function DailyLessonSettingsDialog({
     onSubmit(pillToBackend(pillType), needsSubject ? suggestion : "", regenerate);
   };
 
+  // Did the user actually pick something different from their current setup?
+  const changed =
+    pillToBackend(pillType) !== initialType ||
+    (needsSubject ? suggestion.trim() : "") !== (initialSuggestion || "").trim();
+
+  // Saving a *changed* setting while today's lesson already exists asks whether
+  // to apply it now or from tomorrow. Otherwise just save — generating right
+  // away when there's no lesson for today yet (first run / cron miss).
+  const handleSaveClick = () => {
+    if (!canSubmit) return;
+    if (todaysLessonExists && changed) setConfirmRegen(true);
+    else submit(!todaysLessonExists);
+  };
+
+  const buttonStyle = { width: "100%", padding: "12px", fontSize: "1rem", fontWeight: 600 };
+
+  const saveButton = (
+    <BannerButton
+      onClick={handleSaveClick}
+      disabled={!canSubmit}
+      style={{ ...buttonStyle, opacity: canSubmit ? 1 : 0.5, cursor: canSubmit ? "pointer" : "not-allowed" }}
+    >
+      Save settings
+    </BannerButton>
+  );
+
+  const confirmStep = (
+    <>
+      <p style={{ margin: 0, fontSize: "0.9rem", color: "var(--text-secondary)", textAlign: "center" }}>
+        Apply this to today's lesson, or start from tomorrow?
+      </p>
+      <BannerButton onClick={() => submit(true)} style={buttonStyle}>
+        Regenerate today's lesson
+      </BannerButton>
+      <SubtleTextButton onClick={() => submit(false)}>Start from tomorrow</SubtleTextButton>
+    </>
+  );
+
   return (
     <Dialog
       onDismiss={onDismiss}
@@ -66,7 +105,7 @@ export default function DailyLessonSettingsDialog({
       </h2>
       <p style={{ margin: "0 0 16px", fontSize: "0.9rem", color: "var(--text-secondary)" }}>
         {todaysLessonExists
-          ? "A new lesson, ready for you daily. Pick what you'd like instead — we'll make today's right away."
+          ? "A new lesson, ready for you daily. Pick what you'd like instead."
           : "A new lesson, ready for you daily. Pick what kind — we'll make your first one right now."}
       </p>
 
@@ -79,26 +118,7 @@ export default function DailyLessonSettingsDialog({
       />
 
       <div style={{ marginTop: "20px", display: "flex", flexDirection: "column", alignItems: "center", gap: "10px" }}>
-        <BannerButton
-          onClick={() => submit(true)}
-          disabled={!canSubmit}
-          style={{
-            width: "100%",
-            padding: "12px",
-            fontSize: "1rem",
-            fontWeight: 600,
-            opacity: canSubmit ? 1 : 0.5,
-            cursor: canSubmit ? "pointer" : "not-allowed",
-          }}
-        >
-          {todaysLessonExists ? "Generate today's lesson" : "Start today's lesson"}
-        </BannerButton>
-
-        {todaysLessonExists && (
-          <SubtleTextButton onClick={() => submit(false)} disabled={!canSubmit}>
-            Save for tomorrow instead
-          </SubtleTextButton>
-        )}
+        {confirmRegen ? confirmStep : saveButton}
       </div>
     </Dialog>
   );

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -3,6 +3,7 @@ import { Dialog } from "../components/DialogWrapper";
 import SuggestionSelector, { pillToBackend, backendToPill } from "./SuggestionSelector";
 import { SubtleTextButton } from "./LessonView.sc";
 import { BannerButton } from "./SharedLessonView.sc";
+import { zeeguuOrange } from "../components/colors";
 
 /**
  * Setup / "Change daily topic" dialog. Hosts the lesson-type selector and
@@ -54,15 +55,19 @@ export default function DailyLessonSettingsDialog({
         background: "var(--card-bg)",
         color: "var(--text-primary)",
         borderRadius: "16px",
-        width: "min(90vw, 360px)",
+        width: "min(86vw, 330px)",
         padding: "1.5rem",
+        border: "1px solid rgba(255, 255, 255, 0.14)",
+        boxShadow: "0 16px 48px rgba(0, 0, 0, 0.6)",
       }}
     >
-      <h2 style={{ margin: "0 0 4px", fontSize: "1.25rem", color: "var(--text-primary)" }}>
-        Your daily lesson
+      <h2 style={{ margin: "0 0 4px", fontSize: "1.25rem", color: zeeguuOrange }}>
+        {todaysLessonExists ? "Change your daily lesson" : "Set up your daily lessons"}
       </h2>
       <p style={{ margin: "0 0 16px", fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-        Every morning we'll have a fresh one ready for you. What kind?
+        {todaysLessonExists
+          ? "A new lesson, ready for you daily. Pick what you'd like instead — we'll make today's right away."
+          : "A new lesson, ready for you daily. Pick what kind — we'll make your first one right now."}
       </p>
 
       <SuggestionSelector
@@ -86,7 +91,7 @@ export default function DailyLessonSettingsDialog({
             cursor: canSubmit ? "pointer" : "not-allowed",
           }}
         >
-          {todaysLessonExists ? "Generate today's lesson" : "Start my daily lessons"}
+          {todaysLessonExists ? "Generate today's lesson" : "Start today's lesson"}
         </BannerButton>
 
         {todaysLessonExists && (

--- a/src/dailyAudio/DailyLessonSettingsDialog.js
+++ b/src/dailyAudio/DailyLessonSettingsDialog.js
@@ -33,6 +33,13 @@ export default function DailyLessonSettingsDialog({
   const [autoDisabled, setAutoDisabled] = useState(false);
   const [confirmRegen, setConfirmRegen] = useState(false);
 
+  // Changing the type/subject after the regenerate-or-tomorrow prompt has shown
+  // would leave it describing a stale choice (and could strand the confirm
+  // buttons if the new subject is empty) — so drop back to "Save settings".
+  useEffect(() => {
+    setConfirmRegen(false);
+  }, [pillType, subjectByType]);
+
   // Vocabulary needs enough study words; disable the pill when there aren't.
   useEffect(() => {
     api.checkDailyLessonFeasibility(

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -13,7 +13,6 @@ import ShareLessonButton from "./ShareLessonButton";
 export default function LessonPlaybackView({
   lessonData,
   setLessonData,
-  words,
   error,
   api,
   userDetails,
@@ -25,6 +24,7 @@ export default function LessonPlaybackView({
   footer,
 }) {
   const [openFeedback, setOpenFeedback] = useState(false);
+  const words = lessonData.words || [];
 
   // Callers (e.g. the daily episode card) can replace the default title block
   // with their own header; otherwise we show the plain title + topic line.

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -21,11 +21,15 @@ export default function LessonPlaybackView({
   listeningSession,
   currentPlaybackTime,
   setCurrentPlaybackTime,
+  header,
+  footer,
 }) {
   const [openFeedback, setOpenFeedback] = useState(false);
 
-  return (
-    <LessonWrapper>
+  // Callers (e.g. the daily episode card) can replace the default title block
+  // with their own header; otherwise we show the plain title + topic line.
+  const defaultHeader = (
+    <>
       <LessonTitle>
         {lessonData.title}
         {lessonData.is_completed && <> <CompletionCheck>✓</CompletionCheck></>}
@@ -33,6 +37,12 @@ export default function LessonPlaybackView({
       {lessonData.canonical_suggestion && (
         <LessonMetadata>{lessonData.lesson_type === "situation" ? "Situation" : "Topic"}: <b>{lessonData.canonical_suggestion}</b></LessonMetadata>
       )}
+    </>
+  );
+
+  return (
+    <LessonWrapper>
+      {header || defaultHeader}
 
       {error && <div style={{ color: "red", marginBottom: "20px" }}>{error}</div>}
 
@@ -144,6 +154,8 @@ export default function LessonPlaybackView({
             </SubtleTextButton>
           )}
         </LessonActions>
+
+        {footer}
 
         <FeedbackModal
           prefixMsg={lessonData

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -8,7 +8,7 @@ import { AUDIO_STATUS } from "./AudioLessonConstants";
 import { LessonWrapper, LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton, LessonActions } from "./LessonView.sc";
 import { wordsAsTile } from "./audioUtils";
 import { languageNames } from "../utils/languageDetection";
-import { shareLessonLink } from "./shareLessonLink";
+import ShareLessonButton from "./ShareLessonButton";
 
 export default function LessonPlaybackView({
   lessonData,
@@ -95,15 +95,9 @@ export default function LessonPlaybackView({
             maxWidth: "600px",
             margin: "0 auto 20px auto",
           }}
-        />
-
-        {lessonData.lesson_id && (
-          <div style={{ textAlign: "center", marginBottom: "8px" }}>
-            <SubtleTextButton onClick={() => shareLessonLink(api, lessonData.lesson_id, lessonData.title)}>
-              Share
-            </SubtleTextButton>
-          </div>
-        )}
+        >
+          <ShareLessonButton api={api} lessonId={lessonData.lesson_id} title={lessonData.title} />
+        </CustomAudioPlayer>
 
         {lessonData.is_completed && (
           <div

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -97,6 +97,14 @@ export default function LessonPlaybackView({
           }}
         />
 
+        {lessonData.lesson_id && (
+          <div style={{ textAlign: "center", marginBottom: "8px" }}>
+            <SubtleTextButton onClick={() => shareLessonLink(api, lessonData.lesson_id, lessonData.title)}>
+              Share
+            </SubtleTextButton>
+          </div>
+        )}
+
         {lessonData.is_completed && (
           <div
             style={{
@@ -134,13 +142,6 @@ export default function LessonPlaybackView({
         {footer}
 
         <LessonActions>
-          {lessonData.lesson_id && (
-            <SubtleTextButton
-              onClick={() => shareLessonLink(api, lessonData.lesson_id, lessonData.title)}
-            >
-              Share
-            </SubtleTextButton>
-          )}
           <SubtleTextButton onClick={() => setOpenFeedback(true)}>
             Feedback
           </SubtleTextButton>

--- a/src/dailyAudio/LessonPlaybackView.js
+++ b/src/dailyAudio/LessonPlaybackView.js
@@ -79,6 +79,9 @@ export default function LessonPlaybackView({
                 setLessonData((prev) => ({
                   ...prev,
                   is_completed: true,
+                  // One ✓ per listen — bump locally so replays show immediately,
+                  // mirroring the backend's per-completion increment.
+                  listened_count: (prev.listened_count || 0) + 1,
                   last_completed_at: new Date().toISOString(),
                 }));
                 setUserDetails((prev) => ({ ...prev, daily_audio_status: AUDIO_STATUS.COMPLETED }));
@@ -128,6 +131,8 @@ export default function LessonPlaybackView({
           </div>
         )}
 
+        {footer}
+
         <LessonActions>
           {lessonData.lesson_id && (
             <SubtleTextButton
@@ -154,8 +159,6 @@ export default function LessonPlaybackView({
             </SubtleTextButton>
           )}
         </LessonActions>
-
-        {footer}
 
         <FeedbackModal
           prefixMsg={lessonData

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -8,6 +8,7 @@ import { SubtleTextButton, LessonTitle, CompletionCheck } from "./LessonView.sc"
 import { SubtleLessonCard, ProgressBarTrack, ProgressBarFill } from "./SharedLessonView.sc";
 import { PillRow, SelectablePill } from "./SuggestionSelector.sc";
 import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
+import { completionChecks } from "./audioUtils";
 import { shareLessonLink } from "./shareLessonLink";
 
 // Filter the back catalogue by lesson type. value=null means "All".
@@ -28,13 +29,6 @@ const lessonDateLabel = (lesson) =>
   });
 
 const lessonTitleText = (lesson) => lesson.title || "Past Audio Lesson";
-
-// Render the completion check(s). For replays we draw one ✓ per listen,
-// up to 7; beyond that we use ✓✓✓…✓ so the row doesn't grow without bound.
-const renderChecks = (count) => {
-  if (count <= 7) return "✓".repeat(count);
-  return "✓✓✓…✓";
-};
 
 function CollapsedProgressBar({ lesson }) {
   const duration = lesson.duration_seconds || 0;
@@ -72,7 +66,7 @@ const titleWithDate = (lesson) => {
       {head}
       <span style={{ whiteSpace: "nowrap" }}>
         {tail}
-        {checkCount > 0 && <> <CompletionCheck>{renderChecks(checkCount)}</CompletionCheck></>}
+        {checkCount > 0 && <> <CompletionCheck>{completionChecks(checkCount)}</CompletionCheck></>}
       </span>
     </>
   );

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -9,7 +9,7 @@ import { SubtleLessonCard, ProgressBarTrack, ProgressBarFill } from "./SharedLes
 import { PillRow, SelectablePill } from "./SuggestionSelector.sc";
 import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
 import { completionChecks } from "./audioUtils";
-import { shareLessonLink } from "./shareLessonLink";
+import ShareLessonButton from "./ShareLessonButton";
 
 // Filter the back catalogue by lesson type. value=null means "All".
 const TYPE_FILTERS = [
@@ -382,13 +382,7 @@ function InlineLessonPlayer({ lesson, api, userDetails, onLessonCompleted, onPro
         }}
         onError={() => {}}
       />
-      {lesson.lesson_id && (
-        <div style={{ marginTop: "12px", textAlign: "center" }}>
-          <SubtleTextButton onClick={() => shareLessonLink(api, lesson.lesson_id, lesson.title)}>
-            Share
-          </SubtleTextButton>
-        </div>
-      )}
+      <ShareLessonButton api={api} lessonId={lesson.lesson_id} title={lesson.title} />
     </>
   );
 }

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -1,5 +1,4 @@
 import React, { useState, useContext, useEffect } from "react";
-import styled from "styled-components";
 import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
 import LoadingAnimation from "../components/LoadingAnimation";
@@ -7,40 +6,17 @@ import useListeningSession from "../hooks/useListeningSession";
 import CustomAudioPlayer from "../components/CustomAudioPlayer";
 import { SubtleTextButton, LessonTitle, CompletionCheck } from "./LessonView.sc";
 import { SubtleLessonCard, ProgressBarTrack, ProgressBarFill } from "./SharedLessonView.sc";
+import { PillRow, SelectablePill } from "./SuggestionSelector.sc";
+import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
 import { shareLessonLink } from "./shareLessonLink";
 
-// Small colored pill that surfaces the lesson category in the card preview.
-// Colors mirror SessionHistory's activity chips (Reading/Browsing/Audio)
-// so the visual language is consistent across activity & lessons. Each
-// palette has a dark-mode variant: pale pastels disappear on dark cards,
-// so we swap to a deeper background with brighter text.
-const chipPalette = {
-  topic:              { bg: "#e3f2fd", color: "#1565c0", darkBg: "#1e3a52", darkColor: "#90caf9" },  // blue
-  situation:          { bg: "#e8f5e9", color: "#2e7d32", darkBg: "#1f3d24", darkColor: "#a5d6a7" },  // green
-  three_words_lesson: { bg: "#f3e5f5", color: "#7b1fa2", darkBg: "#3a1f3e", darkColor: "#ce93d8" },  // purple
-};
-
-const LessonTypeChip = styled.span`
-  display: inline-block;
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  margin-bottom: 6px;
-  background: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).bg};
-  color: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).color};
-
-  [data-theme="dark"] & {
-    background: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).darkBg};
-    color: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).darkColor};
-  }
-`;
-
-const chipLabel = (lessonType) => {
-  if (lessonType === "situation") return "Situation";
-  if (lessonType === "three_words_lesson") return "Vocabulary";
-  return "Topic";
-};
+// Filter the back catalogue by lesson type. value=null means "All".
+const TYPE_FILTERS = [
+  { label: "All", value: null },
+  { label: "Vocabulary", value: "three_words_lesson" },
+  { label: "Topic", value: "topic" },
+  { label: "Situation", value: "situation" },
+];
 
 const lessonProgressSeconds = (lesson) =>
   lesson.pause_position_seconds || lesson.position_seconds || lesson.progress_seconds || 0;
@@ -112,6 +88,7 @@ export default function PastLessons() {
   const [hasMore, setHasMore] = useState(true);
   const [offset, setOffset] = useState(0);
   const [openLessonId, setOpenLessonId] = useState(null);
+  const [typeFilter, setTypeFilter] = useState(null);
   const limit = 10;
 
   useEffect(() => {
@@ -205,9 +182,34 @@ export default function PastLessons() {
   const toggleLesson = (lessonId) =>
     setOpenLessonId((current) => (current === lessonId ? null : lessonId));
 
+  // Client-side filter over the lessons loaded so far. Note: with pagination
+  // this only filters the pages already fetched, so a rarely-used type may
+  // show fewer than exist until more pages are loaded. (Follow-up: push the
+  // lesson_type filter down to the past_daily_lessons endpoint.)
+  const visibleLessons = typeFilter
+    ? pastLessons.filter((lesson) => lesson.lesson_type === typeFilter)
+    : pastLessons;
+
   return (
     <div style={{ padding: "20px" }}>
       {error && <div style={{ color: "red", marginBottom: "20px" }}>{error}</div>}
+
+      {pastLessons.length > 0 && (
+        <PillRow role="radiogroup" aria-label="Filter lessons by type" style={{ flexWrap: "wrap", justifyContent: "center", marginBottom: "16px" }}>
+          {TYPE_FILTERS.map(({ label, value }) => (
+            <SelectablePill
+              key={label}
+              type="button"
+              role="radio"
+              aria-checked={typeFilter === value}
+              $selected={typeFilter === value}
+              onClick={() => setTypeFilter(value)}
+            >
+              {label}
+            </SelectablePill>
+          ))}
+        </PillRow>
+      )}
 
       {pastLessons.length === 0 && !isLoading && !error && (
         <div style={{ textAlign: "center", color: "var(--text-muted)", marginTop: "40px" }}>
@@ -215,10 +217,16 @@ export default function PastLessons() {
         </div>
       )}
 
-      {pastLessons.length > 0 && (
+      {pastLessons.length > 0 && visibleLessons.length === 0 && (
+        <div style={{ textAlign: "center", color: "var(--text-muted)", marginTop: "40px" }}>
+          <p>No {chipLabel(typeFilter).toLowerCase()} lessons yet.</p>
+        </div>
+      )}
+
+      {visibleLessons.length > 0 && (
         <div>
-          {pastLessons.map((lesson, idx) => {
-            const prev = idx > 0 ? pastLessons[idx - 1] : null;
+          {visibleLessons.map((lesson, idx) => {
+            const prev = idx > 0 ? visibleLessons[idx - 1] : null;
             const categoryChanged =
               !prev ||
               prev.lesson_type !== lesson.lesson_type ||

--- a/src/dailyAudio/PastLessons.js
+++ b/src/dailyAudio/PastLessons.js
@@ -8,7 +8,7 @@ import { SubtleTextButton, LessonTitle, CompletionCheck } from "./LessonView.sc"
 import { SubtleLessonCard, ProgressBarTrack, ProgressBarFill } from "./SharedLessonView.sc";
 import { PillRow, SelectablePill } from "./SuggestionSelector.sc";
 import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
-import { completionChecks } from "./audioUtils";
+import { completionChecks, formatShortDate } from "./audioUtils";
 import ShareLessonButton from "./ShareLessonButton";
 
 // Filter the back catalogue by lesson type. value=null means "All".
@@ -22,11 +22,7 @@ const TYPE_FILTERS = [
 const lessonProgressSeconds = (lesson) =>
   lesson.pause_position_seconds || lesson.position_seconds || lesson.progress_seconds || 0;
 
-const lessonDateLabel = (lesson) =>
-  new Date(lesson.created_at).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+const lessonDateLabel = (lesson) => formatShortDate(new Date(lesson.created_at));
 
 const lessonTitleText = (lesson) => lesson.title || "Past Audio Lesson";
 
@@ -145,7 +141,14 @@ export default function PastLessons() {
     setPastLessons((prev) =>
       prev.map((l) =>
         l.lesson_id === lessonId
-          ? { ...l, is_completed: true, last_completed_at: new Date().toISOString() }
+          ? {
+              ...l,
+              is_completed: true,
+              // One ✓ per listen — bump locally so replays add a check live,
+              // matching the today card (LessonPlaybackView does the same).
+              listened_count: (l.listened_count || 0) + 1,
+              last_completed_at: new Date().toISOString(),
+            }
           : l,
       ),
     );

--- a/src/dailyAudio/ShareLessonButton.js
+++ b/src/dailyAudio/ShareLessonButton.js
@@ -8,7 +8,7 @@ import { shareLessonLink } from "./shareLessonLink";
 export default function ShareLessonButton({ api, lessonId, title }) {
   if (!lessonId) return null;
   return (
-    <div style={{ textAlign: "center", marginTop: "2px" }}>
+    <div style={{ textAlign: "center", marginTop: "-2px" }}>
       <SubtleTextButton onClick={() => shareLessonLink(api, lessonId, title)}>
         Share
       </SubtleTextButton>

--- a/src/dailyAudio/ShareLessonButton.js
+++ b/src/dailyAudio/ShareLessonButton.js
@@ -8,7 +8,7 @@ import { shareLessonLink } from "./shareLessonLink";
 export default function ShareLessonButton({ api, lessonId, title }) {
   if (!lessonId) return null;
   return (
-    <div style={{ textAlign: "center", marginTop: "12px" }}>
+    <div style={{ textAlign: "center", marginTop: "2px" }}>
       <SubtleTextButton onClick={() => shareLessonLink(api, lessonId, title)}>
         Share
       </SubtleTextButton>

--- a/src/dailyAudio/ShareLessonButton.js
+++ b/src/dailyAudio/ShareLessonButton.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { SubtleTextButton } from "./LessonView.sc";
+import { shareLessonLink } from "./shareLessonLink";
+
+// The Share control shown under the player — shared by today's episode card and
+// the past-lessons list so they stay identical. Renders nothing without a
+// lesson id.
+export default function ShareLessonButton({ api, lessonId, title }) {
+  if (!lessonId) return null;
+  return (
+    <div style={{ textAlign: "center", marginTop: "12px" }}>
+      <SubtleTextButton onClick={() => shareLessonLink(api, lessonId, title)}>
+        Share
+      </SubtleTextButton>
+    </div>
+  );
+}

--- a/src/dailyAudio/SuggestionSelector.js
+++ b/src/dailyAudio/SuggestionSelector.js
@@ -8,66 +8,76 @@ import {
   InputArea,
 } from "./SuggestionSelector.sc";
 
-const MAX_SUGGESTION_LENGTH = 80;
+export const MAX_SUGGESTION_LENGTH = 80;
 
-const SUGGESTION_TYPES = {
+export const SUGGESTION_TYPES = {
   auto: {
     label: "Vocabulary",
-    description: "A listening lesson focused on three words from your study list, each in a short dialogue.",
+    description: "A new lesson built from words on your study list, each in a short dialogue.",
     placeholder: null,
   },
   topic: {
     label: "Topic",
-    description: "A listening lesson with a conversation about a topic of your choice.",
+    description: "A daily conversation about a subject you care about.",
     placeholder: "e.g. cooking, sports",
   },
   situation: {
     label: "Situation",
-    description: "A listening lesson with a conversation simulating a real-world situation of your choice.",
+    description: "A daily conversation that role-plays a real-world situation.",
     placeholder: "e.g. at a restaurant, job interview",
   },
 };
 
-const SELECTED_LESSON_TYPE = "audio_lesson_lesson_type_";
-export const suggestionKey = (type, lang) => `audio_lesson_suggestion_${type}_${lang}`;
+// The UI pills use friendly keys ("auto"); the backend / preference store
+// the canonical lesson_type ("three_words_lesson"). Convert at the boundary.
+const PILL_TO_BACKEND = { auto: "three_words_lesson", topic: "topic", situation: "situation" };
 
-export function getSavedSuggestionType(lang) {
-  return localStorage.getItem(SELECTED_LESSON_TYPE + lang) || "auto";
-}
+export const pillToBackend = (pillKey) => PILL_TO_BACKEND[pillKey] || "three_words_lesson";
 
-export function getSavedSuggestion(lang) {
-  return localStorage.getItem(suggestionKey(getSavedSuggestionType(lang), lang)) || "";
-}
+export const backendToPill = (lessonType) =>
+  lessonType === "topic" || lessonType === "situation" ? lessonType : "auto";
 
-export default function SuggestionSelector({ suggestionType, setSuggestionType, suggestion, setSuggestion, lang, autoDisabled }) {
+/**
+ * Pure controlled selector. The parent owns the (suggestionType, suggestion)
+ * state and is responsible for persistence — this component just renders the
+ * pills + description + input and reports changes upward.
+ */
+export default function SuggestionSelector({
+  suggestionType,
+  setSuggestionType,
+  suggestion,
+  setSuggestion,
+  autoDisabled,
+}) {
+  const selectType = (key) => {
+    if (suggestionType === key) return;
+    if (key === "auto" && autoDisabled) return;
+    setSuggestionType(key);
+    // Switching to Vocabulary clears the (now irrelevant) subject; switching
+    // between Topic/Situation keeps whatever the user already typed.
+    if (key === "auto") setSuggestion("");
+  };
+
   return (
     <SuggestionWrapper>
-
-      <PillRow role="radiogroup" aria-label="Dialogue context">
-        {Object.entries(SUGGESTION_TYPES).map(([key, { label }]) => {
-          return (
+      <PillRow role="radiogroup" aria-label="Daily lesson type">
+        {Object.entries(SUGGESTION_TYPES).map(([key, { label }]) => (
           <SelectablePill
             key={key}
             type="button"
             $selected={suggestionType === key}
             role="radio"
             aria-checked={suggestionType === key}
-            onClick={() => {
-              if (suggestionType === key) return;
-              setSuggestionType(key);
-              localStorage.setItem(SELECTED_LESSON_TYPE + lang, key);
-              setSuggestion(key === "auto" ? "" : localStorage.getItem(suggestionKey(key, lang)) || "");
-            }}
+            disabled={key === "auto" && autoDisabled}
+            style={key === "auto" && autoDisabled ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
+            onClick={() => selectType(key)}
           >
             {label}
           </SelectablePill>
-          );
-        })}
+        ))}
       </PillRow>
 
-      <DescriptionText>
-        {SUGGESTION_TYPES[suggestionType].description}
-      </DescriptionText>
+      <DescriptionText>{SUGGESTION_TYPES[suggestionType].description}</DescriptionText>
 
       <InputArea $hidden={suggestionType === "auto"}>
         <ClearableInput
@@ -75,23 +85,10 @@ export default function SuggestionSelector({ suggestionType, setSuggestionType, 
           maxLength={MAX_SUGGESTION_LENGTH}
           value={suggestion}
           tabIndex={suggestionType === "auto" ? -1 : 0}
-          onChange={(e) => {
-            const val = e.target.value.replace(/\n/g, " ");
-            setSuggestion(val);
-            const key = suggestionKey(suggestionType, lang);
-            if (val.trim()) {
-              localStorage.setItem(key, val);
-            } else {
-              localStorage.removeItem(key);
-            }
-          }}
-          onClear={() => {
-            setSuggestion("");
-            localStorage.removeItem(suggestionKey(suggestionType, lang));
-          }}
+          onChange={(e) => setSuggestion(e.target.value.replace(/\n/g, " "))}
+          onClear={() => setSuggestion("")}
         />
       </InputArea>
-
     </SuggestionWrapper>
   );
 }

--- a/src/dailyAudio/SuggestionSelector.js
+++ b/src/dailyAudio/SuggestionSelector.js
@@ -52,10 +52,9 @@ export default function SuggestionSelector({
   const selectType = (key) => {
     if (suggestionType === key) return;
     if (key === "auto" && autoDisabled) return;
+    // Only switch the type — the parent keeps a per-type subject, so it supplies
+    // the right text for whichever pill is selected (and clears nothing).
     setSuggestionType(key);
-    // Switching to Vocabulary clears the (now irrelevant) subject; switching
-    // between Topic/Situation keeps whatever the user already typed.
-    if (key === "auto") setSuggestion("");
   };
 
   return (

--- a/src/dailyAudio/TodayAudio.js
+++ b/src/dailyAudio/TodayAudio.js
@@ -1,18 +1,17 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Capacitor } from "@capacitor/core";
 import { orange500, zeeguuOrange } from "../components/colors";
 import { APIContext } from "../contexts/APIContext";
 import { UserContext } from "../contexts/UserContext";
 import LoadingAnimation from "../components/LoadingAnimation";
-import EmptyState from "../components/EmptyState";
-import FullWidthErrorMsg from "../components/FullWidthErrorMsg.sc";
 import useListeningSession from "../hooks/useListeningSession";
+import useDailyLessonPreference from "../hooks/useDailyLessonPreference";
 import { AUDIO_STATUS, GENERATION_PROGRESS } from "./AudioLessonConstants";
-import { GenerateView, GenerateButton } from "./GenerateButton.sc";
-import SuggestionSelector, { getSavedSuggestion, getSavedSuggestionType, suggestionKey } from "./SuggestionSelector";
-import LessonPlaybackView from "./LessonPlaybackView";
+import TodayEpisodeCard from "./TodayEpisodeCard";
+import DailyLessonSettingsDialog from "./DailyLessonSettingsDialog";
 import { SubtleTextButton } from "./LessonView.sc";
+import { BannerButton } from "./SharedLessonView.sc";
 import { wordsAsTile, shortDate } from "./audioUtils";
 
 // Shown rotating during the backend phases that don't emit sub-step
@@ -30,33 +29,125 @@ const PLACEHOLDER_PROGRESS_MESSAGES = [
 ];
 const PLACEHOLDER_ROTATION_MS = 2500;
 
-export default function TodayAudio({ setShowTabs }) {
+export default function TodayAudio() {
   const api = useContext(APIContext);
   const { userDetails, setUserDetails } = useContext(UserContext);
   const lang = userDetails?.learned_language || "";
+
+  const { dailyType, dailySuggestion, prefLoaded, isConfigured, saveDailyLesson } =
+    useDailyLessonPreference(api, lang);
+
   const [isLoading, setIsLoading] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [generationProgress, setGenerationProgress] = useState(null);
   const [placeholderIndex, setPlaceholderIndex] = useState(0);
-  const [suggestionType, setSuggestionType] = useState(
-    () => getSavedSuggestionType(lang),
-  );
-  const [suggestion, setSuggestion] = useState(() => {
-    return getSavedSuggestion(lang);
-  });
+  // What the in-progress generation is about, so the progress screen can name
+  // it. { type: backendLessonType, suggestion }
+  const [generatingLabel, setGeneratingLabel] = useState(null);
+  const [lessonData, setLessonData] = useState(null);
+  const [noLesson, setNoLesson] = useState(false); // confirmed: nothing for today yet
+  const [error, setError] = useState(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [currentPlaybackTime, setCurrentPlaybackTime] = useState(0);
+  const history = useHistory();
 
-  // Re-initialize state when language changes
+  // Guards against re-triggering auto-generation every render once we've
+  // already kicked it off (or are explicitly driving generation ourselves).
+  const autoGenAttemptedRef = useRef(false);
+
+  const generatingKey = `zeeguu_generating_lesson_${lang}_${new Date().toDateString()}`;
+  const failedKey = `zeeguu_generation_failed_${lang}_${new Date().toDateString()}`;
+
+  // Listening session tracking via hook
+  const listeningSession = useListeningSession(lessonData?.lesson_id);
+  const words = lessonData?.words || [];
+
+  // Re-initialize when the learned language changes
   useEffect(() => {
-    setSuggestionType(getSavedSuggestionType(lang));
-    setSuggestion(getSavedSuggestion(lang));
     setLessonData(null);
     setError(null);
-    setCanGenerateLesson(null);
+    setNoLesson(false);
+    autoGenAttemptedRef.current = false;
   }, [lang]);
+
+  // Kick off generation for a given (backend lesson type, raw subject). Used by
+  // the auto-generate fallback and by the settings dialog (first day / change
+  // topic). Reuses the existing background-generation + streaming-progress flow.
+  function startGeneration(backendType, rawSuggestion) {
+    const isVocab = backendType === "three_words_lesson";
+    const trimmedSuggestion = isVocab ? null : (rawSuggestion || "").trim() || null;
+    const apiLessonType = isVocab ? null : backendType;
+
+    setGeneratingLabel({ type: backendType, suggestion: trimmedSuggestion || "" });
+    setIsGenerating(true);
+    setNoLesson(false);
+    setError(null);
+    setGenerationProgress(null);
+    setUserDetails((prev) => ({ ...prev, daily_audio_status: AUDIO_STATUS.GENERATING }));
+    localStorage.setItem(generatingKey, "true");
+
+    api.generateDailyLesson(
+      (data) => {
+        if (data.status === AUDIO_STATUS.GENERATING) {
+          // Generation started in background — polling will deliver the lesson
+          return;
+        }
+        // Existing lesson returned directly
+        localStorage.removeItem(generatingKey);
+        localStorage.removeItem(failedKey);
+        setIsGenerating(false);
+        setGenerationProgress(null);
+        setLessonData(data);
+        setUserDetails((prev) => ({
+          ...prev,
+          daily_audio_status: data.is_completed ? AUDIO_STATUS.COMPLETED : AUDIO_STATUS.READY,
+        }));
+      },
+      (err) => {
+        // Generation already running — keep the flag and let polling continue
+        if (err.message && err.message.toLowerCase().includes("already being generated")) {
+          return;
+        }
+        localStorage.removeItem(generatingKey);
+        setIsGenerating(false);
+        setGenerationProgress(null);
+        setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
+
+        const msg = err.message || "Couldn't prepare today's lesson. Please try again.";
+        // Remember the failure for the rest of the day so we don't auto-retry
+        // on every refresh; the user can change the topic to try again.
+        localStorage.setItem(failedKey, msg);
+        setError(msg);
+      },
+      trimmedSuggestion,
+      apiLessonType,
+    );
+  }
+
+  // Saving from the settings dialog. regenerate=true applies the change to
+  // today's lesson now (delete + regenerate); regenerate=false only stores the
+  // preference for tomorrow's lesson.
+  function handleConfigured(backendType, suggestion, regenerate) {
+    saveDailyLesson(backendType, suggestion);
+    setSettingsOpen(false);
+    if (!regenerate) return;
+
+    localStorage.removeItem(failedKey);
+    setError(null);
+    autoGenAttemptedRef.current = true; // we're driving generation explicitly
+    if (lessonData) {
+      const afterDelete = () => {
+        setLessonData(null);
+        startGeneration(backendType, suggestion);
+      };
+      api.deleteTodaysLesson(afterDelete, afterDelete);
+    } else {
+      startGeneration(backendType, suggestion);
+    }
+  }
 
   // Poll for progress when generating
   useEffect(() => {
-    const generatingKey = `zeeguu_generating_lesson_${lang}_${new Date().toDateString()}`;
     const hasLocalStorageFlag = localStorage.getItem(generatingKey);
 
     // Start polling if either: localStorage flag is set (page reload) or isGenerating is true (button click/409)
@@ -71,7 +162,6 @@ export default function TodayAudio({ setShowTabs }) {
       return; // Effect will re-run with isGenerating=true
     }
 
-    // Helper to stop polling and reset state
     let pollInterval;
 
     const stopPolling = () => {
@@ -90,8 +180,10 @@ export default function TodayAudio({ setShowTabs }) {
       if (data && data.lesson_id) {
         stopPolling();
         setLessonData(data);
-        // Update context to show lesson is ready
-        setUserDetails((prev) => ({ ...prev, daily_audio_status: data.is_completed ? AUDIO_STATUS.COMPLETED : AUDIO_STATUS.READY }));
+        setUserDetails((prev) => ({
+          ...prev,
+          daily_audio_status: data.is_completed ? AUDIO_STATUS.COMPLETED : AUDIO_STATUS.READY,
+        }));
         lessonRetryCount = 0;
       } else if (data && data.error) {
         // Lesson exists but has an error (e.g., audio file not ready yet)
@@ -99,7 +191,6 @@ export default function TodayAudio({ setShowTabs }) {
         if (lessonRetryCount >= MAX_LESSON_RETRIES) {
           handleError(data.error);
         }
-        // Otherwise, keep polling - the file might still be writing
       }
     };
 
@@ -108,7 +199,6 @@ export default function TodayAudio({ setShowTabs }) {
       setError(message);
     };
 
-    // Check if lesson is ready (used in multiple places)
     const checkForLesson = () => {
       api.getTodaysLesson(handleLessonReady, () => {});
     };
@@ -126,12 +216,10 @@ export default function TodayAudio({ setShowTabs }) {
               handleError(progress.message || "Lesson generation failed. Please try again.");
             }
           } else {
-            // No progress record - might be a brief gap (e.g., lesson was
-            // regenerated and progress hasn't appeared yet). Retry a few
-            // times before giving up.
+            // No progress record - might be a brief gap. Retry a few times.
             noProgressCount++;
             if (noProgressCount <= MAX_NO_PROGRESS_RETRIES) {
-              return; // keep polling
+              return;
             }
             // Exhausted retries — check if a lesson appeared, otherwise stop
             api.getTodaysLesson(
@@ -140,12 +228,12 @@ export default function TodayAudio({ setShowTabs }) {
                   handleLessonReady(data);
                 } else {
                   stopPolling();
-                  checkLessonGenerationFeasibility();
+                  setNoLesson(true);
                 }
               },
               () => {
                 stopPolling();
-                checkLessonGenerationFeasibility();
+                setNoLesson(true);
               },
             );
           }
@@ -155,7 +243,6 @@ export default function TodayAudio({ setShowTabs }) {
       );
     };
 
-    // Poll for generation progress
     pollInterval = setInterval(pollForProgress, 1500);
 
     // Browsers throttle setInterval for background tabs, so check
@@ -187,7 +274,6 @@ export default function TodayAudio({ setShowTabs }) {
       })();
     }
 
-    // Cleanup on unmount
     return () => {
       stopPolling();
       document.removeEventListener("visibilitychange", onVisibilityChange);
@@ -196,12 +282,8 @@ export default function TodayAudio({ setShowTabs }) {
     };
   }, [api, isGenerating]);
 
-  // Rotate placeholder messages only during the early/long phases where
-  // the backend message sits static for many seconds with no sub-step
-  // progress (no record yet, "pending", "generating_script"). Once we
-  // hit "synthesizing_audio" the per-step counter takes over, and
-  // "combining_audio" / "done" are end states where we want the real
-  // message + a full bar rather than a fresh rotation cycle.
+  // Rotate placeholder messages only during the early/long phases where the
+  // backend message sits static with no sub-step progress.
   const showRealMessage =
     generationProgress?.status === GENERATION_PROGRESS.SYNTHESIZING_AUDIO ||
     generationProgress?.status === GENERATION_PROGRESS.COMBINING_AUDIO ||
@@ -217,199 +299,80 @@ export default function TodayAudio({ setShowTabs }) {
     return () => clearInterval(id);
   }, [isGenerating, showRealMessage]);
 
-  const [openFeedback, setOpenFeedback] = useState(false);
-  const [currentPlaybackTime, setCurrentPlaybackTime] = useState(0);
-  const [lessonData, setLessonData] = useState(null);
-  const [error, setError] = useState(null);
-  const [canGenerateLesson, setCanGenerateLesson] = useState(null); // null = checking, true = can generate, false = cannot
-  const history = useHistory();
-
-  // Listening session tracking via hook
-  const listeningSession = useListeningSession(lessonData?.lesson_id);
-
-  let words = lessonData?.words || [];
-
-  // Control tab visibility - hide tabs when showing empty state
-  useEffect(() => {
-    if (setShowTabs) {
-      // Hide tabs only when we know user can't generate a lesson and has no lesson
-      setShowTabs(true);
-    }
-  }, [canGenerateLesson, lessonData, setShowTabs]);
-
   // Update page title and playback time when lessonData changes
   useEffect(() => {
     if (lessonData && lessonData.words) {
       document.title = shortDate() + " Daily Audio: " + wordsAsTile(words);
-      
-      // Initialize playback time from lesson data
-      const initialTime = lessonData.pause_position_seconds || lessonData.position_seconds || lessonData.progress_seconds || 0;
+      const initialTime =
+        lessonData.pause_position_seconds || lessonData.position_seconds || lessonData.progress_seconds || 0;
       setCurrentPlaybackTime(initialTime);
     } else {
       document.title = "Zeeguu: Audio Lesson";
     }
   }, [lessonData]);
 
-  const failedKey = `zeeguu_generation_failed_${lang}_${new Date().toDateString()}`;
-
-  // Check if lesson generation is possible
-  const checkLessonGenerationFeasibility = () => {
-    // If generation already failed this session, don't retry on refresh
-    const previousError = localStorage.getItem(failedKey);
-    if (previousError) {
-      setCanGenerateLesson(false);
-      setError(previousError);
-      return;
-    }
-
-    api.checkDailyLessonFeasibility(
-      (data) => {
-        setCanGenerateLesson(data.feasible);
-        if (!data.feasible) {
-          setError("Not enough words for a vocabulary lesson. Try a Topic or Situation instead!");
-          // If user had auto selected, switch to topic
-          if (suggestionType === "auto") {
-            setSuggestionType("topic");
-          }
-        }
-      },
-      (error) => {
-        // If the API endpoint doesn't exist, we'll assume generation is possible
-        // and let the generation attempt handle the error
-        setCanGenerateLesson(true);
-      }
-    );
-  };
-
-  // Fetch lesson data on mount - but check for active generation first
+  // On mount: is something generating? else is there a lesson? else nothing yet.
   useEffect(() => {
     setIsLoading(true);
 
-    // First, check if there's an active generation in progress
+    const onLesson = (data) => {
+      setIsLoading(false);
+      if (data) {
+        setLessonData(data);
+        setNoLesson(false);
+      } else {
+        setNoLesson(true);
+      }
+    };
+    const onLessonError = () => {
+      setIsLoading(false);
+      setLessonData(null);
+      setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
+      setNoLesson(true);
+    };
+
     api.getAudioLessonGenerationProgress(
       (progress) => {
         if (progress && ![GENERATION_PROGRESS.DONE, GENERATION_PROGRESS.ERROR].includes(progress.status)) {
-          // Generation in progress - let polling handle it
           setIsLoading(false);
           setIsGenerating(true);
           setGenerationProgress(progress);
-          // Update context so navigation dot shows generating state
           setUserDetails((prev) => ({ ...prev, daily_audio_status: AUDIO_STATUS.GENERATING }));
           return;
         }
-
-        // No active generation - check for existing lesson
-        api.getTodaysLesson(
-          (data) => {
-            setIsLoading(false);
-            setLessonData(data);
-
-            // If no lesson exists, check if we can generate one
-            if (!data) {
-              checkLessonGenerationFeasibility();
-            }
-          },
-          (error) => {
-            setIsLoading(false);
-            setLessonData(null);
-            // Reset status on error
-            setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
-
-            // Don't show technical errors (e.g., "Audio file not found") — just let user regenerate
-            checkLessonGenerationFeasibility();
-          },
-        );
+        api.getTodaysLesson(onLesson, onLessonError);
       },
-      () => {
-        // Progress API error - fall back to checking lesson
-        api.getTodaysLesson(
-          (data) => {
-            setIsLoading(false);
-            setLessonData(data);
-            if (!data) {
-              checkLessonGenerationFeasibility();
-            }
-          },
-          (error) => {
-            setIsLoading(false);
-            setLessonData(null);
-            // Reset status on error
-            setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
-            checkLessonGenerationFeasibility();
-          },
-        );
-      },
+      () => api.getTodaysLesson(onLesson, onLessonError),
     );
   }, [api, lang]);
 
-  const handleGenerateLesson = () => {
-    const generatingKey = `zeeguu_generating_lesson_${lang}_${new Date().toDateString()}`;
+  // No lesson for today yet: if the daily lesson is configured, generate it now
+  // (cron miss / first day / timezone). Otherwise the setup CTA is shown.
+  useEffect(() => {
+    if (!prefLoaded || !noLesson || isGenerating || lessonData) return;
+    if (!isConfigured || autoGenAttemptedRef.current) return;
+    const previousFailure = localStorage.getItem(failedKey);
+    if (previousFailure) {
+      setError(previousFailure);
+      return;
+    }
+    autoGenAttemptedRef.current = true;
+    startGeneration(dailyType, dailySuggestion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefLoaded, noLesson, isGenerating, lessonData, isConfigured, dailyType, dailySuggestion]);
 
-    setIsGenerating(true);
-    setError(null);
-    setGenerationProgress(null);
+  const settingsDialog = settingsOpen && (
+    <DailyLessonSettingsDialog
+      api={api}
+      initialType={dailyType}
+      initialSuggestion={dailySuggestion}
+      todaysLessonExists={!!lessonData}
+      onSubmit={handleConfigured}
+      onDismiss={() => setSettingsOpen(false)}
+    />
+  );
 
-    // Update context so navigation dot shows generating state
-    setUserDetails((prev) => ({ ...prev, daily_audio_status: AUDIO_STATUS.GENERATING }));
-
-    // Set localStorage flag to track generation across page reloads
-    localStorage.setItem(generatingKey, "true");
-
-    const trimmedSuggestion = suggestion.trim() || null;
-    const suggestionTypeToSend = trimmedSuggestion && suggestionType !== "auto" ? suggestionType : null;
-    api.generateDailyLesson(
-      (data) => {
-        if (data.status === AUDIO_STATUS.GENERATING) {
-          // Generation started in background — polling will deliver the lesson
-          return;
-        }
-        // Existing lesson returned directly
-        localStorage.removeItem(generatingKey);
-        localStorage.removeItem(failedKey);
-        setIsGenerating(false);
-        setGenerationProgress(null);
-        setLessonData(data);
-        setUserDetails((prev) => ({ ...prev, daily_audio_status: AUDIO_STATUS.READY }));
-      },
-      (error) => {
-        // Check if generation is already in progress (409 Conflict)
-        if (error.message && error.message.toLowerCase().includes("already being generated")) {
-          // Don't clear the flag - keep polling for the existing generation
-          return;
-        }
-
-        // Clear the localStorage flag on error
-        localStorage.removeItem(generatingKey);
-        setIsGenerating(false);
-        setGenerationProgress(null);
-
-        // Reset status back to available on error
-        setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
-
-        // Check if the error is a topic rejection (user can try a different topic)
-        const isSuggestionRejection = error.message && error.message.toLowerCase().includes("can't generate a lesson for this");
-        if (isSuggestionRejection) {
-          setError(error.message);
-          return;
-        }
-
-        setCanGenerateLesson(false);
-
-        // Check if the error is related to no words in learning
-        let errorMsg;
-        if (error.message && error.message.toLowerCase().includes("not enough words")) {
-          errorMsg = "Not enough words for a vocabulary lesson. Try a Topic or Situation instead!";
-        } else {
-          errorMsg = error.message || "Failed to generate daily lesson. Please try again.";
-        }
-        setError(errorMsg);
-      },
-      trimmedSuggestion,
-      suggestionTypeToSend,
-    );
-  };
-
-  if (isLoading) {
+  if (isLoading || !prefLoaded) {
     return (
       <div style={{ padding: "20px" }}>
         <LoadingAnimation>
@@ -420,38 +383,37 @@ export default function TodayAudio({ setShowTabs }) {
   }
 
   if (isGenerating) {
-    // Build progress detail (e.g., "Word 2/3: Synthesizing man voice")
     let progressDetail =
       PLACEHOLDER_PROGRESS_MESSAGES[placeholderIndex % PLACEHOLDER_PROGRESS_MESSAGES.length];
-    let progressPercent = 1; // Start at 1% so the bar is visible immediately
+    let progressPercent = 1;
 
-    // Always derive percent from the backend's segment/step counters
-    // when present — otherwise the bar would collapse back to 1% the
-    // moment status leaves "synthesizing_audio" (e.g. into combining
-    // or done), which looks like the lesson restarted.
     if (generationProgress?.total_segments > 0) {
       const segmentsCompleted = Math.max(0, generationProgress.current_segment - 1);
       let stepsInCurrentSegment = 0;
       if (generationProgress.total_steps > 0) {
         stepsInCurrentSegment = generationProgress.current_step / generationProgress.total_steps;
       }
-      progressPercent = Math.max(1, ((segmentsCompleted + stepsInCurrentSegment) / generationProgress.total_segments) * 100);
+      progressPercent = Math.max(
+        1,
+        ((segmentsCompleted + stepsInCurrentSegment) / generationProgress.total_segments) * 100,
+      );
     }
 
     if (showRealMessage) {
       progressDetail = generationProgress.message || progressDetail;
     }
 
+    const label = generatingLabel || {};
     let subtitle;
     let bigTitle;
-    if (suggestionType === "topic") {
-      subtitle = "Generating a lesson on the topic";
-      bigTitle = suggestion;
-    } else if (suggestionType === "situation") {
-      subtitle = "Generating a lesson for the situation";
-      bigTitle = suggestion;
+    if (label.type === "topic") {
+      subtitle = "Preparing today's lesson on";
+      bigTitle = label.suggestion;
+    } else if (label.type === "situation") {
+      subtitle = "Preparing today's lesson for";
+      bigTitle = label.suggestion;
     } else {
-      subtitle = "Generating a lesson with";
+      subtitle = "Preparing today's lesson with";
       bigTitle = "Three of Your Study Words";
     }
 
@@ -466,24 +428,10 @@ export default function TodayAudio({ setShowTabs }) {
         }}
       >
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", marginTop: "8%", maxWidth: "320px", width: "100%" }}>
-          <p
-            style={{
-              fontSize: "14px",
-              color: "var(--text-secondary)",
-              margin: 0,
-              marginBottom: "4px",
-            }}
-          >
+          <p style={{ fontSize: "14px", color: "var(--text-secondary)", margin: 0, marginBottom: "4px" }}>
             {subtitle}
           </p>
-          <h1
-            style={{
-              color: zeeguuOrange,
-              margin: 0,
-              marginBottom: "20px",
-              fontSize: "2rem",
-            }}
-          >
+          <h1 style={{ color: zeeguuOrange, margin: 0, marginBottom: "20px", fontSize: "2rem" }}>
             {bigTitle}
           </h1>
 
@@ -536,88 +484,82 @@ export default function TodayAudio({ setShowTabs }) {
           }}
         >
           <p style={{ color: "var(--text-primary)", margin: 0, fontSize: "16px", textAlign: "center" }}>
-            This can take a while.<br />
-            Feel free to browse — you'll find it here when it's ready.
+            This can take a moment.<br />
+            Feel free to browse — your lesson will be here when it's ready.
           </p>
         </div>
 
         <div style={{ flex: 1 }} />
-
       </div>
     );
   }
 
-  if (!lessonData) {
-    if (canGenerateLesson !== null) {
-      const autoDisabled = canGenerateLesson === false;
-      const canGenerate = suggestionType !== "auto" || !autoDisabled;
+  if (lessonData) {
+    return (
+      <>
+        <TodayEpisodeCard
+          lessonData={lessonData}
+          setLessonData={setLessonData}
+          words={words}
+          error={error}
+          api={api}
+          userDetails={userDetails}
+          setUserDetails={setUserDetails}
+          listeningSession={listeningSession}
+          currentPlaybackTime={currentPlaybackTime}
+          setCurrentPlaybackTime={setCurrentPlaybackTime}
+          onChangeTopic={() => setSettingsOpen(true)}
+          onSeePastLessons={() => history.push("/daily-audio/past-lessons")}
+        />
+        {settingsDialog}
+      </>
+    );
+  }
 
-      const errorMessage = error && (
-        <p style={{ color: "var(--text-secondary)", textAlign: "center", maxWidth: "320px", marginTop: "16px" }}>
-          {error}
-        </p>
-      );
-
-      const generateAction = (
-        <>
-          {errorMessage}
-          <GenerateButton onClick={handleGenerateLesson}>
-            Generate
-            <br />
-            Lesson
-          </GenerateButton>
-        </>
-      );
-
-      const cantGenerateMessage = (
-        <p style={{ color: "var(--text-secondary)", textAlign: "center", maxWidth: "300px", marginTop: "20px" }}>
-          {error || "Not enough words for a vocabulary lesson. Try a Topic or Situation instead!"}
-        </p>
-      );
-
-      return (
-        <GenerateView>
-          <SuggestionSelector
-            suggestionType={suggestionType}
-            setSuggestionType={setSuggestionType}
-            suggestion={suggestion}
-            setSuggestion={setSuggestion}
-            lang={lang}
-            autoDisabled={autoDisabled}
-          />
-          {canGenerate ? generateAction : cantGenerateMessage}
-          <div style={{ marginTop: "24px" }}>
-            <SubtleTextButton onClick={() => history.push("/daily-audio/past-lessons")}>
-              See past lessons →
-            </SubtleTextButton>
-          </div>
-        </GenerateView>
-      );
-    }
-
-    // Still checking feasibility
+  // No lesson + configured + no error: auto-generation is about to fire.
+  if (isConfigured && !error) {
     return (
       <div style={{ padding: "20px" }}>
         <LoadingAnimation>
-          <p>Checking...</p>
+          <p>Preparing today's lesson...</p>
         </LoadingAnimation>
       </div>
     );
   }
 
-
+  // First-run setup, or a generation error that the user can retry by changing
+  // the topic.
   return (
-    <LessonPlaybackView
-      lessonData={lessonData}
-      setLessonData={setLessonData}
-      words={words}
-      error={error}
-      api={api}
-      userDetails={userDetails}
-      setUserDetails={setUserDetails}
-      listeningSession={listeningSession}
-      currentPlaybackTime={currentPlaybackTime}
-      setCurrentPlaybackTime={setCurrentPlaybackTime}
-    />
+    <>
+      <div
+        style={{
+          padding: "20px",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "calc(100vh - 12rem)",
+        }}
+      >
+        <div style={{ fontSize: "2.5rem" }} aria-hidden>🎧</div>
+        <h2 style={{ color: zeeguuOrange, margin: "8px 0" }}>
+          {error ? "Let's try a different topic" : "Your daily listening lesson"}
+        </h2>
+        <p style={{ color: "var(--text-secondary)", maxWidth: "300px", marginBottom: "24px" }}>
+          {error ||
+            "Pick a topic you care about and we'll have a fresh lesson ready for you every morning. Just open and listen."}
+        </p>
+        <BannerButton onClick={() => setSettingsOpen(true)} style={{ padding: "12px 24px", fontSize: "1rem" }}>
+          {isConfigured ? "Change daily topic" : "Choose your daily lesson"}
+        </BannerButton>
+        <div style={{ marginTop: "24px" }}>
+          <SubtleTextButton onClick={() => history.push("/daily-audio/past-lessons")}>
+            See past lessons →
+          </SubtleTextButton>
+        </div>
+      </div>
+      {settingsDialog}
+    </>
   );
 }

--- a/src/dailyAudio/TodayAudio.js
+++ b/src/dailyAudio/TodayAudio.js
@@ -67,6 +67,11 @@ export default function TodayAudio() {
     setLessonData(null);
     setError(null);
     setNoLesson(false);
+    // Tear down any in-flight generation/polling tied to the previous language
+    // (the poll effect keys its localStorage flag on the old lang and doesn't
+    // depend on lang, so without this it keeps polling for the wrong language).
+    setIsGenerating(false);
+    setGenerationProgress(null);
     autoGenAttemptedRef.current = false;
   }, [lang]);
 
@@ -113,7 +118,15 @@ export default function TodayAudio() {
         setGenerationProgress(null);
         setUserDetails((prev) => ({ ...prev, daily_audio_status: null }));
 
-        const msg = err.message || "Couldn't prepare today's lesson. Please try again.";
+        // "Not enough words" for a vocabulary lesson is actionable — steer to a
+        // Topic/Situation (restores the old proactive feasibility guidance,
+        // which the auto-generate path otherwise lost).
+        let msg;
+        if (err.message && err.message.toLowerCase().includes("not enough words")) {
+          msg = "Not enough words for a vocabulary lesson yet. Try a Topic or Situation instead.";
+        } else {
+          msg = err.message || "Couldn't prepare today's lesson. Please try again.";
+        }
         // Remember the failure for the rest of the day so we don't auto-retry
         // on every refresh; the user can change the topic to try again.
         localStorage.setItem(failedKey, msg);
@@ -136,11 +149,16 @@ export default function TodayAudio() {
     setError(null);
     autoGenAttemptedRef.current = true; // we're driving generation explicitly
     if (lessonData) {
-      const afterDelete = () => {
-        setLessonData(null);
-        startGeneration(backendType, suggestion);
-      };
-      api.deleteTodaysLesson(afterDelete, afterDelete);
+      api.deleteTodaysLesson(
+        () => {
+          setLessonData(null);
+          startGeneration(backendType, suggestion);
+        },
+        // If the delete fails the backend still has today's lesson, so
+        // regenerating would silently hand back the old one — surface an error
+        // rather than pretend the change applied.
+        () => setError("Couldn't refresh today's lesson. Please try again."),
+      );
     } else {
       startGeneration(backendType, suggestion);
     }
@@ -199,6 +217,16 @@ export default function TodayAudio() {
       setError(message);
     };
 
+    // Polling found neither a progress record nor a lesson — generation isn't
+    // actually running. Stop, mark it attempted (so the auto-gen effect won't
+    // relaunch), and show a recoverable error instead of an endless spinner.
+    const handleExhausted = () => {
+      stopPolling();
+      setNoLesson(true);
+      autoGenAttemptedRef.current = true;
+      setError("We couldn't prepare today's lesson. Try again or pick a different topic.");
+    };
+
     const checkForLesson = () => {
       api.getTodaysLesson(handleLessonReady, () => {});
     };
@@ -227,14 +255,10 @@ export default function TodayAudio() {
                 if (data && data.lesson_id) {
                   handleLessonReady(data);
                 } else {
-                  stopPolling();
-                  setNoLesson(true);
+                  handleExhausted();
                 }
               },
-              () => {
-                stopPolling();
-                setNoLesson(true);
-              },
+              handleExhausted,
             );
           }
         },
@@ -503,7 +527,6 @@ export default function TodayAudio() {
         <TodayEpisodeCard
           lessonData={lessonData}
           setLessonData={setLessonData}
-          words={words}
           error={error}
           api={api}
           userDetails={userDetails}
@@ -518,8 +541,10 @@ export default function TodayAudio() {
     );
   }
 
-  // No lesson + configured + no error: auto-generation is about to fire.
-  if (isConfigured && !error) {
+  // No lesson + configured + no error, and auto-gen hasn't fired yet: it's
+  // about to. Once it HAS fired, never sit on this spinner forever — fall
+  // through to the actionable view below (e.g. after a failed/exhausted run).
+  if (isConfigured && !error && !autoGenAttemptedRef.current) {
     return (
       <div style={{ padding: "20px" }}>
         <LoadingAnimation>

--- a/src/dailyAudio/TodayAudio.js
+++ b/src/dailyAudio/TodayAudio.js
@@ -509,7 +509,6 @@ export default function TodayAudio() {
           currentPlaybackTime={currentPlaybackTime}
           setCurrentPlaybackTime={setCurrentPlaybackTime}
           onChangeTopic={() => setSettingsOpen(true)}
-          onSeePastLessons={() => history.push("/daily-audio/past-lessons")}
         />
         {settingsDialog}
       </>
@@ -544,14 +543,14 @@ export default function TodayAudio() {
       >
         <div style={{ fontSize: "2.5rem" }} aria-hidden>🎧</div>
         <h2 style={{ color: zeeguuOrange, margin: "8px 0" }}>
-          {error ? "Let's try a different topic" : "Your daily listening lesson"}
+          {error ? "Let's try a different topic" : "A new lesson, daily"}
         </h2>
         <p style={{ color: "var(--text-secondary)", maxWidth: "300px", marginBottom: "24px" }}>
           {error ||
-            "Pick a topic you care about and we'll have a fresh lesson ready for you every morning. Just open and listen."}
+            "Choose what you'd like to listen to. We'll make you a fresh lesson on it daily — starting with today's."}
         </p>
         <BannerButton onClick={() => setSettingsOpen(true)} style={{ padding: "12px 24px", fontSize: "1rem" }}>
-          {isConfigured ? "Change daily topic" : "Choose your daily lesson"}
+          {isConfigured ? "Change daily topic" : "Set up my daily lessons"}
         </BannerButton>
         <div style={{ marginTop: "24px" }}>
           <SubtleTextButton onClick={() => history.push("/daily-audio/past-lessons")}>

--- a/src/dailyAudio/TodayAudio.js
+++ b/src/dailyAudio/TodayAudio.js
@@ -361,11 +361,14 @@ export default function TodayAudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefLoaded, noLesson, isGenerating, lessonData, isConfigured, dailyType, dailySuggestion]);
 
+  // Seed the dialog with the saved preference; if none is stored yet (e.g. a
+  // lesson generated before preferences existed), fall back to today's lesson
+  // so the learner always sees their current type/subject pre-selected.
   const settingsDialog = settingsOpen && (
     <DailyLessonSettingsDialog
       api={api}
-      initialType={dailyType}
-      initialSuggestion={dailySuggestion}
+      initialType={dailyType || lessonData?.lesson_type || null}
+      initialSuggestion={(dailyType ? dailySuggestion : lessonData?.canonical_suggestion) || ""}
       todaysLessonExists={!!lessonData}
       onSubmit={handleConfigured}
       onDismiss={() => setSettingsOpen(false)}

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -96,7 +96,7 @@ export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
   const footer = (
     <div style={{ marginTop: "24px", textAlign: "center" }}>
       <ConfigPill onClick={onChangeTopic} title="Change your daily lesson type">
-        <span>Change your daily lesson type</span>
+        <span>Daily lesson type</span>
         <SettingsRoundedIcon style={{ fontSize: "0.95rem" }} />
       </ConfigPill>
     </div>

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -67,14 +67,14 @@ function EpisodeHeader({ lessonData, words }) {
         )}
       </LessonTitle>
 
-      <LessonMetadata>
+      <LessonMetadata style={{ display: "flex", alignItems: "baseline", gap: "6px" }}>
         <LessonTypeChip
           $type={lessonData.lesson_type}
-          style={{ marginBottom: 0, marginRight: "6px", verticalAlign: "middle" }}
+          style={{ marginBottom: 0, flexShrink: 0 }}
         >
           {chipLabel(lessonData.lesson_type)}
         </LessonTypeChip>
-        {metaText}
+        {metaText && <span style={{ minWidth: 0 }}>{metaText}</span>}
       </LessonMetadata>
     </>
   );

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -43,7 +43,7 @@ function EpisodeHeader({ lessonData }) {
           color: "var(--text-secondary)",
         }}
       >
-        {todayDateLabel()}
+        {lessonData.paused ? "⏸ Paused" : todayDateLabel()}
       </span>
 
       <LessonTitle style={{ marginTop: "8px" }}>
@@ -78,6 +78,11 @@ export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
   // stays quiet to keep the screen uncluttered.
   const footer = (
     <div style={{ marginTop: "24px", textAlign: "center" }}>
+      {lessonData.paused && (
+        <p style={{ color: "var(--text-secondary)", fontSize: "14px", margin: "0 0 12px" }}>
+          New daily lessons are paused. Listen to this one and they'll start again tomorrow.
+        </p>
+      )}
       <ConfigPill onClick={onChangeTopic} title="Daily lesson settings">
         <span>Daily lesson settings</span>
         <SettingsRoundedIcon style={{ fontSize: "0.95rem" }} />

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -1,0 +1,85 @@
+import React from "react";
+import LessonPlaybackView from "./LessonPlaybackView";
+import { LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
+import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
+import { todayDateLabel, formatDurationMinutes } from "./audioUtils";
+
+// Design-B "episode card" header: reads like today's episode of a show that
+// renews every morning — TODAY · date, a type chip, the title, and a compact
+// metadata line.
+function EpisodeHeader({ lessonData, words }) {
+  const hasSubject =
+    lessonData.lesson_type === "topic" || lessonData.lesson_type === "situation";
+
+  const metaParts = [
+    formatDurationMinutes(lessonData.duration_seconds),
+    hasSubject ? lessonData.canonical_suggestion : null,
+    words && words.length > 0 ? `${words.length} words` : null,
+  ].filter(Boolean);
+
+  return (
+    <>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span
+          style={{
+            fontSize: "0.8rem",
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+          }}
+        >
+          Today · {todayDateLabel()}
+        </span>
+        <LessonTypeChip $type={lessonData.lesson_type} style={{ marginBottom: 0 }}>
+          {chipLabel(lessonData.lesson_type)}
+        </LessonTypeChip>
+      </div>
+
+      <LessonTitle style={{ marginTop: "8px" }}>
+        {lessonData.title}
+        {lessonData.is_completed && <> <CompletionCheck>✓</CompletionCheck></>}
+      </LessonTitle>
+
+      {metaParts.length > 0 && <LessonMetadata>🎧 {metaParts.join(" · ")}</LessonMetadata>}
+    </>
+  );
+}
+
+function freshLine(lessonData) {
+  if (lessonData.lesson_type === "topic" || lessonData.lesson_type === "situation") {
+    return `A fresh ${lessonData.canonical_suggestion} lesson, every morning.`;
+  }
+  return "A fresh vocabulary lesson, every morning.";
+}
+
+/**
+ * The Today view's main state: today's pre-generated lesson, ready to play.
+ * Reuses LessonPlaybackView for all the player/words/feedback plumbing and
+ * injects the Design-B header + footer.
+ */
+export default function TodayEpisodeCard({ onChangeTopic, onSeePastLessons, ...playbackProps }) {
+  const { lessonData, words } = playbackProps;
+
+  const footer = (
+    <div style={{ marginTop: "24px", textAlign: "center" }}>
+      <p style={{ color: "var(--text-secondary)", fontSize: "14px", margin: "0 0 8px" }}>
+        {lessonData.is_completed
+          ? "You're done for today — a fresh lesson arrives tomorrow 🌅"
+          : freshLine(lessonData)}
+      </p>
+      <div>
+        <SubtleTextButton onClick={onChangeTopic}>Change daily topic</SubtleTextButton>
+        <SubtleTextButton onClick={onSeePastLessons}>See past lessons →</SubtleTextButton>
+      </div>
+    </div>
+  );
+
+  return (
+    <LessonPlaybackView
+      {...playbackProps}
+      header={<EpisodeHeader lessonData={lessonData} words={words} />}
+      footer={footer}
+    />
+  );
+}

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -29,20 +29,9 @@ const ConfigPill = styled.button`
 `;
 
 // Design-B "episode card" header: a date line, the title (with one ✓ per
-// listen), then a metadata line that leads with the type chip and the subject.
-function EpisodeHeader({ lessonData, words }) {
-  const hasSubject =
-    lessonData.lesson_type === "topic" || lessonData.lesson_type === "situation";
-
-  // Type chip lives on the metadata line now; duration is omitted (the player
-  // already shows total time) and there's no headphones glyph.
-  const metaText = [
-    hasSubject ? lessonData.canonical_suggestion : null,
-    words && words.length > 0 ? `${words.length} words` : null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
-
+// listen), then a single category chip — "Type: subject" — exactly like the
+// past-lessons list, so the subject lives inside the pill (no wrap-under).
+function EpisodeHeader({ lessonData }) {
   return (
     <>
       <span
@@ -64,14 +53,11 @@ function EpisodeHeader({ lessonData, words }) {
         )}
       </LessonTitle>
 
-      <LessonMetadata style={{ display: "flex", alignItems: "baseline", gap: "6px" }}>
-        <LessonTypeChip
-          $type={lessonData.lesson_type}
-          style={{ marginBottom: 0, flexShrink: 0 }}
-        >
+      <LessonMetadata>
+        <LessonTypeChip $type={lessonData.lesson_type} style={{ marginBottom: 0 }}>
           {chipLabel(lessonData.lesson_type)}
+          {lessonData.canonical_suggestion ? `: ${lessonData.canonical_suggestion}` : ""}
         </LessonTypeChip>
-        {metaText && <span style={{ minWidth: 0 }}>{metaText}</span>}
       </LessonMetadata>
     </>
   );
@@ -83,7 +69,7 @@ function EpisodeHeader({ lessonData, words }) {
  * injects the Design-B header + footer.
  */
 export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
-  const { lessonData, words } = playbackProps;
+  const { lessonData } = playbackProps;
 
   // Just the daily-lesson config pill (styled like the Discover screen's
   // "Topics: … ⚙" control), above the Share/Feedback utility actions. The
@@ -102,7 +88,7 @@ export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
   return (
     <LessonPlaybackView
       {...playbackProps}
-      header={<EpisodeHeader lessonData={lessonData} words={words} />}
+      header={<EpisodeHeader lessonData={lessonData} />}
       footer={footer}
     />
   );

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -1,56 +1,77 @@
 import React from "react";
+import styled from "styled-components";
+import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import LessonPlaybackView from "./LessonPlaybackView";
-import { LessonTitle, LessonMetadata, CompletionCheck, SubtleTextButton } from "./LessonView.sc";
+import { LessonTitle, LessonMetadata, CompletionCheck } from "./LessonView.sc";
 import { LessonTypeChip, chipLabel } from "./lessonTypeChip";
-import { todayDateLabel, formatDurationMinutes } from "./audioUtils";
+import { todayDateLabel, completionChecks } from "./audioUtils";
 
-// Design-B "episode card" header: reads like today's episode of a show that
-// renews every morning — TODAY · date, a type chip, the title, and a compact
-// metadata line.
+// Config pill, styled like the Discover screen's "Topics: … ⚙" control but with
+// theme tokens (not hardcoded white) so it renders as a pill in light AND dark.
+const ConfigPill = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-light);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.15s, color 0.15s;
+
+  &:active {
+    transform: scale(0.97);
+  }
+`;
+
+// Design-B "episode card" header: a date line, the title (with one ✓ per
+// listen), then a metadata line that leads with the type chip and the subject.
 function EpisodeHeader({ lessonData, words }) {
   const hasSubject =
     lessonData.lesson_type === "topic" || lessonData.lesson_type === "situation";
 
-  const metaParts = [
-    formatDurationMinutes(lessonData.duration_seconds),
+  // Type chip lives on the metadata line now; duration is omitted (the player
+  // already shows total time) and there's no headphones glyph.
+  const metaText = [
     hasSubject ? lessonData.canonical_suggestion : null,
     words && words.length > 0 ? `${words.length} words` : null,
-  ].filter(Boolean);
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <span
-          style={{
-            fontSize: "0.8rem",
-            fontWeight: 700,
-            letterSpacing: "0.06em",
-            textTransform: "uppercase",
-            color: "var(--text-secondary)",
-          }}
-        >
-          Today · {todayDateLabel()}
-        </span>
-        <LessonTypeChip $type={lessonData.lesson_type} style={{ marginBottom: 0 }}>
-          {chipLabel(lessonData.lesson_type)}
-        </LessonTypeChip>
-      </div>
+      <span
+        style={{
+          fontSize: "0.8rem",
+          fontWeight: 700,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: "var(--text-secondary)",
+        }}
+      >
+        {todayDateLabel()}
+      </span>
 
       <LessonTitle style={{ marginTop: "8px" }}>
         {lessonData.title}
-        {lessonData.is_completed && <> <CompletionCheck>✓</CompletionCheck></>}
+        {lessonData.is_completed && (
+          <> <CompletionCheck>{completionChecks(Math.max(1, lessonData.listened_count || 1))}</CompletionCheck></>
+        )}
       </LessonTitle>
 
-      {metaParts.length > 0 && <LessonMetadata>🎧 {metaParts.join(" · ")}</LessonMetadata>}
+      <LessonMetadata style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+        <LessonTypeChip $type={lessonData.lesson_type} style={{ marginBottom: 0 }}>
+          {chipLabel(lessonData.lesson_type)}
+        </LessonTypeChip>
+        {metaText && <span>{metaText}</span>}
+      </LessonMetadata>
     </>
   );
-}
-
-function freshLine(lessonData) {
-  if (lessonData.lesson_type === "topic" || lessonData.lesson_type === "situation") {
-    return `A fresh ${lessonData.canonical_suggestion} lesson, every morning.`;
-  }
-  return "A fresh vocabulary lesson, every morning.";
 }
 
 /**
@@ -58,20 +79,20 @@ function freshLine(lessonData) {
  * Reuses LessonPlaybackView for all the player/words/feedback plumbing and
  * injects the Design-B header + footer.
  */
-export default function TodayEpisodeCard({ onChangeTopic, onSeePastLessons, ...playbackProps }) {
+export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
   const { lessonData, words } = playbackProps;
 
+  // Just the daily-lesson config pill (styled like the Discover screen's
+  // "Topics: … ⚙" control), above the Share/Feedback utility actions. The
+  // "new lesson every day" promise now lives in the settings dialog, and
+  // completion is already acknowledged by the player's banner — so the footer
+  // stays quiet to keep the screen uncluttered.
   const footer = (
     <div style={{ marginTop: "24px", textAlign: "center" }}>
-      <p style={{ color: "var(--text-secondary)", fontSize: "14px", margin: "0 0 8px" }}>
-        {lessonData.is_completed
-          ? "You're done for today — a fresh lesson arrives tomorrow 🌅"
-          : freshLine(lessonData)}
-      </p>
-      <div>
-        <SubtleTextButton onClick={onChangeTopic}>Change daily topic</SubtleTextButton>
-        <SubtleTextButton onClick={onSeePastLessons}>See past lessons →</SubtleTextButton>
-      </div>
+      <ConfigPill onClick={onChangeTopic} title="Change your daily lesson type">
+        <span>Change your daily lesson type</span>
+        <SettingsRoundedIcon style={{ fontSize: "0.95rem" }} />
+      </ConfigPill>
     </div>
   );
 

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -64,11 +64,14 @@ function EpisodeHeader({ lessonData, words }) {
         )}
       </LessonTitle>
 
-      <LessonMetadata style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
-        <LessonTypeChip $type={lessonData.lesson_type} style={{ marginBottom: 0 }}>
+      <LessonMetadata>
+        <LessonTypeChip
+          $type={lessonData.lesson_type}
+          style={{ marginBottom: 0, marginRight: "6px", verticalAlign: "middle" }}
+        >
           {chipLabel(lessonData.lesson_type)}
         </LessonTypeChip>
-        {metaText && <span>{metaText}</span>}
+        {metaText}
       </LessonMetadata>
     </>
   );

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -9,10 +9,13 @@ import { todayDateLabel, completionChecks } from "./audioUtils";
 // Config pill, styled like the Discover screen's "Topics: … ⚙" control but with
 // theme tokens (not hardcoded white) so it renders as a pill in light AND dark.
 const ConfigPill = styled.button`
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.4rem;
-  padding: 0.4rem 0.9rem;
+  width: min(100%, 320px);
+  margin: 0 auto;
+  padding: 0.5rem 0.95rem;
   border-radius: 999px;
   border: 1px solid var(--border-light);
   background: var(--bg-secondary);

--- a/src/dailyAudio/TodayEpisodeCard.js
+++ b/src/dailyAudio/TodayEpisodeCard.js
@@ -9,12 +9,9 @@ import { todayDateLabel, completionChecks } from "./audioUtils";
 // Config pill, styled like the Discover screen's "Topics: … ⚙" control but with
 // theme tokens (not hardcoded white) so it renders as a pill in light AND dark.
 const ConfigPill = styled.button`
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.4rem;
-  width: min(100%, 320px);
-  margin: 0 auto;
+  gap: 0.5rem;
   padding: 0.5rem 0.95rem;
   border-radius: 999px;
   border: 1px solid var(--border-light);
@@ -95,8 +92,8 @@ export default function TodayEpisodeCard({ onChangeTopic, ...playbackProps }) {
   // stays quiet to keep the screen uncluttered.
   const footer = (
     <div style={{ marginTop: "24px", textAlign: "center" }}>
-      <ConfigPill onClick={onChangeTopic} title="Change your daily lesson type">
-        <span>Daily lesson type</span>
+      <ConfigPill onClick={onChangeTopic} title="Daily lesson settings">
+        <span>Daily lesson settings</span>
         <SettingsRoundedIcon style={{ fontSize: "0.95rem" }} />
       </ConfigPill>
     </div>

--- a/src/dailyAudio/_DailyAudioRouter.js
+++ b/src/dailyAudio/_DailyAudioRouter.js
@@ -3,7 +3,7 @@ import { PrivateRoute } from "../PrivateRoute";
 import * as s from "../components/ColumnWidth.sc";
 import TopTabs from "../components/TopTabs";
 import strings from "../i18n/definitions";
-import { Switch, useLocation } from "react-router-dom";
+import { Switch } from "react-router-dom";
 import TodayAudio from "./TodayAudio";
 import PastLessons from "./PastLessons";
 import { APIContext } from "../contexts/APIContext";
@@ -16,9 +16,7 @@ export default function DailyAudioRouter() {
   const api = useContext(APIContext);
   const { userDetails } = useContext(UserContext);
   const learnedLanguage = userDetails?.learned_language;
-  const location = useLocation();
   const [pastLessonsCount, setPastLessonsCount] = useState(0);
-  const [showTabs, setShowTabs] = useState(true);
 
   const swipeRef = useTabbedRoute(TAB_PATHS);
 
@@ -40,13 +38,6 @@ export default function DailyAudioRouter() {
     );
   }, [api, learnedLanguage]);
 
-  // Always show tabs on past-lessons page
-  useEffect(() => {
-    if (location.pathname === "/daily-audio/past-lessons") {
-      setShowTabs(true);
-    }
-  }, [location.pathname]);
-
   let tabsAndLinks = [
     {
       text: strings.today,
@@ -62,10 +53,10 @@ export default function DailyAudioRouter() {
   return (
     <Switch>
       <s.NarrowColumn>
-        {showTabs && <TopTabs title={strings.dailyAudio} tabsAndLinks={tabsAndLinks} />}
+        <TopTabs title={strings.dailyAudio} tabsAndLinks={tabsAndLinks} />
 
         <div ref={swipeRef}>
-          <PrivateRoute exact path="/daily-audio" component={TodayAudio} setShowTabs={setShowTabs} />
+          <PrivateRoute exact path="/daily-audio" component={TodayAudio} />
           <PrivateRoute exact path="/daily-audio/past-lessons" component={PastLessons} />
         </div>
       </s.NarrowColumn>

--- a/src/dailyAudio/audioUtils.js
+++ b/src/dailyAudio/audioUtils.js
@@ -11,19 +11,19 @@ export function shortDate() {
   return `[${new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" })}]`;
 }
 
-// "Wed, May 27" — shown next to the TODAY label on the episode card so the
-// daily lesson reads like a dated episode that renews each day.
+// Completion check(s): one ✓ per listen, capped so the row can't grow without
+// bound (✓✓✓…✓ beyond 7). Shared by today's episode card and the past-lessons
+// list so they show completion the same way.
+export function completionChecks(count) {
+  if (count <= 7) return "✓".repeat(count);
+  return "✓✓✓…✓";
+}
+
+// "May 27" — shown on the episode card so the daily lesson reads like a dated
+// episode. Weekday omitted to keep the (busy) header compact.
 export function todayDateLabel() {
   return new Date().toLocaleDateString("en-US", {
-    weekday: "short",
     month: "short",
     day: "numeric",
   });
-}
-
-// Compact, human duration for the episode card: "4 min". Rounds up so a
-// 30-second clip still reads as "1 min" rather than "0 min".
-export function formatDurationMinutes(seconds) {
-  if (!seconds || seconds <= 0) return "";
-  return `${Math.max(1, Math.round(seconds / 60))} min`;
 }

--- a/src/dailyAudio/audioUtils.js
+++ b/src/dailyAudio/audioUtils.js
@@ -10,3 +10,20 @@ export function wordsAsTile(words) {
 export function shortDate() {
   return `[${new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" })}]`;
 }
+
+// "Wed, May 27" — shown next to the TODAY label on the episode card so the
+// daily lesson reads like a dated episode that renews each day.
+export function todayDateLabel() {
+  return new Date().toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// Compact, human duration for the episode card: "4 min". Rounds up so a
+// 30-second clip still reads as "1 min" rather than "0 min".
+export function formatDurationMinutes(seconds) {
+  if (!seconds || seconds <= 0) return "";
+  return `${Math.max(1, Math.round(seconds / 60))} min`;
+}

--- a/src/dailyAudio/audioUtils.js
+++ b/src/dailyAudio/audioUtils.js
@@ -7,8 +7,14 @@ export function wordsAsTile(words) {
   return capitalized_comma_separated_words;
 }
 
+// "May 27" — the one short-date format for lessons, shared by the episode card
+// header and the past-lessons rows so they can never drift apart.
+export function formatShortDate(date) {
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
 export function shortDate() {
-  return `[${new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" })}]`;
+  return `[${formatShortDate(new Date())}]`;
 }
 
 // Completion check(s): one ✓ per listen, capped so the row can't grow without
@@ -19,11 +25,8 @@ export function completionChecks(count) {
   return "✓✓✓…✓";
 }
 
-// "May 27" — shown on the episode card so the daily lesson reads like a dated
-// episode. Weekday omitted to keep the (busy) header compact.
+// "May 27" for today — shown on the episode card so the daily lesson reads like
+// a dated episode (weekday omitted to keep the header compact).
 export function todayDateLabel() {
-  return new Date().toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  return formatShortDate(new Date());
 }

--- a/src/dailyAudio/lessonTypeChip.js
+++ b/src/dailyAudio/lessonTypeChip.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+// Small colored pill that surfaces a lesson's category. Colors mirror
+// SessionHistory's activity chips (Reading/Browsing/Audio) so the visual
+// language is consistent across activity & lessons. Each palette has a
+// dark-mode variant: pale pastels disappear on dark cards, so we swap to a
+// deeper background with brighter text.
+//
+// Shared between the past-lessons list and today's episode card.
+export const chipPalette = {
+  topic:              { bg: "#e3f2fd", color: "#1565c0", darkBg: "#1e3a52", darkColor: "#90caf9" },  // blue
+  situation:          { bg: "#e8f5e9", color: "#2e7d32", darkBg: "#1f3d24", darkColor: "#a5d6a7" },  // green
+  three_words_lesson: { bg: "#f3e5f5", color: "#7b1fa2", darkBg: "#3a1f3e", darkColor: "#ce93d8" },  // purple
+};
+
+export const LessonTypeChip = styled.span`
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-bottom: 6px;
+  background: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).bg};
+  color: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).color};
+
+  [data-theme="dark"] & {
+    background: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).darkBg};
+    color: ${({ $type }) => (chipPalette[$type] || chipPalette.topic).darkColor};
+  }
+`;
+
+export const chipLabel = (lessonType) => {
+  if (lessonType === "situation") return "Situation";
+  if (lessonType === "three_words_lesson") return "Vocabulary";
+  return "Topic";
+};

--- a/src/hooks/useDailyLessonPreference.js
+++ b/src/hooks/useDailyLessonPreference.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import * as Sentry from "@sentry/react";
 
 // Per-language daily audio lesson preference. The daily lesson is stored and
 // queried per learned-language on the backend, so the preference is keyed per
@@ -41,10 +42,14 @@ export default function useDailyLessonPreference(api, lang) {
       setDailyType(lessonType);
       const verbatim = lessonType === "three_words_lesson" ? "" : suggestion || "";
       setDailySuggestion(verbatim);
-      api.saveUserPreferences({
-        [typeKeyFor(lang)]: lessonType,
-        [suggestionKeyFor(lang)]: verbatim,
-      });
+      // Optimistic; a failed save silently reverts on next load, so at least
+      // make the failure observable rather than fully silent.
+      api.saveUserPreferences(
+        { [typeKeyFor(lang)]: lessonType, [suggestionKeyFor(lang)]: verbatim },
+        null,
+        (err) =>
+          Sentry.captureException(err, { tags: { feature: "daily_audio_preference" } }),
+      );
     },
     [api, lang],
   );

--- a/src/hooks/useDailyLessonPreference.js
+++ b/src/hooks/useDailyLessonPreference.js
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Per-language daily audio lesson preference. The daily lesson is stored and
+// queried per learned-language on the backend, so the preference is keyed per
+// language too (e.g. "daily_audio_lesson_type_da"). The suggestion is stored
+// verbatim — exactly what the user typed — and only canonicalized at
+// generation time.
+const typeKeyFor = (lang) => `daily_audio_lesson_type_${lang}`;
+const suggestionKeyFor = (lang) => `daily_audio_lesson_suggestion_${lang}`;
+
+export default function useDailyLessonPreference(api, lang) {
+  // dailyType is the canonical backend value: three_words_lesson | topic | situation,
+  // or null when the user hasn't set up a daily lesson for this language.
+  const [dailyType, setDailyType] = useState(null);
+  const [dailySuggestion, setDailySuggestion] = useState("");
+  const [prefLoaded, setPrefLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!lang) return;
+    let cancelled = false;
+    setPrefLoaded(false);
+    api
+      .getUserPreferences()
+      .then((prefs) => {
+        if (cancelled) return;
+        setDailyType(prefs[typeKeyFor(lang)] || null);
+        setDailySuggestion(prefs[suggestionKeyFor(lang)] || "");
+        setPrefLoaded(true);
+      })
+      .catch(() => {
+        if (!cancelled) setPrefLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, lang]);
+
+  const saveDailyLesson = useCallback(
+    (lessonType, suggestion) => {
+      // Optimistic local update so the UI reflects the choice immediately.
+      setDailyType(lessonType);
+      const verbatim = lessonType === "three_words_lesson" ? "" : suggestion || "";
+      setDailySuggestion(verbatim);
+      api.saveUserPreferences({
+        [typeKeyFor(lang)]: lessonType,
+        [suggestionKeyFor(lang)]: verbatim,
+      });
+    },
+    [api, lang],
+  );
+
+  return {
+    dailyType,
+    dailySuggestion,
+    prefLoaded,
+    isConfigured: !!dailyType,
+    saveDailyLesson,
+  };
+}


### PR DESCRIPTION
Reworks the **Listen** tab from a vending machine (pick type + topic + tap **Generate** every day) into a **daily delivery**: the user configures a daily lesson once and finds a fresh one waiting each day — they just open and listen. Backend (preference keys + nightly pre-generation) is a separate PR in `zeeguu/api`.

## The Today view (new state machine in `TodayAudio.js`)
- **Setup CTA** — first run, no preference: prompt to choose the daily lesson.
- **Episode card** (`TodayEpisodeCard`) — lesson ready, instant play. Design-B header: `TODAY · date`, type chip, title, `🎧 4 min · subject · N words`, then a "fresh lesson every morning · Change daily topic" footer. Wraps the reused `LessonPlaybackView` (now takes `header`/`footer` props) so the player/words/feedback are unchanged.
- **Auto-generate** — configured but no lesson today (first day / cron miss / timezone): kicks off generation reusing the existing streaming-progress UI.
- **Listened** — done-for-today messaging + replay.

The inline type picker and the orange **Generate Lesson** button are gone from the main flow.

## Supporting changes
- **`DailyLessonSettingsDialog`** — the type/topic config moved into a dialog opened by *Change daily topic*. Primary action saves the preference and regenerates today's lesson now (delete + generate); secondary *Save for tomorrow* persists without regenerating. Also the first-run setup surface.
- **`useDailyLessonPreference`** — per-language preference, **server as source of truth** (drives the cron + cross-device).
- **`SuggestionSelector`** — now a pure controlled component (localStorage removed).
- **`PastLessons`** — type **filter chips** (All / Vocabulary / Topic / Situation); shared `lessonTypeChip` module (extracted from PastLessons).
- Router: dead `setShowTabs` plumbing removed.

## Notes
- Depends on `zeeguu/api` PR (the preference keys). Works fully on demand without the cron.
- New UI copy is inline English to match the existing `dailyAudio/` convention (no `definitions.js` keys added).
- `vite build` passes against master.
- **Open:** rollout gating — ship ungated, or gate the new Today render behind the existing `userDetails.name === "Mircea"` check for first device testing? Not assumed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)