### PR TITLE
Teacher editor: "Adjust to level" bar to adapt own texts to an easier CEFR level

### DIFF
--- a/src/api/ownTexts.js
+++ b/src/api/ownTexts.js
@@ -122,6 +122,45 @@ Zeeguu_API.prototype.estimateArticleCEFR = function (
 };
 
 /*
+  Adapt the teacher's own text to an easier CEFR level (on-demand LLM rewrite).
+  Stateless — operates on the content passed in, so it works for a new (unsaved)
+  draft as well as an existing text. Returns { title, content (HTML), summary,
+  cefr_level }. The caller replaces the editor content and lets the teacher save.
+
+  Example:
+    api.simplifyOwnText("Title", "Plain content", "da", "A2",
+      (data) => { console.log(data.content); },
+      (err) => { console.error(err); });
+*/
+Zeeguu_API.prototype.simplifyOwnText = function (
+  title,
+  content,
+  language,
+  targetLevel,
+  onSuccess,
+  onError
+) {
+  let payload = {
+    title: title,
+    content: content,
+    language: language,
+    cefr_level: targetLevel,
+  };
+  this._post(
+    "simplify_own_text",
+    qs.stringify(payload),
+    (response) => {
+      try {
+        onSuccess(JSON.parse(response));
+      } catch (e) {
+        if (onError) onError("Failed to parse simplification response");
+      }
+    },
+    onError
+  );
+};
+
+/*
   Get all CEFR assessments for an article (LLM, ML, Teacher resolution)
 
   Example:

--- a/src/teacher/myTextsPage/AdjustLevelBar.js
+++ b/src/teacher/myTextsPage/AdjustLevelBar.js
@@ -1,0 +1,121 @@
+import React, { useContext, useState } from "react";
+import styled from "styled-components";
+import { toast } from "react-toastify";
+import { APIContext } from "../../contexts/APIContext";
+import { StyledButton } from "../styledComponents/TeacherButtons.sc";
+
+const CEFR_LEVELS = ["A1", "A2", "B1", "B2", "C1", "C2"];
+const FALLBACK_TARGETS = ["A1", "A2", "B1"];
+
+// Levels strictly easier than the current one. A compound level like "B1/B2"
+// is normalised to its harder end so we never offer a target that isn't simpler.
+function easierLevelsThan(currentLevel) {
+  if (!currentLevel) return FALLBACK_TARGETS;
+  const hardestIdx = String(currentLevel)
+    .split("/")
+    .map((tok) => CEFR_LEVELS.indexOf(tok.trim()))
+    .reduce((max, idx) => Math.max(max, idx), -1);
+  if (hardestIdx <= 0) return []; // unknown, or already A1 — nothing easier
+  return CEFR_LEVELS.slice(0, hardestIdx);
+}
+
+function stripHtml(html) {
+  if (!html) return "";
+  const tmp = document.createElement("DIV");
+  tmp.innerHTML = html;
+  return tmp.textContent || tmp.innerText || "";
+}
+
+const Bar = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: #fff8ef;
+  border: 1px solid #ffcf99;
+  border-radius: 5px;
+
+  .label {
+    font-weight: bold;
+    white-space: nowrap;
+  }
+
+  .hint {
+    font-size: 0.85em;
+    color: #666;
+    font-style: italic;
+  }
+`;
+
+/**
+ * "Adjust to level" bar for the teacher text editor.
+ *
+ * A teacher's pasted text/URL is shown as-is; this lets them rewrite it to an
+ * easier CEFR level on demand. The rewrite is non-destructive until saved:
+ * onAdjusted replaces the editor content and marks the draft unsaved, so the
+ * teacher reviews it and hits Save (or Cancel to restore the original).
+ */
+export default function AdjustLevelBar({
+  currentLevel,
+  title,
+  content, // HTML from the editor
+  language, // language code, or "default"/"" when not chosen yet
+  disabled,
+  onAdjusted,
+}) {
+  const api = useContext(APIContext);
+  const [busyLevel, setBusyLevel] = useState(null);
+
+  const targets = easierLevelsThan(currentLevel);
+  const languageMissing = !language || language === "default";
+  const contentMissing = !stripHtml(content).trim();
+
+  // Nothing simpler to offer (e.g. the text is already A1): hide the bar.
+  if (targets.length === 0) return null;
+
+  const barDisabled = disabled || languageMissing || contentMissing || busyLevel !== null;
+
+  const handleAdjust = (targetLevel) => {
+    setBusyLevel(targetLevel);
+    api.simplifyOwnText(
+      title || "Untitled",
+      stripHtml(content),
+      language,
+      targetLevel,
+      (data) => {
+        setBusyLevel(null);
+        onAdjusted(data.title || title, data.content, targetLevel);
+        toast.success(`Text adapted to ${targetLevel}. Review it and click Save to keep it.`);
+      },
+      (error) => {
+        setBusyLevel(null);
+        toast.error(typeof error === "string" ? error : "Could not adapt this text.");
+      },
+    );
+  };
+
+  return (
+    <Bar>
+      <span className="label">Adjust to level:</span>
+      {targets.map((level) => (
+        <StyledButton
+          key={level}
+          $primary
+          onClick={() => handleAdjust(level)}
+          $disabled={barDisabled}
+          disabled={barDisabled}
+          style={{ minWidth: "3.5rem", fontFamily: "monospace", fontWeight: "bold" }}
+        >
+          {busyLevel === level ? "…" : level}
+        </StyledButton>
+      ))}
+      {languageMissing && <span className="hint">Choose a language first</span>}
+      {!languageMissing && busyLevel && (
+        <span className="hint">Adapting to {busyLevel}… this can take a moment</span>
+      )}
+    </Bar>
+  );
+}

