### PR TITLE
Swipe-right-to-go-back, anchored to the back arrow

### DIFF
--- a/src/hooks/useSwipeBack.js
+++ b/src/hooks/useSwipeBack.js
@@ -2,18 +2,25 @@ import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import useShadowRef from "./useShadowRef";
 
-// Optional `targetPath` redirects the back gesture to a specific route via
-// history.replace (current entry is swapped — no extra back-stack growth).
-// When not set, falls back to history.goBack() — the natural "previous page".
-// Useful when the natural "previous page" isn't what the user expects: e.g.
-// a simplified article opened via Discover→Simplify→reader should land in
-// My Articles on swipe-back, not back at the now-superseded Discover entry.
+// Drives the swipe-right-to-go-back gesture. The navigation action is chosen
+// in this order:
+//   1. `onBack` — run this callback (used by BackArrow so the swipe performs
+//      exactly the same navigation as tapping the arrow).
+//   2. `targetPath` — history.replace to a specific route (current entry is
+//      swapped — no extra back-stack growth). Useful when the natural
+//      "previous page" isn't what the user expects: e.g. a simplified article
+//      opened via Discover→Simplify→reader should land in My Articles on
+//      swipe-back, not back at the now-superseded Discover entry.
+//   3. otherwise history.goBack() — the natural "previous page".
+// `enabled` (default true) lets a caller mount the hook but keep it inert.
 export default function useSwipeBack(options = {}) {
-  const { targetPath = null } = options;
+  const { targetPath = null, enabled = true, onBack = null } = options;
   const history = useHistory();
   const targetPathRef = useShadowRef(targetPath);
+  const onBackRef = useShadowRef(onBack);
 
   useEffect(() => {
+    if (!enabled) return;
     let startX = 0;
     let startY = 0;
     let tracking = false;
@@ -70,7 +77,9 @@ export default function useSwipeBack(options = {}) {
           page.style.transition = "";
           page.style.transform = "";
           page.style.opacity = "";
-          if (targetPathRef.current) {
+          if (onBackRef.current) {
+            onBackRef.current();
+          } else if (targetPathRef.current) {
             history.replace(targetPathRef.current);
           } else {
             history.goBack();
@@ -101,5 +110,5 @@ export default function useSwipeBack(options = {}) {
       document.removeEventListener("touchmove", onTouchMove, opts);
       document.removeEventListener("touchend", onTouchEnd, opts);
     };
-  }, [history]);
+  }, [history, enabled]);
 }

--- a/src/pages/Settings/SharedComponents/BackArrow.js
+++ b/src/pages/Settings/SharedComponents/BackArrow.js
@@ -1,7 +1,8 @@
 import { useHistory } from "react-router-dom";
+import useSwipeBack from "../../../hooks/useSwipeBack";
 import * as s from "./BackArrow.sc";
 
-export default function BackArrow({ redirectLink, func }) {
+export default function BackArrow({ redirectLink, func, swipeBack = true, swipeTargetPath = null }) {
   /*
     Within the Web, the back button usually navigates the user backwards in
     the history of the browser, or redirects them to a new location.
@@ -14,8 +15,19 @@ export default function BackArrow({ redirectLink, func }) {
   */
   const history = useHistory();
 
+  const goBack = () => (func ? func() : redirectLink ? history.push(redirectLink) : history.goBack());
+
+  // A swipe-right anywhere on the page performs the back navigation, so the
+  // gesture is just an alternative trigger for this control. By default it
+  // mirrors the tap exactly; `swipeTargetPath` lets a screen send the swipe to
+  // a specific route via history.replace instead (e.g. a simplified article
+  // should land in My Articles, not back on the superseded Discover entry).
+  // `swipeBack={false}` opts out entirely.
+  const onSwipeBack = swipeTargetPath ? () => history.replace(swipeTargetPath) : goBack;
+  useSwipeBack({ enabled: swipeBack, onBack: onSwipeBack });
+
   return (
-    <s.BackArrow onClick={() => (func ? func() : redirectLink ? history.push(redirectLink) : history.goBack())}>
+    <s.BackArrow onClick={goBack}>
       <svg width="9" height="15" viewBox="0 0 9 15" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M0.292893 6.65666C-0.097631 7.04719 -0.097631 7.68035 0.292893 8.07088L6.65685 14.4348C7.04738 14.8254 7.68054 14.8254 8.07107 14.4348C8.46159 14.0443 8.46159 13.4111 8.07107 13.0206L2.41421 7.36377L8.07107 1.70692C8.46159 1.31639 8.46159 0.683226 8.07107 0.292702C7.68054 -0.0978227 7.04738 -0.0978227 6.65685 0.292702L0.292893 6.65666ZM3 7.36377V6.36377H1V7.36377L1 8.36377H3V7.36377Z" fill="var(--text-secondary)"/>
       </svg>

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -19,7 +19,6 @@ import TopToolbar from "./TopToolbar";
 import ReviewVocabularyInfoBox from "./ReviewVocabularyInfoBox";
 import ArticleAuthors from "./ArticleAuthors";
 import useShadowRef from "../hooks/useShadowRef";
-import useSwipeBack from "../hooks/useSwipeBack";
 import { isSimplifiedArticle as isSimplifiedArticleFn } from "../utils/misc/articleHelpers";
 import useScrollTracking from "../hooks/useScrollTracking";
 import useReadingSession from "../hooks/useReadingSession";
@@ -64,8 +63,9 @@ export default function ArticleReader({ teacherArticleID }) {
   // Simplified articles live in the user's saves — back-gesture them to
   // My Articles regardless of how they got here (direct, or via
   // Discover→Simplify where history.replace clobbered the entry point).
+  // Threaded into TopToolbar's BackArrow, which owns the swipe-back gesture.
   const isSimplified = articleInfo && isSimplifiedArticleFn(articleInfo);
-  useSwipeBack({ targetPath: isSimplified ? "/articles/bookmarked" : null });
+  const swipeBackTargetPath = isSimplified ? "/articles/bookmarked" : null;
   const [loadingProgress, setLoadingProgress] = useState(null);
   const [showSlowLoadingHint, setShowSlowLoadingHint] = useState(false);
 
@@ -433,6 +433,7 @@ export default function ArticleReader({ teacherArticleID }) {
           ) : null
         }
         reportBroken={<ReportBroken UMR_SOURCE={WEB_READER} history={history} articleID={articleID} />}
+        swipeBackTargetPath={swipeBackTargetPath}
       />
 
       <s.ArticleReader style={{ fontSize: `${readerFontSize}px` }}>

--- a/src/reader/TopToolbar.js
+++ b/src/reader/TopToolbar.js
@@ -30,6 +30,7 @@ export default function TopToolbar({
   articleProgress,
   timer,
   reportBroken,
+  swipeBackTargetPath,
 }) {
   const api = useContext(APIContext);
   const { screenWidth, isMobile } = useScreenWidth();
@@ -68,7 +69,7 @@ export default function TopToolbar({
               gap: "0.5rem",
             }}
           >
-            {isMobile && <BackArrow />}
+            {isMobile && <BackArrow swipeTargetPath={swipeBackTargetPath} />}
             {timer}
           </div>
           <div style={{ display: "flex", gap: "1rem" }}>


### PR DESCRIPTION
## What

Adds a swipe-right-to-go-back gesture, modelled as an alternative trigger for the back arrow: **wherever a `BackArrow` exists, a swipe-right does exactly what tapping it does.**

## How

- `BackArrow` computes a single `goBack` handler and uses it for both the click and the swipe (via `useSwipeBack`), so the two can never diverge.
- `useSwipeBack` gains two options:
  - `onBack` — run a callback (used by `BackArrow`); action priority is `onBack` → `targetPath` → `history.goBack()`.
  - `enabled` — mount the hook but keep it inert.
- `BackArrow` props:
  - `swipeTargetPath` — send the swipe to a specific route via `history.replace` instead of plain back (e.g. a simplified article should land in My Articles, not on the superseded Discover entry).
  - `swipeBack={false}` — opt out entirely.
- The article reader previously registered its own document-level `useSwipeBack`. It now threads `swipeBackTargetPath` through `TopToolbar` to the arrow, so there's a single gesture owner and no duplicate listeners.

## Effect

Swipe-back now works on all settings pages, and additionally on the Words and Video reader pages (consistent with their existing back arrows). The article reader keeps its simplified-article → My Articles behavior.

## Test

- On a touch device: open a settings page, swipe right from the left half of the screen → goes back, same as the arrow.
- Open a simplified article, swipe right → lands in My Articles.
- Open a normal article, swipe right → goes back.
- Confirm no double-navigation in the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)