### PR TITLE
Extract SettingsPageHeader from duplicated header markup

### DIFF
--- a/src/pages/Settings/DeleteAccount.js
+++ b/src/pages/Settings/DeleteAccount.js
@@ -2,12 +2,9 @@ import { useEffect } from "react";
 import DeleteAccountButton from "../DeleteAccount/DeleteAccountButton";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import strings from "../../i18n/definitions";
 import { setTitle } from "../../assorted/setTitle";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 export default function DeleteAccount() {
   useEffect(() => {
@@ -16,14 +13,7 @@ export default function DeleteAccount() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>{strings.deleteAccount}</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title={strings.deleteAccount} />
       <Main>
         <DeleteAccountButton />
       </Main>

--- a/src/pages/Settings/Developer.js
+++ b/src/pages/Settings/Developer.js
@@ -2,13 +2,10 @@ import { useContext, useEffect, useState } from "react";
 import { APIContext } from "../../contexts/APIContext";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
 import Button from "../_pages_shared/Button.sc";
 import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import { setTitle } from "../../assorted/setTitle";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 export default function Developer() {
   const api = useContext(APIContext);
@@ -28,14 +25,7 @@ export default function Developer() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>Developer</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title="Developer" />
       <Main>
         <ButtonContainer className={"adaptive-alignment-horizontal"}>
           <Button onClick={handleClearOnboardingMessages}>Clear onboarding message table</Button>

--- a/src/pages/Settings/DisplayPreferences.js
+++ b/src/pages/Settings/DisplayPreferences.js
@@ -7,14 +7,11 @@ import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import Checkbox from "../../components/modal_shared/Checkbox";
 import strings from "../../i18n/definitions";
 import { setTitle } from "../../assorted/setTitle";
 import { APIContext } from "../../contexts/APIContext";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 export default function DisplayPreferences() {
   const api = useContext(APIContext);
@@ -42,14 +39,7 @@ export default function DisplayPreferences() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>Activity Timer</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title="Activity Timer" />
       <Main>
         <Form>
           <FormSection>

--- a/src/pages/Settings/ExerciseSchedulingPreferences.js
+++ b/src/pages/Settings/ExerciseSchedulingPreferences.js
@@ -7,9 +7,7 @@ import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import strings from "../../i18n/definitions";
 import { setTitle } from "../../assorted/setTitle";
 import { APIContext } from "../../contexts/APIContext";
@@ -18,7 +16,6 @@ import useFormField from "../../hooks/useFormField";
 import { PositiveIntegerValidator } from "../../utils/ValidatorRule/Validator";
 import validateRules from "../../assorted/validateRules";
 import { ExercisesCounterContext } from "../../exercises/ExercisesCounterContext";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 const PREF_KEY_MAX_WORDS_TO_SCHEDULE = "max_words_to_schedule";
 
@@ -62,14 +59,7 @@ export default function ExerciseSchedulingPreferences() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>Exercise Scheduling</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title="Exercise Scheduling" />
       <Main>
         <Form>
           <FormSection>

--- a/src/pages/Settings/ExerciseTypePreferences.js
+++ b/src/pages/Settings/ExerciseTypePreferences.js
@@ -10,15 +10,12 @@ import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import Checkbox from "../../components/modal_shared/Checkbox";
 import strings from "../../i18n/definitions";
 import { setTitle } from "../../assorted/setTitle";
 import { APIContext } from "../../contexts/APIContext";
 import useBookmarkAutoPronounce from "../../hooks/useBookmarkAutoPronounce";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 export default function ExerciseTypePreferences() {
   const api = useContext(APIContext);
@@ -73,16 +70,7 @@ export default function ExerciseTypePreferences() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-
-          <Header withoutLogo>
-            <Heading>{strings.exerciseTypePreferences}</Heading>
-          </Header>
-
-      </HeaderWrapper>
+      <SettingsPageHeader title={strings.exerciseTypePreferences} />
       <Main>
         <Form>
           <FormSection>

--- a/src/pages/Settings/FeedPreferences.js
+++ b/src/pages/Settings/FeedPreferences.js
@@ -5,14 +5,11 @@ import TagContainer from "../_pages_shared/TagContainer.sc";
 import useSelectInterest from "../../hooks/useSelectInterest";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Main from "../_pages_shared/Main.sc";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import { setTitle } from "../../assorted/setTitle";
 import { APIContext } from "../../contexts/APIContext";
 
 import { SectionHeading, SectionDescription } from "./FeedPreferences.sc";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 import useUnwantedContentPreferences from "../../hooks/useUnwantedContentPreferences";
 import useFormField from "../../hooks/useFormField";
@@ -79,14 +76,7 @@ export default function FeedPreferences() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>Feed Preferences</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title="Feed Preferences" />
       <Main>
         <SectionHeading>Topics of Interest</SectionHeading>{" "}
         {/*<SectionDescription>Show me articles about the following topics:</SectionDescription>*/}

--- a/src/pages/Settings/LanguageSettings.js
+++ b/src/pages/Settings/LanguageSettings.js
@@ -15,11 +15,9 @@ import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
 import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
 import PreferencesPage from "../_pages_shared/PreferencesPage";
-import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
 import Main from "../_pages_shared/Main.sc";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import Selector from "../../components/Selector";
 import { setTitle } from "../../assorted/setTitle";
 import useFormField from "../../hooks/useFormField";
@@ -27,7 +25,6 @@ import { NonEmptyValidator, Validator } from "../../utils/ValidatorRule/Validato
 import useShadowRef from "../../hooks/useShadowRef";
 import { scrollToTop } from "../../utils/misc/scrollToTop";
 import validateRules from "../../assorted/validateRules";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 
 export default function LanguageSettings() {
   const api = useContext(APIContext);
@@ -109,14 +106,7 @@ export default function LanguageSettings() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>{strings.languageSettings}</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title={strings.languageSettings} />
       <Main>
         <Form>
           <FormSection>

--- a/src/pages/Settings/MyClassrooms/MyClassrooms.js
+++ b/src/pages/Settings/MyClassrooms/MyClassrooms.js
@@ -7,12 +7,10 @@ import InputField from "../../../components/InputField";
 import Form from "../../_pages_shared/Form.sc";
 import FormSection from "../../_pages_shared/FormSection.sc";
 import PreferencesPage from "../../_pages_shared/PreferencesPage";
-import Header from "../../_pages_shared/Header";
-import Heading from "../../_pages_shared/Heading.sc";
 import Main from "../../_pages_shared/Main.sc";
 import FullWidthListContainer from "../../../components/FullWidthListContainer.sc";
 import FullWidthErrorMsg from "../../../components/FullWidthErrorMsg.sc";
-import BackArrow from "../settings_pages_shared/BackArrow";
+import SettingsPageHeader from "../settings_pages_shared/SettingsPageHeader";
 import strings from "../../../i18n/definitions";
 import LoadingAnimation from "../../../components/LoadingAnimation";
 import FullWidthListItem from "../../../components/FullWidthListItem";
@@ -23,7 +21,6 @@ import { setTitle } from "../../../assorted/setTitle";
 import { APIContext } from "../../../contexts/APIContext";
 import LocalStorage from "../../../assorted/LocalStorage";
 import { saveSharedUserInfo } from "../../../utils/cookies/userInfo";
-import { HeaderWrapper, BackArrowWrapper } from "../Settings.sc";
 
 export default function MyClassrooms() {
   const api = useContext(APIContext);
@@ -131,14 +128,7 @@ export default function MyClassrooms() {
 
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>{strings.myClassrooms}</Heading>
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title={strings.myClassrooms} />
       <Main>
         <FullWidthListContainer>
           {studentIsInCohort ? (

--- a/src/pages/Settings/ProfileDetails.js
+++ b/src/pages/Settings/ProfileDetails.js
@@ -15,7 +15,7 @@ import PreferencesPage from "../_pages_shared/PreferencesPage";
 import Header from "../_pages_shared/Header";
 import Heading from "../_pages_shared/Heading.sc";
 import Main from "../_pages_shared/Main.sc";
-import BackArrow from "./settings_pages_shared/BackArrow";
+import SettingsPageHeader from "./settings_pages_shared/SettingsPageHeader";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
 import LoadingAnimation from "../../components/LoadingAnimation";
 import useFormField from "../../hooks/useFormField";
@@ -35,7 +35,6 @@ import {
 } from "../../profile/avatarOptions";
 import { AvatarBackground, AvatarImage } from "../../profile/UserProfile.sc";
 import Feature from "../../features/Feature";
-import { HeaderWrapper, BackArrowWrapper } from "./Settings.sc";
 import * as s from "./ProfileDetails.sc";
 import EditIcon from "@mui/icons-material/Edit";
 import CheckIcon from "@mui/icons-material/Check";
@@ -137,19 +136,13 @@ export default function ProfileDetails() {
   }
   return (
     <PreferencesPage layoutVariant={"minimalistic-top-aligned"}>
-      <HeaderWrapper>
-        <BackArrowWrapper>
-          <BackArrow redirectLink={redirectPath} />
-        </BackArrowWrapper>
-        <Header withoutLogo>
-          <Heading>{strings.profileDetails}</Heading>
-          {successfullyChangedPassword && (
-            <>
-              <FullWidthConfirmMsg>Password changed successfully!</FullWidthConfirmMsg>
-            </>
-          )}
-        </Header>
-      </HeaderWrapper>
+      <SettingsPageHeader title={strings.profileDetails} redirectLink={redirectPath}>
+        {successfullyChangedPassword && (
+          <>
+            <FullWidthConfirmMsg>Password changed successfully!</FullWidthConfirmMsg>
+          </>
+        )}
+      </SettingsPageHeader>
       <Main>
         <Form>
           {errorMessage && <FullWidthErrorMsg>{errorMessage}</FullWidthErrorMsg>}

--- a/src/pages/Settings/settings_pages_shared/SettingsPageHeader.js
+++ b/src/pages/Settings/settings_pages_shared/SettingsPageHeader.js
@@ -1,0 +1,18 @@
+import BackArrow from "./BackArrow";
+import Header from "../../_pages_shared/Header";
+import Heading from "../../_pages_shared/Heading.sc";
+import { HeaderWrapper, BackArrowWrapper } from "../Settings.sc";
+
+export default function SettingsPageHeader({ title, redirectLink, func, children }) {
+  return (
+    <HeaderWrapper>
+      <BackArrowWrapper>
+        <BackArrow redirectLink={redirectLink} func={func} />
+      </BackArrowWrapper>
+      <Header withoutLogo>
+        <Heading>{title}</Heading>
+        {children}
+      </Header>
+    </HeaderWrapper>
+  );
+}


### PR DESCRIPTION
## What

The back-arrow + page-title header was duplicated verbatim across **9 Settings pages**:

```jsx
<HeaderWrapper>
  <BackArrowWrapper>
    <BackArrow />
  </BackArrowWrapper>
  <Header withoutLogo>
    <Heading>{title}</Heading>
  </Header>
</HeaderWrapper>
```

This extracts it into a single `SettingsPageHeader` component (in `settings_pages_shared/`), so each page becomes:

```jsx
<SettingsPageHeader title={strings.deleteAccount} />
```

## Component API

- `title` — the heading (string or `strings.*`)
- `redirectLink` / `func` — optional, forwarded to `BackArrow` (used by `ProfileDetails`' custom back target)
- `children` — optional, rendered inside the header after the heading (used by `ProfileDetails`' inline "password changed" confirmation)

`HeaderWrapper` / `BackArrowWrapper` stay defined in `Settings.sc.js`; the component imports them.

## Notes

- Net **−71 lines**; removes the now-unused `BackArrow` / `HeaderWrapper` / `Header` / `Heading` imports from each page.
- `ProfileDetails` keeps its `Header`/`Heading` imports — they're still used by the "Choose Your Avatar" section.
- Also cleans up stray whitespace in `ExerciseTypePreferences`' header.
- `vite build` passes.

> Based on `Activity-margins-fix` (where this header markup was introduced), not `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)