### PR TITLE
Rename Heading components to PageTitle and ModalTitle

### DIFF
--- a/src/components/ExplainBookmarkSelectionModal.js
+++ b/src/components/ExplainBookmarkSelectionModal.js
@@ -1,6 +1,6 @@
 import Modal from "../components/modal_shared/Modal";
 import Header from "../components/modal_shared/Header.sc";
-import Heading from "../components/modal_shared/Heading.sc";
+import ModalTitle from "../components/modal_shared/ModalTitle.sc";
 import Main from "../components/modal_shared/Main.sc";
 import { APP_DOMAIN } from "../appConstants";
 import { MAX_BOOKMARKS_TO_STUDY_PER_ARTICLE } from "../exercises/ExerciseConstants";
@@ -23,7 +23,7 @@ export default function ExplainBookmarkSelectionModal({ open, setShowExplainBook
           <img style={{ height: "2em" }} src={APP_DOMAIN + "/static/icons/new-info-icon.png"} alt="" />
         </p>
 
-        <Heading>How Zeeguu Selects Words to Practice</Heading>
+        <ModalTitle>How Zeeguu Selects Words to Practice</ModalTitle>
       </Header>
       <Main>
         <p>

--- a/src/components/FeedbackModal.js
+++ b/src/components/FeedbackModal.js
@@ -11,7 +11,7 @@ import FormSection from "../pages/_pages_shared/FormSection.sc.js";
 import TextField from "./TextField.js";
 import Main from "./modal_shared/Main.sc.js";
 import Header from "./modal_shared/Header.sc.js";
-import Heading from "./modal_shared/Heading.sc.js";
+import ModalTitle from "./modal_shared/ModalTitle.sc.js";
 import { FEEDBACK_CODES, FEEDBACK_CODES_NAME, getCategoryIdForUrl } from "./FeedbackConstants.js";
 import useScreenWidth from "../hooks/useScreenWidth.js";
 
@@ -86,7 +86,7 @@ export default function FeedbackModal({
     >
       <Main>
         <Header withoutLogo>
-          <Heading>Provide Feedback</Heading>
+          <ModalTitle>Provide Feedback</ModalTitle>
         </Header>
         <Form action={onSubmit}>
           <FormSection>

--- a/src/components/MainNav/LanguageModal.js
+++ b/src/components/MainNav/LanguageModal.js
@@ -8,7 +8,7 @@ import ButtonContainer from "../modal_shared/ButtonContainer.sc.js";
 import FormSection from "../../pages/_pages_shared/FormSection.sc.js";
 import Main from "../modal_shared/Main.sc.js";
 import Header from "../modal_shared/Header.sc.js";
-import Heading from "../modal_shared/Heading.sc.js";
+import ModalTitle from "../modal_shared/ModalTitle.sc.js";
 import RadioGroup from "./RadioGroup.js";
 import ReactLink from "../ReactLink.sc.js";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
@@ -160,7 +160,7 @@ export default function LanguageModal({ open, setOpen }) {
       {confirmModal}
       <Modal open={open} onClose={() => setOpen(false)}>
         <Header withoutLogo>
-          <Heading>{isSwitching ? "Changing language..." : "Your Active Languages:"}</Heading>
+          <ModalTitle>{isSwitching ? "Changing language..." : "Your Active Languages:"}</ModalTitle>
         </Header>
         <Main>
           <Form>{isSwitching ? switchingBody : languageListBody}</Form>

--- a/src/components/modal_shared/ModalTitle.sc.js
+++ b/src/components/modal_shared/ModalTitle.sc.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const Heading = styled.h2`
+const ModalTitle = styled.h2`
   font-size: 1.3rem;
   line-height: 150%;
   text-align: center;
@@ -21,4 +21,4 @@ const Heading = styled.h2`
   }
 `;
 
-export default Heading;
+export default ModalTitle;

--- a/src/components/progress_tracking/ProgressTrackingModal.sc.js
+++ b/src/components/progress_tracking/ProgressTrackingModal.sc.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import Heading from "../modal_shared/Heading.sc.js";
+import ModalTitle from "../modal_shared/ModalTitle.sc.js";
 import { Value } from "../progress_tracking/ProgressItems.sc.js";
 
 
@@ -40,7 +40,7 @@ export const ModalContent = styled.div`
   padding: 1em;
 `;
 
-export const CenteredHeading = styled(Heading)`
+export const CenteredHeading = styled(ModalTitle)`
 text-align: center;
 `;
 

--- a/src/components/redirect_notification/MobileNotification.js
+++ b/src/components/redirect_notification/MobileNotification.js
@@ -2,7 +2,7 @@ import * as s from "../modal_shared/Modal.sc";
 import { useContext, useState } from "react";
 import Modal from "../modal_shared/Modal";
 import Header from "../modal_shared/Header.sc";
-import Heading from "../modal_shared/Heading.sc";
+import ModalTitle from "../modal_shared/ModalTitle.sc";
 import Main from "../modal_shared/Main.sc";
 import Footer from "../modal_shared/Footer.sc";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc";
@@ -78,7 +78,7 @@ export default function MobileNotification({
   return (
     <Modal open={open} onClose={handleCancel}>
       <Header>
-        <Heading style={{textAlign:"center"}}>You will be redirected to the original article page</Heading>
+        <ModalTitle style={{textAlign:"center"}}>You will be redirected to the original article page</ModalTitle>
       </Header>
       <Main>
         <p style={{textAlign:"center"}}>

--- a/src/components/redirect_notification/SupportedNotification.js
+++ b/src/components/redirect_notification/SupportedNotification.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import Modal from "../modal_shared/Modal";
 import Header from "../modal_shared/Header.sc";
-import Heading from "../modal_shared/Heading.sc";
+import ModalTitle from "../modal_shared/ModalTitle.sc";
 import Main from "../modal_shared/Main.sc";
 import FullWidthImage from "../FullWidthImage";
 import Footer from "../modal_shared/Footer.sc";
@@ -54,9 +54,9 @@ export default function SupportedNotification({
   return (
     <Modal open={open} onClose={handleCancel}>
       <Header>
-        <Heading style={{textAlign:"center"}}>
+        <ModalTitle style={{textAlign:"center"}}>
           You will be redirected to the original article page       
-        </Heading>
+        </ModalTitle>
       </Header>
       <Main>
         <p >

--- a/src/components/redirect_notification/SupportedNotificationNotInstalled.js
+++ b/src/components/redirect_notification/SupportedNotificationNotInstalled.js
@@ -4,7 +4,7 @@ import { runningInChromeDesktop } from "../../utils/misc/browserDetection";
 import RoundedForwardArrow from "@mui/icons-material/ArrowForwardRounded";
 import Modal from "../modal_shared/Modal";
 import Header from "../modal_shared/Header.sc";
-import Heading from "../modal_shared/Heading.sc";
+import ModalTitle from "../modal_shared/ModalTitle.sc";
 import Main from "../modal_shared/Main.sc";
 import Footer from "../modal_shared/Footer.sc";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc";
@@ -23,11 +23,11 @@ export default function SupportedNotificationNotInstalled({
   return (
     <Modal open={open} onClose={handleCancel}>
       <Header>
-        <Heading>
+        <ModalTitle>
           Enable translating foreign articles with&nbsp;the&nbsp;Zeeguu
           browser&nbsp;
           {runningInChromeDesktop() ? "extension" : "add-on"}
-        </Heading>
+        </ModalTitle>
       </Header>
       <Main>
         <FullWidthImage

--- a/src/components/redirect_notification/UnsupportedNotification.js
+++ b/src/components/redirect_notification/UnsupportedNotification.js
@@ -2,7 +2,7 @@ import * as s from "../modal_shared/Modal.sc";
 import { useContext, useState } from "react";
 import Modal from "../modal_shared/Modal";
 import Header from "../modal_shared/Header.sc";
-import Heading from "../modal_shared/Heading.sc";
+import ModalTitle from "../modal_shared/ModalTitle.sc";
 import Main from "../modal_shared/Main.sc";
 import Footer from "../modal_shared/Footer.sc";
 import ButtonContainer from "../modal_shared/ButtonContainer.sc";
@@ -90,10 +90,10 @@ export default function UnsupportedNotification({
   return (
     <Modal open={open} onClose={handleCancel}>
       <Header>
-        <Heading>
+        <ModalTitle>
           Your browser doesn't support <br></br>
           the Zeeguu browser extension
-        </Heading>
+        </ModalTitle>
       </Header>
       <Main>
         <p>

--- a/src/exercises/CelebrationModal.js
+++ b/src/exercises/CelebrationModal.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import Confetti from "react-confetti";
 import Modal from "../components/modal_shared/Modal";
 import Header from "../components/modal_shared/Header.sc";
-import Heading from "../components/modal_shared/Heading.sc";
+import ModalTitle from "../components/modal_shared/ModalTitle.sc";
 import Main from "../components/modal_shared/Main.sc";
 import Footer from "../components/modal_shared/Footer.sc";
 import strings from "../i18n/definitions";
@@ -34,7 +34,7 @@ export default function CelebrationModal({ open, onClose }) {
       )}
       <Modal open={open} onClose={onClose}>
         <Header>
-          <Heading>{strings.celebrationTitle}</Heading>
+          <ModalTitle>{strings.celebrationTitle}</ModalTitle>
         </Header>
         <Main>
           <p>{strings.celebrationMsg}</p>

--- a/src/exercises/removeBookmark/RemoveBookmarkModal.js
+++ b/src/exercises/removeBookmark/RemoveBookmarkModal.js
@@ -1,7 +1,7 @@
 import Modal from "../../components/modal_shared/Modal";
 import Header from "../../components/modal_shared/Header.sc";
 import Main from "../../components/modal_shared/Main.sc";
-import Heading from "../../components/modal_shared/Heading.sc";
+import ModalTitle from "../../components/modal_shared/ModalTitle.sc";
 import ButtonContainer from "../../components/modal_shared/ButtonContainer.sc";
 import Button from "../../pages/_pages_shared/Button.sc";
 import TextField from "../../components/TextField";
@@ -80,9 +80,9 @@ export default function RemoveBookmarkModal({
     >
       <Header>
         {exerciseBookmarkForFeedback && (
-          <Heading>
+          <ModalTitle>
             Why remove {exerciseBookmarkForFeedback.from}/{exerciseBookmarkForFeedback.to}?
-          </Heading>
+          </ModalTitle>
         )}
       </Header>
       <Main>

--- a/src/pages/DeleteAccount/DeleteAccount.js
+++ b/src/pages/DeleteAccount/DeleteAccount.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useContext } from "react";
 import { UserContext } from "../../contexts/UserContext";
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import Footer from "../_pages_shared/Footer.sc";
 import LoadingAnimation from "../../components/LoadingAnimation";
@@ -61,7 +61,7 @@ export default function DeleteAccount() {
   return (
     <CardPage isBackgroundFixed={true}>
       <Header>
-        <Heading>{headingMsg}</Heading>
+        <PageTitle>{headingMsg}</PageTitle>
       </Header>
       <Main>
         {currentStatus === DeletionStatus.WAITING_API_RESPONSE && (

--- a/src/pages/DeleteAccount/DeleteAccountButton.js
+++ b/src/pages/DeleteAccount/DeleteAccountButton.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import Modal from "../../components/modal_shared/Modal";
 import Header from "../../components/modal_shared/Header.sc";
-import Heading from "../../components/modal_shared/Heading.sc";
+import ModalTitle from "../../components/modal_shared/ModalTitle.sc";
 import Main from "../../components/modal_shared/Main.sc";
 import Footer from "../../components/modal_shared/Footer.sc";
 import ButtonContainer from "../../components/modal_shared/ButtonContainer.sc";
@@ -37,7 +37,7 @@ export default function DeleteAccountButton() {
       >
         <Header>
           <p style={{ textAlign: "center", fontSize: "40px" }}>❗</p>
-          <Heading>You are deleting your account</Heading>
+          <ModalTitle>You are deleting your account</ModalTitle>
         </Header>
         <Main>
           <p>

--- a/src/pages/LogIn.js
+++ b/src/pages/LogIn.js
@@ -11,7 +11,7 @@ import strings from "../i18n/definitions";
 
 import CardPage from "./_pages_shared/CardPage";
 import Header from "./_pages_shared/Header";
-import Heading from "./_pages_shared/Heading.sc";
+import PageTitle from "./_pages_shared/PageTitle.sc";
 import Main from "./_pages_shared/Main.sc";
 import Form from "./_pages_shared/Form.sc";
 import FormSection from "./_pages_shared/FormSection.sc";
@@ -65,7 +65,7 @@ export default function LogIn({ handleSuccessfulLogIn }) {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Login</Heading>
+        <PageTitle>Login</PageTitle>
       </Header>
       <Main>
         <Form action={""} method={"post"}>

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,13 +1,13 @@
 import CardPage from "./_pages_shared/CardPage";
 import Header from "./_pages_shared/Header";
-import Heading from "./_pages_shared/Heading.sc";
+import PageTitle from "./_pages_shared/PageTitle.sc";
 import Main from "./_pages_shared/Main.sc";
 import { Link } from "react-router-dom";
 export default function NotFound() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Ooops!</Heading>
+        <PageTitle>Ooops!</PageTitle>
       </Header>
       <Main>
         <p>The page you are looking for cannot be found.</p>

--- a/src/pages/ResetPassword.js
+++ b/src/pages/ResetPassword.js
@@ -5,7 +5,7 @@ import { EmailValidator, NonEmptyValidator } from "../utils/ValidatorRule/Valida
 import strings from "../i18n/definitions";
 import CardPage from "./_pages_shared/CardPage";
 import Header from "./_pages_shared/Header";
-import Heading from "./_pages_shared/Heading.sc";
+import PageTitle from "./_pages_shared/PageTitle.sc";
 import Main from "./_pages_shared/Main.sc";
 import Footer from "./_pages_shared/Footer.sc";
 
@@ -53,7 +53,7 @@ export default function ResetPassword() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Reset Password</Heading>
+        <PageTitle>Reset Password</PageTitle>
       </Header>
       <Main>
         {!codeSent && !isLoggedIn && (

--- a/src/pages/Settings/Pages/MyClassrooms/LeaveClassroomModal.js
+++ b/src/pages/Settings/Pages/MyClassrooms/LeaveClassroomModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Modal from "../../../../components/modal_shared/Modal";
 import Header from "../../../../components/modal_shared/Header.sc";
-import Heading from "../../../../components/modal_shared/Heading.sc";
+import ModalTitle from "../../../../components/modal_shared/ModalTitle.sc";
 import Footer from "../../../../components/modal_shared/Footer.sc";
 import ButtonContainer from "../../../../components/modal_shared/ButtonContainer.sc";
 import Button from "../../../_pages_shared/Button.sc";
@@ -21,9 +21,9 @@ export default function LeaveClassroomModal({
   return (
     <Modal open={isLeaveClassroomModalOpen} onClose={handleCloseLeaveClassroomModal}>
       <Header>
-        <Heading>
+        <ModalTitle>
           You are about to leave the following classroom: <s.ColorAccent>{currentClassroom.name}</s.ColorAccent>
-        </Heading>
+        </ModalTitle>
       </Header>
       <Footer>
         <ButtonContainer $buttonCountNum={1}>

--- a/src/pages/Settings/Pages/ProfileDetails.js
+++ b/src/pages/Settings/Pages/ProfileDetails.js
@@ -13,7 +13,7 @@ import ButtonContainer from "../../_pages_shared/ButtonContainer.sc";
 import InputField from "../../../components/InputField";
 import CardPage from "../../_pages_shared/CardPage";
 import Header from "../../_pages_shared/Header";
-import Heading from "../../_pages_shared/Heading.sc";
+import PageTitle from "../../_pages_shared/PageTitle.sc";
 import Main from "../../_pages_shared/Main.sc";
 import SettingsPageHeader from "../SharedComponents/SettingsPageHeader";
 import FullWidthErrorMsg from "../../../components/FullWidthErrorMsg.sc";
@@ -225,7 +225,7 @@ export default function ProfileDetails() {
       {isGamificationEnabled && (
         <Modal open={showAvatarModal} onClose={() => setShowAvatarModal(false)}>
           <Header withoutLogo>
-            <Heading>Choose Your Avatar</Heading>
+            <PageTitle>Choose Your Avatar</PageTitle>
           </Header>
           <Main>
             <s.PickerSection>

--- a/src/pages/Settings/SharedComponents/SettingsPageHeader.js
+++ b/src/pages/Settings/SharedComponents/SettingsPageHeader.js
@@ -1,6 +1,6 @@
 import BackArrow from "./BackArrow.js";
 import Header from "../../_pages_shared/Header.js";
-import Heading from "../../_pages_shared/Heading.sc.js";
+import PageTitle from "../../_pages_shared/PageTitle.sc.js";
 import { HeaderWrapper, BackArrowWrapper } from "../Pages/Settings.sc.js";
 
 export default function SettingsPageHeader({ title, redirectLink, func, children }) {
@@ -10,7 +10,7 @@ export default function SettingsPageHeader({ title, redirectLink, func, children
         <BackArrow redirectLink={redirectLink} func={func} />
       </BackArrowWrapper>
       <Header withoutLogo>
-        <Heading>{title}</Heading>
+        <PageTitle>{title}</PageTitle>
         {children}
       </Header>
     </HeaderWrapper>

--- a/src/pages/_pages_shared/PageTitle.sc.js
+++ b/src/pages/_pages_shared/PageTitle.sc.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const Heading = styled.h1`
+const PageTitle = styled.h1`
   width: 100%;
   font-size: 1.3em;
   line-height: 120%;
@@ -16,4 +16,4 @@ const Heading = styled.h1`
   }
 `;
 
-export default Heading;
+export default PageTitle;

--- a/src/pages/onboarding/CreateAccount.js
+++ b/src/pages/onboarding/CreateAccount.js
@@ -19,7 +19,7 @@ import strings from "../../i18n/definitions";
 
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import Form from "../_pages_shared/Form.sc";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
@@ -161,7 +161,7 @@ export default function CreateAccount({ handleSuccessfulLogIn }) {
         </>
       </Modal>
       <Header>
-        <Heading>Create Account</Heading>
+        <PageTitle>Create Account</PageTitle>
       </Header>
       <Main>
         <Form action={""} method={"POST"}>

--- a/src/pages/onboarding/ExtensionInstalled.js
+++ b/src/pages/onboarding/ExtensionInstalled.js
@@ -3,7 +3,7 @@ import { useContext, useEffect } from "react";
 import { useHistory } from "react-router-dom/cjs/react-router-dom";
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import FullWidthImage from "../../components/FullWidthImage";
 import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
@@ -26,11 +26,11 @@ export default function ExtensionInstalled() {
   return (
     <CardPage isBackgroundFixed={true}>
       <Header>
-        <Heading>
+        <PageTitle>
           Right-click to&nbsp; activate the&nbsp;Zeeguu&nbsp;
           {runningInChromeDesktop() ? "extension" : "add-on"}
           on any page containing an article.
-        </Heading>
+        </PageTitle>
       </Header>
       <Main>
         <FullWidthImage src={"read-any-article.gif"} />

--- a/src/pages/onboarding/InstallExtension.js
+++ b/src/pages/onboarding/InstallExtension.js
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 import { setTitle } from "../../assorted/setTitle";
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
 import Footer from "../_pages_shared/Footer.sc";
@@ -25,10 +25,10 @@ export default function InstallExtension() {
   return (
     <CardPage isBackgroundFixed={true}>
       <Header>
-        <Heading>
+        <PageTitle>
           Read any article on the web<br></br>
           in&nbsp;your&nbsp;target&nbsp;language
-        </Heading>
+        </PageTitle>
       </Header>
       <Main>
         <FullWidthImage src={"translations.png"} />

--- a/src/pages/onboarding/InviteCode.js
+++ b/src/pages/onboarding/InviteCode.js
@@ -9,7 +9,7 @@ import { APIContext } from "../../contexts/APIContext";
 
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
@@ -66,7 +66,7 @@ export default function InviteCode() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Invite Code</Heading>
+        <PageTitle>Invite Code</PageTitle>
       </Header>
       <Main>
         <Form action={""}>

--- a/src/pages/onboarding/LanguagePreferences.js
+++ b/src/pages/onboarding/LanguagePreferences.js
@@ -20,7 +20,7 @@ import { saveSharedUserInfo, setUserSession } from "../../utils/cookies/userInfo
 
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import Form from "../_pages_shared/Form.sc";
 import FormSection from "../_pages_shared/FormSection.sc";
@@ -171,7 +171,7 @@ export default function LanguagePreferences() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>What language would&nbsp;you&nbsp;like&nbsp;to&nbsp;learn?</Heading>
+        <PageTitle>What language would&nbsp;you&nbsp;like&nbsp;to&nbsp;learn?</PageTitle>
       </Header>
       <Main>
         <Form action={""}>

--- a/src/pages/onboarding/SelectInterests.js
+++ b/src/pages/onboarding/SelectInterests.js
@@ -4,7 +4,7 @@ import { isSupportedBrowser } from "../../utils/misc/browserDetection";
 import useSelectInterest from "../../hooks/useSelectInterest";
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
 import Footer from "../_pages_shared/Footer.sc";
@@ -35,7 +35,7 @@ export default function SelectInterests({ hasExtension }) {
   return (
     <CardPage isBackgroundFixed={true}>
       <Header>
-        <Heading>What would you like to read&nbsp;about?</Heading>
+        <PageTitle>What would you like to read&nbsp;about?</PageTitle>
       </Header>
       <Main>
         <TagContainer>

--- a/src/pages/onboarding/VerifyEmail.js
+++ b/src/pages/onboarding/VerifyEmail.js
@@ -7,7 +7,7 @@ import strings from "../../i18n/definitions";
 
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import Form from "../_pages_shared/Form.sc";
 import FullWidthErrorMsg from "../../components/FullWidthErrorMsg.sc";
@@ -79,7 +79,7 @@ export default function VerifyEmail() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Verify Your Email</Heading>
+        <PageTitle>Verify Your Email</PageTitle>
       </Header>
       <Main>
         <p style={{ textAlign: "center", marginBottom: "1.5rem" }}>

--- a/src/pages/onboarding/Welcome.js
+++ b/src/pages/onboarding/Welcome.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import CardPage from "../_pages_shared/CardPage";
 import Header from "../_pages_shared/Header";
-import Heading from "../_pages_shared/Heading.sc";
+import PageTitle from "../_pages_shared/PageTitle.sc";
 import Main from "../_pages_shared/Main.sc";
 import ButtonContainer from "../_pages_shared/ButtonContainer.sc";
 import Button from "../_pages_shared/Button.sc";
@@ -53,7 +53,7 @@ export default function Welcome() {
   return (
     <CardPage pageWidth={"narrow"} isBackgroundFixed={true}>
       <Header>
-        <Heading>Welcome to Zeeguu</Heading>
+        <PageTitle>Welcome to Zeeguu</PageTitle>
       </Header>
       <Main>
         <Subtitle>Do you already have an account?</Subtitle>

--- a/src/profile/LanguagesModal.js
+++ b/src/profile/LanguagesModal.js
@@ -1,6 +1,6 @@
 import Modal from "../components/modal_shared/Modal";
 import Header from "../components/modal_shared/Header.sc";
-import Heading from "../components/modal_shared/Heading.sc";
+import ModalTitle from "../components/modal_shared/ModalTitle.sc";
 import Main from "../components/modal_shared/Main.sc";
 import DynamicFlagImage from "../components/DynamicFlagImage";
 import LocalFireDepartmentIcon from "@mui/icons-material/LocalFireDepartment";
@@ -11,7 +11,7 @@ export function LanguagesModal({ open, onClose, isOwnProfile, profileData, activ
   return (
     <Modal open={open} onClose={onClose}>
       <Header>
-        <Heading>{isOwnProfile ? "Your" : `${profileData?.username}'s`} Languages</Heading>
+        <ModalTitle>{isOwnProfile ? "Your" : `${profileData?.username}'s`} Languages</ModalTitle>
       </Header>
       <Main>
         <s.LanguagesGrid>

--- a/src/profile/UnfriendConfirmModal.js
+++ b/src/profile/UnfriendConfirmModal.js
@@ -1,6 +1,6 @@
 import Modal from "../components/modal_shared/Modal";
 import Header from "../components/modal_shared/Header.sc";
-import Heading from "../components/modal_shared/Heading.sc";
+import ModalTitle from "../components/modal_shared/ModalTitle.sc";
 import Main from "../components/modal_shared/Main.sc";
 import Button from "../pages/_pages_shared/Button.sc";
 import * as s from "./UnfriendConfirmModal.sc";
@@ -9,7 +9,7 @@ export function UnfriendConfirmModal({ open, onClose, onConfirm, displayName, is
   return (
     <Modal open={open} onClose={onClose}>
       <Header>
-        <Heading>Confirm Unfriend</Heading>
+        <ModalTitle>Confirm Unfriend</ModalTitle>
       </Header>
       <Main>
         <div>


### PR DESCRIPTION
## What

Two separate styled-components were both named `Heading`, named after their HTML tag rather than their role:

| Before | After | Element | Role |
|---|---|---|---|
| `pages/_pages_shared/Heading.sc.js` | `PageTitle.sc.js` | `<h1>` | The single top title of a full page (LogIn, onboarding, Settings, NotFound…) |
| `components/modal_shared/Heading.sc.js` | `ModalTitle.sc.js` | `<h2>` | The title inside a modal/dialog |

## Why

`Heading` describes the tag; `PageTitle` / `ModalTitle` describe the role, and the pair is now unambiguous (no two components sharing a name). `PageTitle` also reads consistently next to its neighbour `SettingsPageHeader`.

## Changes

- Renamed both files + their default exports.
- Updated import paths, local import names, and JSX usages across all 28 consumers.
- `ProgressTrackingModal.sc.js` keeps its exported `CenteredHeading` name (only its underlying `styled(...)` base changed to `ModalTitle`).

No behavioural change. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)