### PR TITLE
Translate-and-adapt: pass stored article id + graceful fallback

### DIFF
--- a/src/api/userArticles.js
+++ b/src/api/userArticles.js
@@ -407,12 +407,21 @@ Zeeguu_API.prototype.detectArticleLanguage = function (
 };
 
 Zeeguu_API.prototype.translateAndAdaptArticle = function (
-  url,
+  urlOrParams,
   targetLanguage,
   callback,
   onError,
 ) {
-  let params = { url: url };
+  // Accepts either a url string (external share flow) or { url, articleId }.
+  // Prefer articleId when we already have the article — the backend then
+  // translates the stored content instead of re-downloading the URL.
+  let params = {};
+  if (typeof urlOrParams === "string") {
+    params.url = urlOrParams;
+  } else {
+    if (urlOrParams.url) params.url = urlOrParams.url;
+    if (urlOrParams.articleId) params.article_id = urlOrParams.articleId;
+  }
   if (targetLanguage) {
     params.target_language = targetLanguage;
   }

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -331,7 +331,7 @@ export default function ArticleReader({ teacherArticleID }) {
   const handleTranslateAndAdapt = () => {
     setIsProcessingArticle(true);
     api.translateAndAdaptArticle(
-      articleInfo.url,
+      { articleId: articleInfo.id, url: articleInfo.url },
       userDetails.learned_language,
       (result) => {
         setIsProcessingArticle(false);
@@ -339,9 +339,12 @@ export default function ArticleReader({ teacherArticleID }) {
         history.replace("/read/article?id=" + result.id);
       },
       (error) => {
+        // Don't leave the user staring at a closed modal with nothing changed:
+        // fall back to reading the original article (translations off, since
+        // it's not in their learned language).
         console.error("Translation failed:", error);
         setIsProcessingArticle(false);
-        setShowLanguageModal(false);
+        handleReadOriginal();
       },
     );
   };

--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -138,7 +138,7 @@ export default function SharedArticleHandler() {
     if (uploadId) return runArticleConversion(api.translateAndAdaptArticleUpload.bind(api), "translate");
     beginProcessing("translate");
     api.translateAndAdaptArticle(
-      sharedUrl,
+      { url: sharedUrl, articleId: articleDetection?.id },
       userDetails.learned_language,
       (result) => navigateToArticle(result.id),
       (error) => {


### PR DESCRIPTION
## Summary
**Web** half of the translate-and-adapt fix. When a user chose *Translate to my level* on an article open in the reader, the request could fail server-side and the reader **silently closed the modal** — "nothing happened."

## Changes
- `translateAndAdaptArticle` accepts `{ url, articleId }` and sends `article_id`, so the backend can translate the **stored** article content instead of re-downloading a URL (which fails when the stored URL is a Zeeguu reader link).
- `ArticleReader`: on translation error, fall back to reading the original (translations off, since it isn't in the learned language) instead of dead-ending on a closed modal.
- `SharedArticleHandler`: pass the detected `articleId` when known, so the share flow also uses stored content.

## Companion PR
- api: zeeguu/api#644 (accepts `article_id`, fixes the 500 crash)

## Test plan
- [ ] Deeplink into a foreign-language article, tap *Translate to my level* → opens translated version
- [ ] Simulate backend translate failure → reader falls back to the original article (no stuck/closed-empty modal)
- [ ] Share flow (external URL) still translates and still falls back to "promote" on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)