### PR TITLE
feat(video): share-to-video web route + extension YouTube ingestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ext:installDepsWindows": "cd src/extension && cd .\\src\\zeeguu-react && npm install && cd ..\\..\\. && mklink /d .\\node_modules .\\src\\zeeguu-react\\node_modules",
     "ext:installDeps": "cd src/extension && (cd src/zeeguu-react/ && npm install) && ln -s src/zeeguu-react/node_modules .",
     "ext:prebuild": "cd src/extension && rm -rf build",
-    "ext:buildDev": "npm run ext:buildDevUnix:popup && npm run ext:buildDev:bg && npm run ext:buildDev:izo && npm run ext:buildDev:scrape && cd src/extension && rm -f ./build/manifest.* && cp ./manifest.chrome.dev.json ./build/manifest.json",
+    "ext:buildDev": "npm run ext:buildDevUnix:popup && npm run ext:buildDev:bg && npm run ext:buildDev:izo && npm run ext:buildDev:scrape && cd src/extension && mkdir -p ./build && cp ./src/youtube/youtubeContentScript.js ./build/youtubeContentScript.js && cp ./src/youtube/youtubePatch.js ./build/youtubePatch.js && rm -f ./build/manifest.* && cp ./manifest.chrome.dev.json ./build/manifest.json",
     "ext:buildProd": "npm run ext:buildUnix:popup && npm run ext:build:bg && npm run ext:build:izo && npm run ext:build:scrape && cd src/extension && rm -f ./build/manifest.* && cp ./manifest.chrome.json ./build/manifest.json",
     "ext:buildWindows": "cd src/extension && npm-run-all buildWindows:* && npm-run-all build:* && copy .\\public\\manifest.chrome.json .\\build\\manifest.json /Y",
     "ext:buildWindowsDev": "cd src/extension && npm-run-all buildWindows:* && npm-run-all build:* && copy .\\public\\manifest.chrome.dev.json .\\build\\manifest.json /Y",

--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -23,6 +23,7 @@ import ReadingHistory from "./words/WordHistory";
 import ActivityRouter from "./activity/_ActivityRouter";
 import ArticleReader from "./reader/ArticleReader";
 import SharedArticleHandler from "./reader/SharedArticleHandler";
+import SharedVideoHandler from "./reader/SharedVideoHandler";
 import LoadingAnimation from "./components/LoadingAnimation";
 import { getStoredSession } from "./utils/cookies/userInfo";
 import LocalStorage from "./assorted/LocalStorage";
@@ -138,6 +139,7 @@ export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
         )}
         <PrivateRouteWithLayout path="/teacher" component={TeacherRouter} />
         <PrivateRouteWithLayout path="/shared-article" component={SharedArticleHandler} />
+        <PrivateRouteWithLayout path="/shared-video" component={SharedVideoHandler} />
         <PrivateRouteWithLayout path="/read/article" component={ArticleReader} />
         <Redirect from="/user_dashboard" to="/activity-history/statistics" />
         <PrivateRouteWithLayout path="/search" component={ArticlesRouter} />

--- a/src/api/userVideos.js
+++ b/src/api/userVideos.js
@@ -31,3 +31,12 @@ Zeeguu_API.prototype.updatePlaybackPosition = function (videoID, positionInSecon
 Zeeguu_API.prototype.setVideoOpened = function (videoID) {
   this._post("video_opened", `video_id=${videoID}`);
 };
+
+// **********
+// SHARE-TO-VIDEO: client-side ingestion
+// Captions are extracted in the user's browser (residential IP) because YouTube
+// blocks server-side caption fetches from datacenter IPs.
+// **********
+Zeeguu_API.prototype.createVideoUpload = function (payload, callback, onError) {
+  this._postJSON("video_upload/create", payload, callback, onError);
+};

--- a/src/extension/manifest.chrome.dev.json
+++ b/src/extension/manifest.chrome.dev.json
@@ -48,6 +48,16 @@
       "js": [
         "injectOnZeeguuOrg.js"
       ]
+    },
+    {
+      "matches": [
+        "*://*.youtube.com/*",
+        "*://youtu.be/*"
+      ],
+      "js": [
+        "youtubeContentScript.js"
+      ],
+      "run_at": "document_start"
     }
   ],
   "icons": {
@@ -71,6 +81,15 @@
       ],
       "matches": [
         "<all_urls>"
+      ]
+    },
+    {
+      "resources": [
+        "youtubePatch.js"
+      ],
+      "matches": [
+        "*://*.youtube.com/*",
+        "*://youtu.be/*"
       ]
     }
   ]

