### PR TITLE
Surface server error message on failed article conversion

### DIFF
--- a/src/reader/SharedArticleHandler.js
+++ b/src/reader/SharedArticleHandler.js
@@ -112,9 +112,19 @@ export default function SharedArticleHandler() {
     setStatus("loading");
   };
 
-  const onConversionError = () => {
+  const onConversionError = (errorMessage) => {
     setStatus("error");
-    setErrorMessage("Could not process this article.");
+    // Surface the server's message when it's human-readable (the API sends
+    // actionable text like "…too long… try a single chapter" as JSON
+    // `message`). Fall back to a friendly generic for bare "HTTP 4xx" or
+    // network strings, which aren't useful to a reader.
+    const isBareHttpCode =
+      typeof errorMessage === "string" && /^HTTP \d+$/.test(errorMessage.trim());
+    setErrorMessage(
+      errorMessage && !isBareHttpCode
+        ? errorMessage
+        : "Could not process this article. It may be too long, or the source may be blocking us — try a shorter piece or a single chapter.",
+    );
   };
 
   const runArticleConversion = (apiFn, action, noTranslate) => {


### PR DESCRIPTION
When translate-and-adapt / simplify / promote of a shared upload fails, the reader showed a hardcoded **"Could not process this article."** — `onConversionError` was a zero-arg function that discarded the message the API already passes to it (`_post` extracts JSON `message` on error, classDef.js:204).

Now `onConversionError(errorMessage)` displays the server's message when it's human-readable (e.g. *"…too long to process in one piece — try importing a single chapter"*), and falls back to a friendlier, more actionable generic for bare `HTTP 4xx` / network strings.

**Pairs with** the API change (zeeguu/api) that returns these conversion failures via `make_error` (JSON `{message}`) instead of `flask.abort` (HTML) — without that, the browser only sees `HTTP 422`. Until the API side merges, this still improves the fallback text.

Context: a user's fanfiction import failed at translate-and-adapt (LLM output truncated at the token cap); the fix raises the caps and now returns an actionable message. This PR makes the reader show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)