### PR TITLE
Invalidate recommendations cache when interests change

### DIFF
--- a/src/hooks/useSelectInterest.js
+++ b/src/hooks/useSelectInterest.js
@@ -33,6 +33,9 @@ export default function useSelectInterest(api) {
     setSubscribedTopics([...subscribedTopics, topic]);
     setAvailableTopics(availableTopics.filter((each) => each.id !== topic.id));
     api.subscribeToTopic(topic);
+    // Recommendations are cached (5-min TTL); drop the snapshot so the feed
+    // reflects the new subscription instead of the pre-change one.
+    api.invalidateCache("user_articles/recommended");
   }
 
   function unsubscribeFromTopic(topic) {
@@ -41,6 +44,7 @@ export default function useSelectInterest(api) {
     );
     setAvailableTopics([...availableTopics, topic]);
     api.unsubscribeFromTopic(topic);
+    api.invalidateCache("user_articles/recommended");
   }
 
   function toggleTopicSubscription(topic) {
@@ -55,6 +59,7 @@ export default function useSelectInterest(api) {
   function subscribeToSearch(response) {
     api.subscribeToSearch(response, (data) => {
       setSubscribedSearches([...subscribedSearches, data]);
+      api.invalidateCache("user_articles/recommended");
     });
   }
 
@@ -65,6 +70,7 @@ export default function useSelectInterest(api) {
       subscribedSearches.filter((each) => each.id !== search.id),
     );
     api.unsubscribeFromSearch(search);
+    api.invalidateCache("user_articles/recommended");
   }
 
   function isSubscribed(topic) {


### PR DESCRIPTION
## Problem

Adding a topic (e.g. **Sports**) in preferences and returning to the home feed showed no articles for that topic. Subscribing/unsubscribing a topic or search filter only saved the preference to the backend — it never dropped the client-side recommendations cache (5-min TTL in `classDef.js`). So the feed served the **pre-change cached snapshot**, and the new interest had no effect until the cache expired or the user pulled to refresh.

## Fix

Invalidate `user_articles/recommended` on every interest mutation (topic + search filter, subscribe + unsubscribe), reusing the existing `invalidateCache` helper — the same pattern already used by the article reader and pull-to-refresh.

## Notes

This addresses the stale-client-cache half of the problem. A more robust design (a single interests store with a version-keyed recommendations cache, gating the feed refetch on the backend write settling to also kill the subscribe-POST race) was discussed but deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)