### PR TITLE
feat(video): translated subtitles control on shared-video reader (v1.5)

### DIFF
--- a/src/api/userVideos.js
+++ b/src/api/userVideos.js
@@ -31,3 +31,32 @@ Zeeguu_API.prototype.updatePlaybackPosition = function (videoID, positionInSecon
 Zeeguu_API.prototype.setVideoOpened = function (videoID) {
   this._post("video_opened", `video_id=${videoID}`);
 };
+
+// **********
+// TRANSLATED SUBTITLES (v1.5)
+// **********
+// Get the video info with translated captions swapped in. The server falls back to the
+// original captions if `captionSetId` isn't `ready` yet, so the caller can use this freely
+// during polling without bespoke error handling.
+Zeeguu_API.prototype.getVideoInfoWithCaptionSet = function (videoID, captionSetId, callback) {
+  this._getJSON(`user_video?video_id=${videoID}&caption_set_id=${captionSetId}`, callback);
+};
+
+// Kick off (or look up) a translated-caption set for this video in the learner's target
+// language + CEFR. Idempotent server-side; a follow-up call for the same (video, lang, cefr)
+// returns the same set without re-translating. Returns `{ id, status, ... }` — caller polls
+// status until `ready`, then fetches via getVideoInfoWithCaptionSet().
+Zeeguu_API.prototype.requestCaptionTranslation = function (
+  videoID, targetLanguage, targetCefr, callback, onError,
+) {
+  this._postJSON(
+    `video/${videoID}/translate_captions`,
+    { target_language: targetLanguage, target_cefr: targetCefr },
+    callback,
+    onError,
+  );
+};
+
+Zeeguu_API.prototype.pollCaptionTranslationStatus = function (videoID, setId, callback) {
+  this._getJSON(`video/${videoID}/translate_captions/status?set_id=${setId}`, callback);
+};

--- a/src/videos/TranslateCaptionsControl.js
+++ b/src/videos/TranslateCaptionsControl.js
@@ -1,0 +1,214 @@
+import { useContext, useEffect, useRef, useState } from "react";
+import { APIContext } from "../contexts/APIContext";
+
+// Status values the server can return on a CaptionTranslationSet.
+const STATUS_PENDING = "pending";
+const STATUS_TRANSLATING = "translating";
+const STATUS_READY = "ready";
+const STATUS_ERROR = "error";
+
+const POLL_INTERVAL_MS = 2000;
+const PERSIST_KEY = (videoId) => `zeeguu_video_caption_pref_${videoId}`;
+
+/**
+ * The single UI control for v1.5's translated-subtitles feature.
+ *
+ * Lifecycle, given a video in a language different from the learner's:
+ *  1. Renders an "offer" banner with a Translate button until the user opts in.
+ *  2. On opt-in: requests the translation, then polls the status endpoint.
+ *  3. Once `ready`: renders an Original / Translated pill switcher and emits
+ *     `onTrackChange(captionSetId | null)` so the parent re-fetches the
+ *     video info with the right caption track.
+ *
+ * Track preference is persisted per-video in localStorage; on mount, if the
+ * user previously chose `translated`, we kick off a (server-side idempotent)
+ * request so the set is restored without a second click.
+ */
+export default function TranslateCaptionsControl({
+  videoId,
+  sourceLanguageCode,
+  targetLanguageCode,
+  targetCefr,
+  onTrackChange,
+}) {
+  const api = useContext(APIContext);
+
+  const [captionSetId, setCaptionSetId] = useState(null);
+  const [status, setStatus] = useState(null); // null | pending | translating | ready | error
+  const [error, setError] = useState(null);
+  const [activeTrack, setActiveTrack] = useState("original"); // "original" | "translated"
+  const pollTimerRef = useRef(null);
+
+  // Restore the user's last choice for this video. We only auto-request when the saved
+  // preference was "translated"; the original-track default needs no extra work.
+  useEffect(() => {
+    if (!videoId) return;
+    const saved =
+      typeof window !== "undefined" ? window.localStorage.getItem(PERSIST_KEY(videoId)) : null;
+    if (saved === "translated") {
+      requestTranslation();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [videoId]);
+
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+  }, []);
+
+  function persistChoice(choice) {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(PERSIST_KEY(videoId), choice);
+    } catch (_) {
+      /* localStorage can be unavailable in private modes; non-fatal. */
+    }
+  }
+
+  function pollUntilReady(setId) {
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    pollTimerRef.current = setTimeout(() => {
+      api.pollCaptionTranslationStatus(videoId, setId, (info) => {
+        setStatus(info.status);
+        if (info.status === STATUS_READY) {
+          setCaptionSetId(setId);
+          setActiveTrack("translated");
+          persistChoice("translated");
+          onTrackChange(setId);
+        } else if (info.status === STATUS_ERROR) {
+          setError(info.error_message || "Translation failed.");
+        } else {
+          pollUntilReady(setId);
+        }
+      });
+    }, POLL_INTERVAL_MS);
+  }
+
+  function requestTranslation() {
+    setError(null);
+    setStatus(STATUS_PENDING);
+    api.requestCaptionTranslation(
+      videoId,
+      targetLanguageCode,
+      targetCefr,
+      (info) => {
+        setStatus(info.status);
+        if (info.status === STATUS_READY) {
+          setCaptionSetId(info.id);
+          setActiveTrack("translated");
+          persistChoice("translated");
+          onTrackChange(info.id);
+        } else if (info.status === STATUS_ERROR) {
+          setError(info.error_message || "Translation failed.");
+        } else {
+          pollUntilReady(info.id);
+        }
+      },
+      (e) => {
+        setStatus(STATUS_ERROR);
+        setError(typeof e === "string" ? e : e?.message || "Could not start translation.");
+      },
+    );
+  }
+
+  function switchTo(track) {
+    if (track === activeTrack) return;
+    setActiveTrack(track);
+    persistChoice(track);
+    onTrackChange(track === "translated" ? captionSetId : null);
+  }
+
+  // ── Render branches ─────────────────────────────────────────────────────
+  if (status === STATUS_PENDING || status === STATUS_TRANSLATING) {
+    return (
+      <div style={bannerStyle}>
+        <span>
+          Translating subtitles to {targetLanguageCode.toUpperCase()} ({targetCefr})… this can take
+          ~30 seconds.
+        </span>
+      </div>
+    );
+  }
+
+  if (status === STATUS_ERROR) {
+    return (
+      <div style={bannerStyle}>
+        <span>Translation failed{error ? `: ${error}` : "."}</span>
+        <button style={buttonStyle} onClick={requestTranslation}>
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  // Translation is ready (or restored from a previous session) → show the pill switcher.
+  if (captionSetId != null) {
+    return (
+      <div style={bannerStyle}>
+        <span style={{ fontSize: "0.9em", color: "#555" }}>Subtitles:</span>
+        <button
+          style={pillStyle(activeTrack === "original")}
+          onClick={() => switchTo("original")}
+        >
+          Original ({sourceLanguageCode})
+        </button>
+        <button
+          style={pillStyle(activeTrack === "translated")}
+          onClick={() => switchTo("translated")}
+        >
+          Translated ({targetLanguageCode}, {targetCefr})
+        </button>
+      </div>
+    );
+  }
+
+  // Default: offer to translate.
+  return (
+    <div style={bannerStyle}>
+      <span>
+        Captions are in <strong>{sourceLanguageCode}</strong>. Translate to{" "}
+        <strong>
+          {targetLanguageCode} ({targetCefr})
+        </strong>
+        ?
+      </span>
+      <button style={buttonStyle} onClick={requestTranslation}>
+        Translate subtitles
+      </button>
+    </div>
+  );
+}
+
+// ── Inline styles ─────────────────────────────────────────────────────────
+// Kept inline (vs. a styled-components file) to keep this v1.5 patch small and reviewable.
+// If/when this banner stays, lift these into VideoPlayer.sc alongside the existing styles.
+const bannerStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.75em",
+  padding: "0.6em 1em",
+  margin: "0.5em 0",
+  background: "#f6f3ec",
+  border: "1px solid #e6dec9",
+  borderRadius: "6px",
+  fontSize: "0.95em",
+  flexWrap: "wrap",
+};
+const buttonStyle = {
+  padding: "0.4em 0.9em",
+  border: "1px solid #c9a96e",
+  background: "#fff",
+  borderRadius: "4px",
+  cursor: "pointer",
+  fontWeight: 600,
+};
+const pillStyle = (active) => ({
+  padding: "0.3em 0.8em",
+  border: "1px solid #c9a96e",
+  background: active ? "#c9a96e" : "#fff",
+  color: active ? "#fff" : "#333",
+  borderRadius: "999px",
+  cursor: "pointer",
+  fontSize: "0.85em",
+});

--- a/src/videos/VideoPlayer.js
+++ b/src/videos/VideoPlayer.js
@@ -5,8 +5,10 @@ import { TranslatableText } from "../reader/TranslatableText";
 import InteractiveText from "../reader/InteractiveText";
 import { APIContext } from "../contexts/APIContext";
 import { SpeechContext } from "../contexts/SpeechContext";
+import { UserContext } from "../contexts/UserContext";
 import { setTitle } from "../assorted/setTitle";
 import BackArrow from "../pages/Settings/settings_pages_shared/BackArrow";
+import TranslateCaptionsControl from "./TranslateCaptionsControl";
 import {
   MainContainer,
   VideoContainer,
@@ -42,6 +44,7 @@ export default function VideoPlayer() {
   videoID = query.get("id");
 
   const speech = useContext(SpeechContext);
+  const { userDetails } = useContext(UserContext);
   const containerRef = useRef(null);
   const lastCaptionIdRef = useRef(null);
 
@@ -122,6 +125,22 @@ export default function VideoPlayer() {
       player.pauseVideo();
     }
   }, [translatedWords, player]);
+
+  // v1.5: swap caption tracks (original ↔ translated). The id space of
+  // context_identifier.video_caption_id is preserved across the translation, so we have to
+  // reset the "last shown caption" ref — otherwise the currently displayed (stale-text)
+  // caption matches the same id and the interval skips re-rendering until the next caption
+  // boundary.
+  function handleCaptionTrackChange(captionSetIdOrNull) {
+    lastCaptionIdRef.current = null;
+    setCurrentInteractiveCaption(null);
+    const onLoaded = (video) => setVideoInfo(video);
+    if (captionSetIdOrNull == null) {
+      api.getVideoInfo(videoID, onLoaded);
+    } else {
+      api.getVideoInfoWithCaptionSet(videoID, captionSetIdOrNull, onLoaded);
+    }
+  }
 
   const onReady = (event) => {
     setPlayer(event.target);
@@ -228,6 +247,18 @@ export default function VideoPlayer() {
           </InfoContainer>
         </>
       )}
+      {!isFullscreen &&
+        videoInfo.language_code &&
+        userDetails?.learned_language &&
+        videoInfo.language_code !== userDetails.learned_language && (
+          <TranslateCaptionsControl
+            videoId={videoID}
+            sourceLanguageCode={videoInfo.language_code}
+            targetLanguageCode={userDetails.learned_language}
+            targetCefr={userDetails.learned_cefr_level || "B1"}
+            onTrackChange={handleCaptionTrackChange}
+          />
+        )}
       <VideoContainer>
         <YouTube
           videoId={videoInfo.video_unique_key}


### PR DESCRIPTION
**v1.5 of share-to-video** (web side) — adds the in-place subtitle translation control to `VideoPlayer.js`. When the video's caption language differs from the learner's `learned_language`, the reader offers to translate captions to the learner's language at their CEFR level. The interactive reader (tap-to-translate, bookmarks, time-synced highlight) keeps working because timings and per-caption context_identifier are unchanged across the swap — only the rendered text and tokenisation differ.

Pairs with **[zeeguu/api PR #647](https://github.com/zeeguu/api/pull/647)** which adds the `caption_translation_set` model, the LLM service, the `POST/GET /video/<id>/translate_captions` endpoints, and the `/user_video?caption_set_id=` extension. Both are scoped so they can be reviewed and reverted independently of the in-flight v1 work (`zeeguu/api#635`).

## Changes
- **New `src/videos/TranslateCaptionsControl.js`** — encapsulates the offer banner, the translating-spinner state, the ~2 s polling loop, the error/retry branch, and a persistent Original/Translated pill switcher once a set is ready. Per-video preference is stored in localStorage and restored on next visit by calling the (idempotent) translate endpoint.
- **`src/api/userVideos.js`** — three new `Zeeguu_API` methods (`requestCaptionTranslation`, `pollCaptionTranslationStatus`, `getVideoInfoWithCaptionSet`).
- **`src/videos/VideoPlayer.js`** — imports `UserContext` for `learned_language`/`learned_cefr_level`, renders the control above the player only when source and target languages differ, and on track change refetches videoInfo with the right `caption_set_id` while resetting `lastCaptionIdRef` so the currently displayed (stale-text) caption re-renders immediately rather than waiting for the next caption boundary.

## How to try locally
1. Pull the api branch, run the migration (`tools/migrations/26-05-31-a--add_caption_translation.sql`), restart the api.
2. Pull this branch + `npm run dev` (or equivalent).
3. Open an existing English-captioned video as a Danish learner. The banner appears above the player — click "Translate subtitles", watch the polling, then verify the swap.

## Out of scope (captured for later)
TTS dubbing in the learner's language: see `docs/future-work/dubbed-audio-from-shared-video.md`. Translated subtitles alone capture most of the UX win and avoid the derivative-work copyright question entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)