### PR TITLE
Feed cards: drop the empty image box when there's no usable image

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -264,12 +264,14 @@ export default function ArticlePreview({
   const openTextLink = navWrap(
     <>
       Open
-      {!should_open_in_zeeguu && <OpenInNewRoundedIcon style={{ fontSize: 18, marginLeft: 4 }} />}
+      {!should_open_in_zeeguu && <OpenInNewRoundedIcon style={{ fontSize: 16, marginLeft: 4 }} />}
     </>,
     {
       display: "inline-flex",
       alignItems: "center",
       color: "var(--text-muted)",
+      fontSize: "inherit",
+      fontFamily: "inherit",
       fontWeight: 500,
       textDecoration: "none",
     },
@@ -441,9 +443,9 @@ export default function ArticlePreview({
                         aria-label={isArticleSaved ? "Remove from saves" : "Save"}
                       >
                         {isArticleSaved ? (
-                          <BookmarkRoundedIcon style={{ fontSize: 18 }} />
+                          <BookmarkRoundedIcon style={{ fontSize: 16 }} />
                         ) : (
-                          <BookmarkBorderRoundedIcon style={{ fontSize: 18 }} />
+                          <BookmarkBorderRoundedIcon style={{ fontSize: 16 }} />
                         )}
                         {isArticleSaved ? "Saved" : "Save"}
                       </s.SaveActionButton>

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -349,21 +349,6 @@ export default function ArticlePreview({
             the empty circle just wastes title width. Keep it for saved-list
             surfaces (teacher OwnArticles uses inSavedView). */}
         {inSavedView && <ReadingCompletionProgress last_reading_percentage={article.reading_completion} />}
-        {/* Image-less cards have no photo to overlay the Save toggle on, so
-            it lives inline at the end of the title row instead. */}
-        {!hasImage && !isHiddenView && (
-          <s.SaveInlineButton
-            type="button"
-            onClick={handleToggleSave}
-            aria-label={isArticleSaved ? "Remove from saves" : "Save"}
-          >
-            {isArticleSaved ? (
-              <BookmarkRoundedIcon style={{ fontSize: 20 }} />
-            ) : (
-              <BookmarkBorderRoundedIcon style={{ fontSize: 20 }} />
-            )}
-          </s.SaveInlineButton>
-        )}
       </s.TitleContainer>
 
       {/* Single quiet metadata strip under the title: CEFR · Simplified ·
@@ -445,9 +430,27 @@ export default function ArticlePreview({
                     )}
                   </>
                 )}
-                {/* Image-less cards dropped the photo region (and its Open
-                    overlay), so carry an explicit Open affordance here. */}
-                {!hasImage && <s.SummaryOpenRow>{openTextLink}</s.SummaryOpenRow>}
+                {/* Image-less cards dropped the photo region, so its Save +
+                    Open controls regroup into one action row here. */}
+                {!hasImage && (
+                  <s.SummaryActionRow>
+                    {!isHiddenView && (
+                      <s.SaveActionButton
+                        type="button"
+                        onClick={handleToggleSave}
+                        aria-label={isArticleSaved ? "Remove from saves" : "Save"}
+                      >
+                        {isArticleSaved ? (
+                          <BookmarkRoundedIcon style={{ fontSize: 18 }} />
+                        ) : (
+                          <BookmarkBorderRoundedIcon style={{ fontSize: 18 }} />
+                        )}
+                        {isArticleSaved ? "Saved" : "Save"}
+                      </s.SaveActionButton>
+                    )}
+                    {openTextLink}
+                  </s.SummaryActionRow>
+                )}
                 {/* Bottom action row only used as a fallback: the Hidden
                   surface needs Unhide. */}
                 {isHiddenView && (

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -17,7 +17,6 @@ import ZeeguuSpeech from "../speech/APIBasedSpeech";
 import { estimateReadingTime, timeAgo } from "../utils/misc/readableTime";
 import ActionButton from "../components/ActionButton";
 import { articleSourceLabel } from "../utils/misc/articleHelpers";
-import { topicIconFor } from "../utils/misc/topicIcon";
 import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
 import BookmarkBorderRoundedIcon from "@mui/icons-material/BookmarkBorderRounded";
 import BookmarkRoundedIcon from "@mui/icons-material/BookmarkRounded";
@@ -51,6 +50,9 @@ export default function ArticlePreview({
   const [isHidden, setIsHidden] = useState(article.hidden || false);
   const [isAnimatingOut, setIsAnimatingOut] = useState(false);
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
+  // No img_url, or the <img> 404'd / failed to load — either way we render
+  // no image region at all rather than an empty box that reads as broken.
+  const [imageFailed, setImageFailed] = useState(false);
   // "Show more" is dead weight when the summary fits in the clamp, but the
   // CSS `…` stays unconditional when the box does overflow — so we need to
   // know which case we're in. useClampedOverflow handles measurement +
@@ -128,7 +130,7 @@ export default function ArticlePreview({
   };
 
   let topics = article.topics_list;
-  const PlaceholderIcon = topicIconFor(article.topics_list);
+  const hasImage = !!article.img_url && !imageFailed;
 
   function handleCloseRedirectionModal() {
     setIsRedirectionModaOpen(false);
@@ -208,28 +210,14 @@ export default function ArticlePreview({
     : article.video || (!Feature.extension_experiment1() && !hasExtension) || is_saved || hasInAppSimplification;
   const should_open_with_modal = doNotShowRedirectionModal_UserPreference === false;
 
-  // The clickable media block at the top of the card. `visual` is either
-  // the real <img> or the topic-glyph placeholder; both get the same
-  // "Open" overlay and the same open-in-Zeeguu / modal / external wrapper
-  // so an image-less card opens (and overlays its Save button) exactly
-  // like one with a photo. Returned without the s.ImageWithOverlay wrapper
-  // so callers can stack the Save icon as a sibling — nesting it inside
-  // this Link would let icon clicks bubble into navigation.
-  function mediaLink(visual) {
-    const innerLinkStyle = { display: "block", position: "relative", lineHeight: 0 };
-    const inner = (
-      <>
-        {visual}
-        <s.ImageOpenOverlay>
-          Open
-          {!should_open_in_zeeguu && <OpenInNewRoundedIcon style={{ fontSize: 18, marginLeft: 4 }} />}
-        </s.ImageOpenOverlay>
-      </>
-    );
+  // Wraps `children` in the right open-in-Zeeguu / modal / external handler
+  // for this article. `buttonExtraStyle` covers the few cases (the image
+  // block) where the modal <button> needs to fill its parent's width.
+  function navWrap(children, style, buttonExtraStyle = {}) {
     if (should_open_in_zeeguu) {
       return (
-        <Link to={`/read/article?id=${inAppArticleId}`} onClick={handleArticleClick} style={innerLinkStyle}>
-          {inner}
+        <Link to={`/read/article?id=${inAppArticleId}`} onClick={handleArticleClick} style={style}>
+          {children}
         </Link>
       );
     }
@@ -241,31 +229,51 @@ export default function ArticlePreview({
             handleArticleClick();
             handleOpenRedirectionModal();
           }}
-          style={{
-            ...innerLinkStyle,
-            background: "none",
-            border: "none",
-            padding: 0,
-            cursor: "pointer",
-            width: "100%",
-          }}
+          style={{ ...style, background: "none", border: "none", padding: 0, cursor: "pointer", ...buttonExtraStyle }}
         >
-          {inner}
+          {children}
         </button>
       );
     }
     return (
-      <a
-        target={isMobile ? "_self" : "_blank"}
-        rel="noreferrer"
-        href={externalUrl}
-        onClick={handleArticleClick}
-        style={innerLinkStyle}
-      >
-        {inner}
+      <a target={isMobile ? "_self" : "_blank"} rel="noreferrer" href={externalUrl} onClick={handleArticleClick} style={style}>
+        {children}
       </a>
     );
   }
+
+  // The clickable media block at the top of the card: the real <img> plus
+  // an "Open" overlay. Returned without the s.ImageWithOverlay wrapper so
+  // callers can stack the Save icon as a sibling — nesting it inside this
+  // Link would let icon clicks bubble into navigation.
+  function mediaLink(visual) {
+    const inner = (
+      <>
+        {visual}
+        <s.ImageOpenOverlay>
+          Open
+          {!should_open_in_zeeguu && <OpenInNewRoundedIcon style={{ fontSize: 18, marginLeft: 4 }} />}
+        </s.ImageOpenOverlay>
+      </>
+    );
+    return navWrap(inner, { display: "block", position: "relative", lineHeight: 0 }, { width: "100%" });
+  }
+
+  // Image-less cards have no Open overlay to tap, so this quiet text link
+  // under the summary carries the same navigation instead.
+  const openTextLink = navWrap(
+    <>
+      Open
+      {!should_open_in_zeeguu && <OpenInNewRoundedIcon style={{ fontSize: 18, marginLeft: 4 }} />}
+    </>,
+    {
+      display: "inline-flex",
+      alignItems: "center",
+      color: "var(--text-muted)",
+      fontWeight: 500,
+      textDecoration: "none",
+    },
+  );
 
   const imageVisual = (
     <img
@@ -273,14 +281,9 @@ export default function ArticlePreview({
       src={article.img_url}
       loading="lazy"
       decoding="async"
+      onError={() => setImageFailed(true)}
       style={{ cursor: "pointer", display: "block" }}
     />
-  );
-
-  const placeholderVisual = (
-    <s.PlaceholderImage>
-      <PlaceholderIcon style={{ fontSize: 56 }} />
-    </s.PlaceholderImage>
   );
 
   if (isHidden && !isHiddenView) {
@@ -346,6 +349,21 @@ export default function ArticlePreview({
             the empty circle just wastes title width. Keep it for saved-list
             surfaces (teacher OwnArticles uses inSavedView). */}
         {inSavedView && <ReadingCompletionProgress last_reading_percentage={article.reading_completion} />}
+        {/* Image-less cards have no photo to overlay the Save toggle on, so
+            it lives inline at the end of the title row instead. */}
+        {!hasImage && !isHiddenView && (
+          <s.SaveInlineButton
+            type="button"
+            onClick={handleToggleSave}
+            aria-label={isArticleSaved ? "Remove from saves" : "Save"}
+          >
+            {isArticleSaved ? (
+              <BookmarkRoundedIcon style={{ fontSize: 20 }} />
+            ) : (
+              <BookmarkBorderRoundedIcon style={{ fontSize: 20 }} />
+            )}
+          </s.SaveInlineButton>
+        )}
       </s.TitleContainer>
 
       {/* Single quiet metadata strip under the title: CEFR · Simplified ·
@@ -382,25 +400,27 @@ export default function ArticlePreview({
       </MetaStrip>
 
       <s.ArticleContent>
-        <s.ImageWithOverlay>
-          {mediaLink(article.img_url ? imageVisual : placeholderVisual)}
-          {/* Save toggle overlaid on the image (or placeholder) — bookmark
-              icon flips between outline and filled. Sibling of the
-              image-link so clicks here don't bubble into navigation. */}
-          {!isHiddenView && (
-            <s.SaveIconButton
-              type="button"
-              onClick={handleToggleSave}
-              aria-label={isArticleSaved ? "Remove from saves" : "Save"}
-            >
-              {isArticleSaved ? (
-                <BookmarkRoundedIcon style={{ fontSize: 18 }} />
-              ) : (
-                <BookmarkBorderRoundedIcon style={{ fontSize: 18 }} />
-              )}
-            </s.SaveIconButton>
-          )}
-        </s.ImageWithOverlay>
+        {hasImage && (
+          <s.ImageWithOverlay>
+            {mediaLink(imageVisual)}
+            {/* Save toggle overlaid on the image — bookmark icon flips
+                between outline and filled. Sibling of the image-link so
+                clicks here don't bubble into navigation. */}
+            {!isHiddenView && (
+              <s.SaveIconButton
+                type="button"
+                onClick={handleToggleSave}
+                aria-label={isArticleSaved ? "Remove from saves" : "Save"}
+              >
+                {isArticleSaved ? (
+                  <BookmarkRoundedIcon style={{ fontSize: 18 }} />
+                ) : (
+                  <BookmarkBorderRoundedIcon style={{ fontSize: 18 }} />
+                )}
+              </s.SaveIconButton>
+            )}
+          </s.ImageWithOverlay>
+        )}
         {!inSavedView &&
           (() => {
             const summaryNode = interactiveSummary ? (
@@ -425,10 +445,11 @@ export default function ArticlePreview({
                     )}
                   </>
                 )}
+                {/* Image-less cards dropped the photo region (and its Open
+                    overlay), so carry an explicit Open affordance here. */}
+                {!hasImage && <s.SummaryOpenRow>{openTextLink}</s.SummaryOpenRow>}
                 {/* Bottom action row only used as a fallback: the Hidden
-                  surface needs Unhide. Image-less cards no longer need an
-                  explicit Open here — the placeholder banner carries the
-                  Open overlay just like a real image. */}
+                  surface needs Unhide. */}
                 {isHiddenView && (
                   <div
                     style={{

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -235,8 +235,10 @@ const SummaryActionRow = styled.div`
   margin-top: 0.6em;
   /* Fixed action size (the parent Summary is a large 1.3em); both children
      inherit this so Save and Open match instead of falling back to their
-     button/anchor defaults. */
+     button/anchor defaults. line-height: 1 hugs the text box to the glyphs
+     so the flex-centered icons sit level with the text rather than high. */
   font-size: 0.95rem;
+  line-height: 1;
 `;
 
 // Save toggle as a labelled inline action (icon + "Save"/"Saved"), sized

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -226,30 +226,31 @@ const ImageWithOverlay = styled.div`
 `;
 
 // Image-less cards drop the photo region entirely (an empty box reads as
-// "broken"), so the Save toggle relocates inline to the end of the title
-// row. No photo to scrim against — a plain muted glyph, not a dark circle.
-const SaveInlineButton = styled.button`
-  flex: 0 0 auto;
+// "broken"). The Open overlay and Save toggle that used to live on the
+// photo regroup into a single left-aligned action row under the summary.
+const SummaryActionRow = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 2em;
-  height: 2em;
+  gap: 1.2em;
+  margin-top: 0.6em;
+`;
+
+// Save toggle as a labelled inline action (icon + "Save"/"Saved"), sized
+// to match the adjacent "Open" link rather than scrimmed over a photo.
+const SaveActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
   background: none;
   border: none;
-  color: var(--text-muted);
-  cursor: pointer;
   padding: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font: inherit;
+  font-weight: 500;
   &:active {
     color: var(--text-primary);
   }
-`;
-
-// The other half of the dropped image region: without a photo there's no
-// "Open" overlay to tap, so a quiet text affordance sits under the summary.
-const SummaryOpenRow = styled.div`
-  margin-top: 0.6em;
-  text-align: right;
 `;
 
 // Subtle bottom gradient + "Open" label so the image visibly reads as
@@ -345,8 +346,8 @@ export {
   BottomContainer,
   Summary,
   ImageWithOverlay,
-  SaveInlineButton,
-  SummaryOpenRow,
+  SummaryActionRow,
+  SaveActionButton,
   ImageOpenOverlay,
   ClampedSummary,
   SummaryToggle,

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -225,30 +225,31 @@ const ImageWithOverlay = styled.div`
   }
 `;
 
-// Stand-in banner for image-less articles: occupies the same slot as a
-// real photo so every card keeps its image region — and, crucially, the
-// Open + Save overlays that live on top of it. A vague, topic-matched
-// glyph (see topicIcon.js) on a muted surface, deliberately understated.
-// Dimensions mirror the img rules in ArticleContent so the overlays line
-// up identically.
-const PlaceholderImage = styled.div`
+// Image-less cards drop the photo region entirely (an empty box reads as
+// "broken"), so the Save toggle relocates inline to the end of the title
+// row. No photo to scrim against — a plain muted glyph, not a dark circle.
+const SaveInlineButton = styled.button`
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 2em;
+  height: 2em;
+  background: none;
+  border: none;
+  color: var(--text-muted);
   cursor: pointer;
-  background: var(--bg-tertiary);
-  color: var(--text-faint);
-  border-radius: 1em;
-  margin: 1em 0.5em 0 0.5em;
-  width: 16em;
-  height: 12em;
-  align-self: flex-start;
-
-  @media (max-width: 990px) {
-    width: 100%;
-    height: 13em;
-    margin: 0.5rem 0;
+  padding: 0;
+  &:active {
+    color: var(--text-primary);
   }
+`;
+
+// The other half of the dropped image region: without a photo there's no
+// "Open" overlay to tap, so a quiet text affordance sits under the summary.
+const SummaryOpenRow = styled.div`
+  margin-top: 0.6em;
+  text-align: right;
 `;
 
 // Subtle bottom gradient + "Open" label so the image visibly reads as
@@ -344,7 +345,8 @@ export {
   BottomContainer,
   Summary,
   ImageWithOverlay,
-  PlaceholderImage,
+  SaveInlineButton,
+  SummaryOpenRow,
   ImageOpenOverlay,
   ClampedSummary,
   SummaryToggle,

--- a/src/articles/ArticlePreview.sc.js
+++ b/src/articles/ArticlePreview.sc.js
@@ -233,6 +233,10 @@ const SummaryActionRow = styled.div`
   align-items: center;
   gap: 1.2em;
   margin-top: 0.6em;
+  /* Fixed action size (the parent Summary is a large 1.3em); both children
+     inherit this so Save and Open match instead of falling back to their
+     button/anchor defaults. */
+  font-size: 0.95rem;
 `;
 
 // Save toggle as a labelled inline action (icon + "Save"/"Saved"), sized


### PR DESCRIPTION
## Problem

Articles with no image rendered a tall placeholder box (a topic glyph on a muted surface) that reads as **broken** — see the report screenshot. Worse, articles whose `img_url` returned a 404/failed to load had **no `onError` handler at all**, so the browser's broken-image icon showed inside the card.

## Change

Both cases now collapse to a clean **no-image layout** — no box at all:

- `hasImage = !!article.img_url && !imageFailed` gates the entire image region.
- An `onError` on the `<img>` flips a failed load into the no-image layout.
- The box used to host the **Open** and **Save** controls, so they relocate:
  - **Save** → inline bookmark glyph at the end of the title row.
  - **Open** → a quiet `Open ↗` text link under the summary.
- The open-in-Zeeguu / modal / external navigation is extracted into a shared `navWrap()` helper used by both the image overlay and the new text link, so behaviour is identical across paths.
- Removes the now-dead `PlaceholderImage` styled component and the `topicIconFor` placeholder machinery.

Cards **with** a working image are visually unchanged.

## Notes

- Based on `master` (independent of the unmerged `feat/home-feed-filter-pills` work — the two base files were byte-identical across both branches).
- Verified the edited files parse/transform cleanly via esbuild; not yet eyeballed in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)