### PR TITLE
Fix iOS top-gap on settings pages; rename layout variant to card-under-menu

### DIFF
--- a/src/pages/Settings/Pages/ActivityTimer.js
+++ b/src/pages/Settings/Pages/ActivityTimer.js
@@ -38,7 +38,7 @@ export default function ActivityTimer() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title="Activity Timer" />
       <Main>
         <Form>

--- a/src/pages/Settings/Pages/AudioAndPronunciation.js
+++ b/src/pages/Settings/Pages/AudioAndPronunciation.js
@@ -69,7 +69,7 @@ export default function AudioAndPronunciation() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title={strings.exerciseTypePreferences} />
       <Main>
         <Form>

--- a/src/pages/Settings/Pages/DeleteAccount.js
+++ b/src/pages/Settings/Pages/DeleteAccount.js
@@ -12,7 +12,7 @@ export default function DeleteAccount() {
   }, []);
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title={strings.deleteAccount} />
       <Main>
         <DeleteAccountButton />

--- a/src/pages/Settings/Pages/Developer.js
+++ b/src/pages/Settings/Pages/Developer.js
@@ -24,7 +24,7 @@ export default function Developer() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title="Developer" />
       <Main>
         <ButtonContainer className={"adaptive-alignment-horizontal"}>

--- a/src/pages/Settings/Pages/ExerciseSchedulingPreferences.js
+++ b/src/pages/Settings/Pages/ExerciseSchedulingPreferences.js
@@ -58,7 +58,7 @@ export default function ExerciseSchedulingPreferences() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title="Exercise Scheduling" />
       <Main>
         <Form>

--- a/src/pages/Settings/Pages/FeedPreferences.js
+++ b/src/pages/Settings/Pages/FeedPreferences.js
@@ -75,7 +75,7 @@ export default function FeedPreferences() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title="Feed Preferences" redirectLink={isFromArticles && "/articles"} />
       <Main>
         <SectionContainer>

--- a/src/pages/Settings/Pages/LanguageSettings.js
+++ b/src/pages/Settings/Pages/LanguageSettings.js
@@ -105,7 +105,7 @@ export default function LanguageSettings() {
   }
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title={strings.languageSettings} />
       <Main>
         <Form>

--- a/src/pages/Settings/Pages/MyClassrooms/MyClassrooms.js
+++ b/src/pages/Settings/Pages/MyClassrooms/MyClassrooms.js
@@ -127,7 +127,7 @@ export default function MyClassrooms() {
   const studentIsInCohort = studentCohorts && studentCohorts.length > 0;
 
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title={strings.myClassrooms} />
       <Main>
         <FullWidthListContainer>

--- a/src/pages/Settings/Pages/ProfileDetails.js
+++ b/src/pages/Settings/Pages/ProfileDetails.js
@@ -135,7 +135,7 @@ export default function ProfileDetails() {
     return <LoadingAnimation />;
   }
   return (
-    <CardPage layoutVariant={"minimalistic-top-aligned"} isTransparent reducedPadding>
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
       <SettingsPageHeader title={strings.profileDetails} redirectLink={redirectPath}>
         {successfullyChangedPassword && (
           <>

--- a/src/pages/_pages_shared/CardPage.sc.js
+++ b/src/pages/_pages_shared/CardPage.sc.js
@@ -26,13 +26,19 @@ const PageBackdrop = styled.div`
   }
 
   ${({ $layoutVariant }) =>
-    $layoutVariant === "minimalistic-top-aligned" &&
+    $layoutVariant === "card-under-menu" &&
     css`
       width: 100%;
       min-height: auto;
       background: none;
       justify-content: flex-start;
       overflow-x: hidden;
+      /* This variant is always position: static, so it flows inside <body>,
+         which already applies padding-top: env(safe-area-inset-top) (index.css).
+         The base PageBackdrop's own safe-area padding-top would double-count it
+         and leave a notch-sized gap on iOS (invisible in browsers where env()=0).
+         The fixed-background variants escape <body> padding and keep theirs. */
+      padding-top: 0;
     `}
 `;
 
@@ -78,7 +84,7 @@ const ContentCard = styled.div`
     `}
 
   ${({ $layoutVariant }) =>
-    $layoutVariant === "minimalistic-top-aligned" &&
+    $layoutVariant === "card-under-menu" &&
     css`
       @media (max-width: 1200px) {
         margin: 1rem;


### PR DESCRIPTION
## What

Two related cleanups to the shared `CardPage` used by the settings pages.

### 1. Fix the iOS-only top gap

Settings pages showed a large empty band between the top menu and the page title — but **only on iOS**, not in a desktop browser.

Cause: `<body>` already applies `padding-top: env(safe-area-inset-top)` (index.css), so the whole app — including the top menu — is pushed below the notch. `PageBackdrop` then applied the **same** inset a second time, nested deep inside the already-padded body. On iOS that double-counts the notch and leaves a gap; in browsers `env()` resolves to `0`, so it was invisible there.

Fix: zero the redundant `padding-top` for this layout (which is always `position: static` and flows inside the padded body). The full-screen login/onboarding card uses `position: fixed`, escapes the body padding, and keeps its own safe-area padding untouched.

### 2. Rename the layout variant

`minimalistic-top-aligned` → `card-under-menu`. The new name describes what the layout actually is (a card rendered under the top menu) and makes the double-padding bug self-explanatory. Renamed in `CardPage.sc.js` and the 9 settings pages that use it. The full-screen card stays its own concept (default + `isBackgroundFixed`), not a sibling variant.

## Test

- Verify settings pages (Feed Preferences, My Classrooms, Profile, Language, etc.) on an iOS device/simulator: the title should now sit directly under the top menu, no gap.
- Confirm login/onboarding pages are unchanged (they still clear the notch correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)