--- a/src/extension/src/background/background.js
+++ b/src/extension/src/background/background.js
@@ -6,6 +6,8 @@ import { getIsLoggedIn, getUserInfoDictFromCookies } from "../popup/cookies";
 import Zeeguu_API from "../../../api/Zeeguu_API";
 import { EXTENSION_SOURCE } from "../constants";
 import { isUnsupportedTab, sendTabToZeeguu } from "../shared/sendTabToZeeguu";
+import { isYouTubeTab } from "../shared/sendYouTubeTabToZeeguu";
+import { shareYouTubeTab } from "../shared/shareYouTubeTab";
 
 // Montserrat font
 const googleFontUrl =
@@ -130,6 +132,13 @@ async function startReader() {
     const userData = await getUserInfoDictFromCookies(WEB_URL);
     api.setSession(userData.session);
     await api.logUserActivity(api.OPEN_CONTEXT, "", tab.url, EXTENSION_SOURCE);
+
+    if (isYouTubeTab(tab)) {
+      const url = await shareYouTubeTab(api, tab, WEB_URL);
+      BROWSER_API.tabs.create({ url });
+      return;
+    }
+
     const upload = await sendTabToZeeguu(api, tab);
     BROWSER_API.tabs.create({
       url: `${WEB_URL}/shared-article?upload_id=${upload.id}`,

--- a/src/extension/src/popup/Popup.js
+++ b/src/extension/src/popup/Popup.js
@@ -6,6 +6,8 @@ import Zeeguu_API from "../../../api/Zeeguu_API";
 import { API_URL, WEB_URL } from "../../../config";
 import { EXTENSION_SOURCE } from "../constants";
 import { isUnsupportedTab, sendTabToZeeguu } from "../shared/sendTabToZeeguu";
+import { isYouTubeTab } from "../shared/sendYouTubeTabToZeeguu";
+import { shareYouTubeTab } from "../shared/shareYouTubeTab";
 import { BROWSER_API } from "../utils/browserApi";
 import { getUserInfoDictFromCookies } from "./cookies";
 import { BottomContainer, HeadingContainer, MiddleContainer, NotifyButton, PopUp } from "./Popup.styles";
@@ -47,6 +49,15 @@ export default function Popup({ loggedIn }) {
       try {
         setState(STATES.SCRAPING);
         setState(STATES.UPLOADING);
+
+        if (isYouTubeTab(tab)) {
+          const url = await shareYouTubeTab(api, tab, WEB_URL);
+          setState(STATES.OPENING);
+          await BROWSER_API.tabs.create({ url });
+          window.close();
+          return;
+        }
+
         const upload = await sendTabToZeeguu(api, tab);
 
         setState(STATES.OPENING);

--- a/src/extension/src/shared/sendYouTubeTabToZeeguu.js
+++ b/src/extension/src/shared/sendYouTubeTabToZeeguu.js
@@ -1,0 +1,148 @@
+import { BROWSER_API } from "../utils/browserApi";
+
+// Runs entirely in YouTube's MAIN world. Must stay synchronous because
+// chrome.scripting in MV3 does not reliably await async returns across the
+// MAIN-world boundary -- the result comes back as null.
+//
+// YouTube's /api/timedtext now requires a one-shot PO Token we can't
+// reproduce. So we *don't* fetch the captions ourselves any more; we read
+// them from `window.__zeeguuCapturedCaptions`, populated by the content
+// script youtubeContentScript.js + the MAIN-world patch youtubePatch.js
+// the moment YouTube's player fetches captions itself (i.e. once the user
+// turns CC on).
+function extractYouTubeCaptionsInPage(preferredLanguage) {
+  try {
+    let playerResponse = null;
+    try {
+      const player = document.querySelector("#movie_player");
+      if (player && typeof player.getPlayerResponse === "function") {
+        playerResponse = player.getPlayerResponse();
+      }
+    } catch (e) {
+      /* fall through to global */
+    }
+    if (!playerResponse) {
+      playerResponse = window.ytInitialPlayerResponse;
+    }
+    if (!playerResponse) {
+      return {
+        error: "Could not read YouTube player data. Wait for the player to load and try again.",
+      };
+    }
+
+    const videoId = playerResponse?.videoDetails?.videoId;
+    if (!videoId) {
+      return { error: "Could not determine YouTube video ID." };
+    }
+
+    const tracks =
+      playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ||
+      [];
+    if (tracks.length === 0) {
+      return { error: "This video has no captions." };
+    }
+
+    const wantedLang = (preferredLanguage || "").toLowerCase();
+    const tracksInLang = wantedLang
+      ? tracks.filter((t) => (t.languageCode || "").toLowerCase() === wantedLang)
+      : tracks;
+    if (wantedLang && tracksInLang.length === 0) {
+      const avail = [...new Set(tracks.map((t) => t.languageCode))].join(", ");
+      return {
+        error: `This video has no captions in your learning language (${preferredLanguage}). Available: ${avail}`,
+      };
+    }
+
+    // Look up captured captions for this video + language. The youtubePatch
+    // content script populates `window.__zeeguuCapturedCaptions[videoId:lang]`
+    // when YouTube's own player fetches captions (i.e. after user enables CC).
+    const captured = window.__zeeguuCapturedCaptions || {};
+    const langsToTry = wantedLang
+      ? [wantedLang]
+      : tracksInLang.map((t) => (t.languageCode || "").toLowerCase());
+
+    for (const lang of langsToTry) {
+      const segments = captured[videoId + ":" + lang];
+      if (segments && segments.length > 0) {
+        return {
+          video_unique_key: videoId,
+          language: lang,
+          captions: segments,
+        };
+      }
+    }
+
+    // No capture yet. Prompt the user to enable CC -- once YouTube's player
+    // fetches the caption track, the patch will store it and the next
+    // share-click will succeed.
+    return {
+      error:
+        "Please turn on subtitles in the YouTube player (CC button) for this video, then click Zeeguu again. (YouTube's anti-scraping means we have to catch the captions as the player loads them.)",
+    };
+  } catch (e) {
+    return {
+      error:
+        "MAIN-world scraper threw: " +
+        (e && (e.message || String(e))) +
+        (e && e.stack ? " | stack: " + String(e.stack).slice(0, 200) : ""),
+    };
+  }
+}
+
+async function scrapeYouTubeTab(tab, preferredLanguage) {
+  let results;
+  try {
+    results = await BROWSER_API.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: extractYouTubeCaptionsInPage,
+      args: [preferredLanguage || null],
+      world: "MAIN",
+    });
+  } catch (e) {
+    throw new Error("chrome.scripting.executeScript threw: " + (e?.message || e));
+  }
+  if (!results || results.length === 0) {
+    throw new Error("chrome.scripting returned no injection results.");
+  }
+  const injection = results[0];
+  if (injection.error) {
+    throw new Error(
+      "Scraper threw in MAIN world: " +
+        (injection.error.message || JSON.stringify(injection.error)),
+    );
+  }
+  const data = injection.result;
+  if (!data) {
+    throw new Error("Scraper returned no data.");
+  }
+  if (data.error) {
+    throw new Error(data.error);
+  }
+  return data;
+}
+
+export async function sendYouTubeTabToZeeguu(api, tab, preferredLanguage) {
+  const scraped = await scrapeYouTubeTab(tab, preferredLanguage);
+  const result = await new Promise((resolve, reject) =>
+    api.createVideoUpload(
+      {
+        url: tab.url,
+        video_unique_key: scraped.video_unique_key,
+        language: scraped.language,
+        captions: scraped.captions,
+      },
+      resolve,
+      reject,
+    ),
+  );
+  return result; // { video_id, video_unique_key }
+}
+
+export function isYouTubeTab(tab) {
+  if (!tab?.url) return false;
+  // Match watch / shorts / embed / live and the youtu.be short-link host.
+  // `watch` requires the `?` so `youtube.com/watching/...` doesn't match.
+  return /^https?:\/\/(?:[a-z0-9-]+\.)?(youtube\.com\/(watch\?|shorts\/|embed\/|live\/)|youtu\.be\/)/i.test(
+    tab.url,
+  );
+}

--- a/src/extension/src/shared/shareYouTubeTab.js
+++ b/src/extension/src/shared/shareYouTubeTab.js
@@ -1,0 +1,11 @@
+import { sendYouTubeTabToZeeguu } from "./sendYouTubeTabToZeeguu";
+
+// Shared YouTube-share entry point for both popup (toolbar-icon click) and
+// background (right-click context menu). Captures user details for the
+// learning-language hint and returns the URL to open on Zeeguu.
+export async function shareYouTubeTab(api, tab, webUrl) {
+  const userDetails = await api.getUserDetails();
+  const learnedLanguage = userDetails?.learned_language || null;
+  const { video_id } = await sendYouTubeTabToZeeguu(api, tab, learnedLanguage);
+  return `${webUrl}/shared-video?video_id=${video_id}`;
+}

--- a/src/extension/src/youtube/youtubeContentScript.js
+++ b/src/extension/src/youtube/youtubeContentScript.js
@@ -1,0 +1,18 @@
+// Runs at document_start on youtube.com tabs (ISOLATED world). Its only job
+// is to inject youtubePatch.js into the page's MAIN world so the patch's
+// monkey-wraps see the same `fetch` / `XMLHttpRequest` that YouTube's player
+// uses. Loading from `web_accessible_resources` bypasses YouTube's CSP, which
+// would otherwise reject an inline <script> tag.
+(function () {
+  try {
+    const script = document.createElement("script");
+    script.src = chrome.runtime.getURL("youtubePatch.js");
+    script.async = false;
+    (document.head || document.documentElement).prepend(script);
+    // Once injected and evaluated, we can drop the tag -- the patch lives on
+    // `window` for the rest of the page's life.
+    script.onload = () => script.remove();
+  } catch (e) {
+    console.error("Zeeguu youtube patch injection failed:", e);
+  }
+})();

--- a/src/extension/src/youtube/youtubePatch.js
+++ b/src/extension/src/youtube/youtubePatch.js
@@ -1,0 +1,129 @@
+// Runs in YouTube's MAIN world. Injected by youtubeContentScript.js as a
+// <script src=...> tag (a content script in ISOLATED world can't reach the
+// MAIN-world `fetch` / `XMLHttpRequest` it needs to wrap).
+//
+// Why this exists: YouTube's `/api/timedtext` endpoint now requires a one-shot
+// PO Token (Proof of Origin Token) computed by YouTube's BotGuard JS. We can't
+// reproduce it. But once the player itself makes a successful caption fetch,
+// the response body IS available in the page -- we just have to intercept it.
+// That's what this patch does.
+(function () {
+  if (window.__zeeguuPatchInstalled) return;
+  window.__zeeguuPatchInstalled = true;
+  const TIMEDTEXT_API_PATH = "/api/timedtext";
+  // Keyed by `${videoId}:${langCode}` so SPA-navigation between videos doesn't
+  // confuse different videos' captions with the same language.
+  window.__zeeguuCapturedCaptions = window.__zeeguuCapturedCaptions || {};
+
+  function parseSegments(text) {
+    if (!text) return null;
+
+    // JSON3 (YouTube's current default). trim() guards against leading
+    // whitespace or BOMs that would slip past a bare startsWith check.
+    if (text.trim().startsWith("{")) {
+      try {
+        const data = JSON.parse(text);
+        const events = data && data.events;
+        if (!Array.isArray(events)) return null;
+        const out = [];
+        for (const ev of events) {
+          if (!ev || !ev.segs) continue;
+          const start = ev.tStartMs || 0;
+          const dur = ev.dDurationMs || 0;
+          const segText = ev.segs.map((s) => s.utf8 || "").join("").trim();
+          if (!segText) continue;
+          out.push({
+            time_start: start,
+            time_end: start + dur,
+            text: segText,
+          });
+        }
+        return out;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    // srv1 / simple-XML fallback (only hit if YouTube returns XML).
+    const out = [];
+    const re = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const startMatch = /\bstart="([^"]+)"/.exec(m[1]);
+      const durMatch = /\bdur="([^"]+)"/.exec(m[1]);
+      const start = parseFloat(startMatch ? startMatch[1] : "0");
+      const dur = parseFloat(durMatch ? durMatch[1] : "0");
+      const decoded = m[2]
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&apos;/g, "'")
+        .replace(/&#(\d+);/g, (_, c) => String.fromCharCode(parseInt(c, 10)))
+        .trim();
+      if (!decoded) continue;
+      out.push({
+        time_start: Math.round(start * 1000),
+        time_end: Math.round((start + dur) * 1000),
+        text: decoded,
+      });
+    }
+    return out;
+  }
+
+  function capture(url, text) {
+    if (!text || text.length < 30) return;
+    let videoId = "";
+    let lang = "";
+    try {
+      const u = new URL(url, location.origin);
+      videoId = u.searchParams.get("v") || "";
+      lang = (u.searchParams.get("lang") || "").toLowerCase();
+    } catch (e) {
+      return;
+    }
+    if (!videoId || !lang) return;
+    const segments = parseSegments(text);
+    if (!segments || segments.length === 0) return;
+    window.__zeeguuCapturedCaptions[videoId + ":" + lang] = segments;
+  }
+
+  // --- fetch wrap ---
+  const origFetch = window.fetch;
+  window.fetch = function (input, init) {
+    const url = typeof input === "string" ? input : input && input.url;
+    const result = origFetch.call(this, input, init);
+    if (url && url.indexOf(TIMEDTEXT_API_PATH) !== -1) {
+      result
+        .then((resp) => {
+          if (!resp || !resp.ok) return;
+          resp.clone().text().then((t) => capture(url, t)).catch(() => {});
+        })
+        .catch(() => {});
+    }
+    return result;
+  };
+
+  // --- XHR wrap ---
+  const origOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (method, url) {
+    this.__zeeguuUrl = url;
+    return origOpen.apply(this, arguments);
+  };
+  const origSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function () {
+    const xhr = this;
+    const url = xhr.__zeeguuUrl;
+    if (url && typeof url === "string" && url.indexOf(TIMEDTEXT_API_PATH) !== -1) {
+      xhr.addEventListener("load", function () {
+        try {
+          capture(url, xhr.responseText);
+        } catch (e) {
+          /* ignore */
+        }
+      });
+    }
+    return origSend.apply(this, arguments);
+  };
+})();