--- a/src/teacher/myTextsPage/CefrAssessmentDisplay.js
+++ b/src/teacher/myTextsPage/CefrAssessmentDisplay.js
@@ -11,6 +11,7 @@ export default function CefrAssessmentDisplay({
   articleTitle,
   languageCode,
   onOverrideChange,
+  onEffectiveLevelChange, // Optional: notified whenever the display (effective) level changes
   initialAssessments // Optional: pre-loaded assessment data from article
 }) {
   const api = useContext(APIContext);
@@ -38,6 +39,14 @@ export default function CefrAssessmentDisplay({
     console.log(`getMaxLevel(${level1}, ${level2}): idx1=${idx1}, idx2=${idx2}, result=${result}`);
     return result;
   };
+
+  // Notify parent whenever the effective (display) level changes, so sibling
+  // UI (e.g. the "Adjust to level" bar) can offer only easier target levels.
+  useEffect(() => {
+    if (onEffectiveLevelChange) {
+      onEffectiveLevelChange(effectiveLevel);
+    }
+  }, [effectiveLevel, onEffectiveLevelChange]);
 
   // Load initial assessments when initialAssessments prop changes
   useEffect(() => {

--- a/src/teacher/myTextsPage/EditText.js
+++ b/src/teacher/myTextsPage/EditText.js
@@ -14,6 +14,7 @@ import { Error } from "../sharedComponents/Error";
 import ShareWithCollegueDialog from "./ShareWithColleagueDialog";
 import { APIContext } from "../../contexts/APIContext";
 import CefrAssessmentDisplay from "./CefrAssessmentDisplay";
+import AdjustLevelBar from "./AdjustLevelBar";
 import LoadingAnimation from "../../components/LoadingAnimation";
 import { detectLanguageFromText, languageNames } from "../../utils/languageDetection";
 
@@ -28,6 +29,7 @@ export default function EditText() {
   });
   const [originalCEFRLevel, setOriginalCEFRLevel] = useState(""); // Track original to detect manual changes
   const [cefrAssessments, setCefrAssessments] = useState(null); // Store CEFR assessment data
+  const [displayLevel, setDisplayLevel] = useState(null); // Effective level from the CEFR panel (drives Adjust targets)
   const [cohortList, setCohortList] = useState([]);
   const [showAddToCohortDialog, setShowAddToCohortDialog] = useState(false);
   const [showDeleteTextWarning, setShowDeleteTextWarning] = useState(false);
@@ -184,6 +186,34 @@ export default function EditText() {
     });
   }
 
+  // Handle an on-demand "Adjust to level" rewrite from AdjustLevelBar.
+  // Non-destructive until saved: we replace the draft content and mark it
+  // changed, so the teacher reviews and hits Save (or Cancel to restore).
+  function handleContentAdjusted(newTitle, newHtmlContent, targetLevel) {
+    setStateChanged(true);
+    setArticleState({
+      ...articleState,
+      article_title: newTitle,
+      article_content: newHtmlContent,
+      cefr_level: targetLevel,
+      assessment_method: "llm_simplified",
+    });
+  }
+
+  // After saving an adapted text, store its level so students see the right
+  // difficulty. The own-text endpoints ignore cefr_level, so we reuse the
+  // resolve-CEFR path. Scoped to the "Adjust to level" case only.
+  function persistAdaptedLevelIfNeeded(id) {
+    if (articleState.assessment_method === "llm_simplified" && articleState.cefr_level) {
+      api.resolveCEFR(
+        id,
+        articleState.cefr_level,
+        () => {},
+        (error) => console.error("Failed to persist adapted CEFR level:", error),
+      );
+    }
+  }
+
   const uploadArticle = () => {
     // Strip HTML tags to get plain text for content field
     const stripHtml = (html) => {
@@ -204,6 +234,11 @@ export default function EditText() {
       articleState.language_code,
       (newID) => {
         console.log(`article created with id: ${newID}`);
+        // Persist an adapted level so students see the right difficulty. The
+        // upload/update endpoints don't store cefr_level, so we use the existing
+        // resolve-CEFR path. Only for the "Adjust to level" case — a plain save
+        // must not mark an ML-guessed level as teacher-confirmed.
+        persistAdaptedLevelIfNeeded(newID);
         setStateChanged(false);
         history.push(`/teacher/texts/editText/${newID}`);
       },
@@ -234,6 +269,7 @@ export default function EditText() {
       articleState.language_code,
       (result) => {
         if ((result = "OK")) {
+          persistAdaptedLevelIfNeeded(articleID);
           setStateChanged(false);
         } else {
           console.log(result);
@@ -345,7 +381,17 @@ export default function EditText() {
           articleTitle={articleState.article_title}
           languageCode={articleState.language_code}
           onOverrideChange={handleTeacherOverride}
+          onEffectiveLevelChange={setDisplayLevel}
           initialAssessments={cefrAssessments}
+        />
+
+        {/* Adjust to level: rewrite the teacher's text to an easier CEFR level on demand */}
+        <AdjustLevelBar
+          currentLevel={displayLevel}
+          title={articleState.article_title}
+          content={articleState.article_content}
+          language={articleState.language_code}
+          onAdjusted={handleContentAdjusted}
         />
 
         <EditTextInputFields


### PR DESCRIPTION
## Why

A teacher can paste their own text or a URL into the classroom editor, but it was shown **as-is** — never adapted to a level. Jack Burston and Androulla Athanasiou (CUT Language Centre) asked for an **"Adjust Level" button above the text in the editor** (their mockup below). This implements it.

## What

An **"Adjust to level: A1 A2 B1 …"** bar below the existing CEFR Difficulty Assessment panel in the teacher text editor:

- Clicking a level rewrites the text to that level via the new `/simplify_own_text` endpoint, loads the result into the editor, and marks the draft **unsaved** — the teacher reviews and hits **Save** (Cancel restores the original; non-destructive until save).
- Only levels **easier than** the current display level are offered (a B2 text → A1/A2/B1). The LLM only simplifies, so a harder target is never shown.
- On Save, the adapted level is persisted via the existing `resolve_cefr` path, because the own-text endpoints don't store `cefr_level` — so students actually see the right difficulty. Scoped to the adapt case, so a plain save doesn't get mislabelled "teacher-confirmed".

### Files
- **`AdjustLevelBar.js`** (new) — self-contained bar; owns the API call, progress, and easier-levels logic.
- **`api/ownTexts.js`** — `simplifyOwnText(...)` client method.
- **`CefrAssessmentDisplay.js`** — emits its effective level up via `onEffectiveLevelChange` so the sibling bar knows what's "easier".
- **`EditText.js`** — renders the bar, swaps in adapted content, persists the level on save.

## Design note for review

The `update_own_text` / `upload_own_text` endpoints currently **ignore `cefr_level`** (pre-existing), so a saved adaptation wouldn't update the level students see. Rather than reworking that CEFR-persistence chain, this persists the adapted level at Save time through the already-working `resolveCEFR` endpoint. Happy to instead fix it at the endpoint level if you'd prefer — flagging the choice.

## Pairs with

Backend PR: zeeguu/api#680 (adds `/simplify_own_text`). Merge/deploy API first.

## Testing

Not yet exercised on a running instance — opening for review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)