--- a/src/reader/SharedVideoHandler.js
+++ b/src/reader/SharedVideoHandler.js
@@ -1,0 +1,79 @@
+import { useState, useEffect, useContext } from "react";
+import { useHistory } from "react-router-dom";
+import { APIContext } from "../contexts/APIContext";
+import useQuery from "../hooks/useQuery";
+import LoadingAnimation from "../components/LoadingAnimation";
+
+export default function SharedVideoHandler() {
+  const api = useContext(APIContext);
+  const history = useHistory();
+  const query = useQuery();
+  const videoId = query.get("video_id");
+
+  const [status, setStatus] = useState("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [videoTitle, setVideoTitle] = useState(null);
+
+  useEffect(() => {
+    if (!videoId) {
+      setStatus("error");
+      setErrorMessage("No video id provided.");
+      return;
+    }
+    api.getVideoInfo(
+      videoId,
+      (video) => {
+        if (!video || !video.id) {
+          setStatus("error");
+          setErrorMessage("Video not found.");
+          return;
+        }
+        setVideoTitle(video.title || null);
+        // Hold the "Preparing <title>..." screen long enough to actually be
+        // visible -- without the delay the redirect fires on the same paint
+        // frame as the title set, and the user sees nothing.
+        setTimeout(() => history.replace(`/watch/video?id=${videoId}`), 800);
+      },
+      () => {
+        setStatus("error");
+        setErrorMessage("Could not load the shared video.");
+      },
+    );
+  }, [videoId]);
+
+  if (status === "error") {
+    return (
+      <div style={{ textAlign: "center", padding: "4em 2em" }}>
+        <h2>Could not open video</h2>
+        <p>{errorMessage}</p>
+        {videoId && (
+          <p style={{ color: "#666", fontSize: "0.9em" }}>video #{videoId}</p>
+        )}
+        <button
+          onClick={() => history.push("/articles")}
+          style={{
+            marginTop: "1em",
+            padding: "0.5em 1.5em",
+            fontSize: "1em",
+            cursor: "pointer",
+          }}
+        >
+          Go to Articles
+        </button>
+      </div>
+    );
+  }
+
+  const message = videoTitle
+    ? `Preparing "${videoTitle}"…`
+    : "Preparing your video…";
+
+  return (
+    <LoadingAnimation
+      reportIssueDelay={30000}
+      specificStyle={{ minHeight: "70vh", justifyContent: "center" }}
+    >
+      <div style={{ textAlign: "center", marginTop: "1em" }}>{message}</div>
+    </LoadingAnimation>
+  );
+}


### PR DESCRIPTION
Client-side half of the share-to-video flow. Pairs with [zeeguu/api#635](https://github.com/zeeguu/api/pull/635) (already merged + deployed).

End-to-end smoke-tested in prod today: the API side already accepts uploads from the new extension (server log shows POST /video_upload/create → 200 with the captioned video row + topic inferred). This PR adds the missing /shared-video web route that the extension opens on success — the only piece preventing the share flow from completing cleanly.

## What happens when a user clicks the Zeeguu icon on a YouTube watch page

1. `isYouTubeTab(tab)` matches the URL.
2. The shared helper `shareYouTubeTab(api, tab, WEB_URL)` is called from both the popup (toolbar click) and `background.js` (right-click \"Read with Zeeguu\").
3. `chrome.scripting.executeScript({ world: \"MAIN\" })` runs an extractor that reads `window.__zeeguuCapturedCaptions[videoId:lang]` — populated by the monkey-patch (see below).
4. Selected track is POSTed to `/video_upload/create` along with `video_unique_key` and `language`.
5. Extension opens `${WEB_URL}/shared-video?video_id=<id>`.
6. `SharedVideoHandler` fetches video info, shows \"Preparing <title>…\" for ~800ms so the user can read the title, then redirects to `/watch/video?id=<id>` (existing route → existing VideoPlayer + the `TranslateCaptionsControl` from #1155).

## Why a monkey-patch

YouTube's \`/api/timedtext\` baseUrl from `playerCaptionsTracklistRenderer` now requires a one-shot **PO Token** (Proof of Origin Token) computed by YouTube's BotGuard JS. We cannot reproduce it; direct fetches of the baseUrl (with or without `fmt=srv1`) return empty bodies or HTTP 404. This is the same anti-scraping that `yt-dlp` and `youtube_transcript_api` fight quarterly.

The workaround: capture the player's own successful fetch.

- `youtubeContentScript.js` runs at \`document_start\` on \`*.youtube.com\` / \`youtu.be\` (ISOLATED world) and injects \`youtubePatch.js\` via \`<script src=chrome.runtime.getURL(...)>\` (declared in \`web_accessible_resources\` so YouTube's CSP accepts it).
- \`youtubePatch.js\` runs in MAIN world. It wraps \`window.fetch\` and \`XMLHttpRequest.{open,send}\`, watches for \`/api/timedtext\` URLs, parses the response (JSON3 default, srv1 XML fallback), and stashes each result on \`window.__zeeguuCapturedCaptions[videoId:lang]\`.
- When the user enables CC, YouTube's player fetches captions, the patch captures the response, and the next Zeeguu-icon click succeeds.

When nothing has been captured yet, the popup surfaces a clear prompt: \"Please turn on subtitles in the YouTube player (CC button) for this video, then click Zeeguu again.\"

## Files

- \`src/MainAppRouter.js\` + \`src/reader/SharedVideoHandler.js\`: new \`/shared-video\` route.
- \`src/api/userVideos.js\`: \`createVideoUpload\` (JSON body via \`_postJSON\` — the captions array doesn't fit form-encoded).
- \`src/extension/src/youtube/youtubePatch.js\`: MAIN-world fetch/XHR wraps + caption parsing.
- \`src/extension/src/youtube/youtubeContentScript.js\`: injects the patch.
- \`src/extension/src/shared/sendYouTubeTabToZeeguu.js\`: orchestrator + \`isYouTubeTab\`. Track selection: prefer manual over auto-generated within the user's \`learned_language\`; error out cleanly if no captions in the target language exist.
- \`src/extension/src/shared/shareYouTubeTab.js\`: shared entry-point for popup + background.
- \`src/extension/manifest.chrome.dev.json\`: declares the new \`content_script\` + \`web_accessible_resource\`.
- \`package.json\`: \`ext:buildDev\` now copies the two \`youtube/*\` files into \`build/\`.

## Why \`chrome.scripting\` returns the data synchronously

In MV3, \`chrome.scripting.executeScript({ world: \"MAIN\" })\` does not reliably await async returns across the world boundary — async functions come back with \`result: null\`. The extractor is therefore synchronous: it only reads from \`window.__zeeguuCapturedCaptions\` (already populated by the patch) and returns immediately. No fetches happen across the boundary.

## Known caveats

- Production manifest (\`manifest.chrome.json\`) NOT updated in this PR — only \`manifest.chrome.dev.json\`. Production manifest needs the same additions before publishing to the Chrome store.
- Firefox manifests not updated (this PR is desktop-Chrome-first).
- iOS share extension would still go down the article path; YouTube-share on iOS is a separate follow-up.

## Test plan
- [ ] Reload extension at \`chrome://extensions\` from the new build (\`web-v635/src/extension/build\`).
- [ ] Open a YouTube watch page in the user's learned-language; enable CC.
- [ ] Click Zeeguu icon → expect \`/shared-video?video_id=N\` to load \"Preparing <title>...\" then redirect to \`/watch/video?id=N\`.
- [ ] Click Zeeguu icon on a YouTube page where CC has not been enabled → expect the popup to prompt for CC.
- [ ] Click Zeeguu icon on a YouTube page with no captions in target language → expect \"This video has no captions in your learning language (XX). Available: YY\".
- [ ] Click Zeeguu icon on a non-YouTube page → existing article flow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)