### PR TITLE
Teacher editor: reflect adapted level in CEFR panel + add "Reset to original"

### DIFF
--- a/src/teacher/myTextsPage/AdjustLevelBar.js
+++ b/src/teacher/myTextsPage/AdjustLevelBar.js
@@ -65,6 +65,8 @@ export default function AdjustLevelBar({
   language, // language code, or "default"/"" when not chosen yet
   disabled,
   onAdjusted,
+  adaptedLevel, // the level this text has been adapted to, or null if untouched
+  onReset, // restore the pre-adjust original; enables the Reset button when set
 }) {
   const api = useContext(APIContext);
   const [busyLevel, setBusyLevel] = useState(null);
@@ -72,9 +74,11 @@ export default function AdjustLevelBar({
   const targets = easierLevelsThan(currentLevel);
   const languageMissing = !language || language === "default";
   const contentMissing = !stripHtml(content).trim();
+  const canReset = Boolean(adaptedLevel && onReset);
 
-  // Nothing simpler to offer (e.g. the text is already A1): hide the bar.
-  if (targets.length === 0) return null;
+  // Nothing simpler to offer (e.g. the text is already A1) and no pending
+  // adaptation to undo: hide the bar entirely.
+  if (targets.length === 0 && !canReset) return null;
 
   const barDisabled = disabled || languageMissing || contentMissing || busyLevel !== null;
 
@@ -99,7 +103,9 @@ export default function AdjustLevelBar({
 
   return (
     <Bar>
-      <span className="label">Adjust to level:</span>
+      <span className="label">
+        {adaptedLevel ? `Adapted to ${adaptedLevel}:` : "Adjust to level:"}
+      </span>
       {targets.map((level) => (
         <StyledButton
           key={level}
@@ -112,6 +118,17 @@ export default function AdjustLevelBar({
           {busyLevel === level ? "…" : level}
         </StyledButton>
       ))}
+      {canReset && (
+        <StyledButton
+          $secondary
+          onClick={onReset}
+          $disabled={busyLevel !== null}
+          disabled={busyLevel !== null}
+          style={{ marginLeft: "auto" }}
+        >
+          Reset to original
+        </StyledButton>
+      )}
       {languageMissing && <span className="hint">Choose a language first</span>}
       {!languageMissing && busyLevel && (
         <span className="hint">Adapting to {busyLevel}… this can take a moment</span>

--- a/src/teacher/myTextsPage/CefrAssessmentDisplay.js
+++ b/src/teacher/myTextsPage/CefrAssessmentDisplay.js
@@ -12,7 +12,8 @@ export default function CefrAssessmentDisplay({
   languageCode,
   onOverrideChange,
   onEffectiveLevelChange, // Optional: notified whenever the display (effective) level changes
-  initialAssessments // Optional: pre-loaded assessment data from article
+  initialAssessments, // Optional: pre-loaded assessment data from article
+  adaptedLevel // Optional: level the text was adapted to via the "Adjust to level" bar
 }) {
   const api = useContext(APIContext);
 
@@ -306,30 +307,51 @@ export default function CefrAssessmentDisplay({
           )}
         </div>
 
-        {/* Teacher Override Row */}
-        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-          <span style={{ fontWeight: "bold", minWidth: "120px" }}>Teacher Override:</span>
-          <select
-            value={teacherOverride || ""}
-            onChange={handleOverrideChange}
-            style={{
-              padding: "0.4rem 0.8rem",
-              fontSize: "1em",
-              borderRadius: "4px",
-              border: "1px solid #ccc",
-              fontFamily: "monospace",
-              fontWeight: teacherOverride ? "bold" : "normal",
-              color: teacherOverride ? "#dc2626" : "#333",
-            }}
-          >
-            <option value="">None (use automatic)</option>
-            {CEFR_LEVELS.map((level) => (
-              <option key={level} value={level}>
-                {level}
-              </option>
-            ))}
-          </select>
-        </div>
+        {/* Teacher Override Row — replaced by an "Adapted (LLM)" line once the
+            teacher adapts the text: the adaptation supersedes (and cancels) any
+            manual override, so we don't show both. */}
+        {adaptedLevel ? (
+          <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+            <span style={{ fontWeight: "bold", minWidth: "120px" }}>Adapted (LLM):</span>
+            <span
+              style={{
+                fontFamily: "monospace",
+                fontSize: "1.1em",
+                fontWeight: "bold",
+                color: "#7c3aed",
+              }}
+            >
+              {adaptedLevel}
+            </span>
+            <span style={{ fontSize: "0.85em", color: "#666", fontStyle: "italic" }}>
+              (rewritten to this level — Reset to restore the original)
+            </span>
+          </div>
+        ) : (
+          <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+            <span style={{ fontWeight: "bold", minWidth: "120px" }}>Teacher Override:</span>
+            <select
+              value={teacherOverride || ""}
+              onChange={handleOverrideChange}
+              style={{
+                padding: "0.4rem 0.8rem",
+                fontSize: "1em",
+                borderRadius: "4px",
+                border: "1px solid #ccc",
+                fontFamily: "monospace",
+                fontWeight: teacherOverride ? "bold" : "normal",
+                color: teacherOverride ? "#dc2626" : "#333",
+              }}
+            >
+              <option value="">None (use automatic)</option>
+              {CEFR_LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {level}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Display Level Row - what students will see */}
         <div
@@ -354,7 +376,9 @@ export default function CefrAssessmentDisplay({
             {effectiveLevel || "—"}
           </span>
           <span style={{ fontSize: "0.85em", color: "#666", fontStyle: "italic" }}>
-            {teacherOverride
+            {adaptedLevel
+              ? `(adapted to ${adaptedLevel} via LLM)`
+              : teacherOverride
               ? "(using your override)"
               : "(conservative: max of LLM and ML-1)"
             }

--- a/src/teacher/myTextsPage/EditText.js
+++ b/src/teacher/myTextsPage/EditText.js
@@ -30,6 +30,8 @@ export default function EditText() {
   const [originalCEFRLevel, setOriginalCEFRLevel] = useState(""); // Track original to detect manual changes
   const [cefrAssessments, setCefrAssessments] = useState(null); // Store CEFR assessment data
   const [displayLevel, setDisplayLevel] = useState(null); // Effective level from the CEFR panel (drives Adjust targets)
+  const [adaptedLevel, setAdaptedLevel] = useState(null); // Level the text was adapted to via the bar (null = untouched)
+  const [preAdjustSnapshot, setPreAdjustSnapshot] = useState(null); // Pre-adapt state captured on first adjust, for Reset
   const [cohortList, setCohortList] = useState([]);
   const [showAddToCohortDialog, setShowAddToCohortDialog] = useState(false);
   const [showDeleteTextWarning, setShowDeleteTextWarning] = useState(false);
@@ -188,8 +190,15 @@ export default function EditText() {
 
   // Handle an on-demand "Adjust to level" rewrite from AdjustLevelBar.
   // Non-destructive until saved: we replace the draft content and mark it
-  // changed, so the teacher reviews and hits Save (or Cancel to restore).
+  // changed, so the teacher reviews and hits Save (or Reset/Cancel to restore).
   function handleContentAdjusted(newTitle, newHtmlContent, targetLevel) {
+    // Snapshot the pre-adjust state on the FIRST adjust only, so Reset restores
+    // the teacher's original text (including edits made before adjusting) — not
+    // just the last-saved server copy the way Cancel does.
+    setPreAdjustSnapshot(
+      (prev) => prev || { articleState, cefrAssessments, stateChanged },
+    );
+    setAdaptedLevel(targetLevel);
     setStateChanged(true);
     setArticleState({
       ...articleState,
@@ -198,6 +207,35 @@ export default function EditText() {
       cefr_level: targetLevel,
       assessment_method: "llm_simplified",
     });
+    // Push the adapted level into the CEFR panel as a teacher override so the
+    // Display Level reflects the teacher's choice immediately. Without this the
+    // stale LLM assessment (not recomputed on adjust) dominates the conservative
+    // max, and the panel — and the bar's target list derived from it — keep
+    // showing the old, harder level. Display-only: the level is persisted on
+    // Save via persistAdaptedLevelIfNeeded (resolveCEFR), not here.
+    setCefrAssessments((prev) => ({ ...(prev || {}), teacher: { level: targetLevel } }));
+  }
+
+  // Undo an on-demand adaptation, restoring the pre-adjust original. Distinct
+  // from Cancel, which re-fetches the last-saved server copy and discards every
+  // edit; Reset only unwinds the adaptation, keeping any earlier edits.
+  function handleResetAdjustment() {
+    if (!preAdjustSnapshot) return;
+    setArticleState(preAdjustSnapshot.articleState);
+    // Restore the panel's pre-adjust assessments, clearing the override we
+    // pushed. The panel ignores a null initialAssessments, so when there was
+    // nothing to restore we hand it an explicit teacher-cleared object.
+    setCefrAssessments(preAdjustSnapshot.cefrAssessments || { teacher: null });
+    setStateChanged(preAdjustSnapshot.stateChanged);
+    setPreAdjustSnapshot(null);
+    setAdaptedLevel(null);
+  }
+
+  // Forget the "adapted / can reset" state — used after a Save persists the
+  // adaptation, so the bar returns to its normal "Adjust to level" mode.
+  function clearAdaptationTracking() {
+    setAdaptedLevel(null);
+    setPreAdjustSnapshot(null);
   }
 
   // After saving an adapted text, store its level so students see the right
@@ -240,6 +278,7 @@ export default function EditText() {
         // must not mark an ML-guessed level as teacher-confirmed.
         persistAdaptedLevelIfNeeded(newID);
         setStateChanged(false);
+        clearAdaptationTracking(); // the adaptation is now the saved original
         history.push(`/teacher/texts/editText/${newID}`);
       },
       (error) => {
@@ -271,6 +310,7 @@ export default function EditText() {
         if ((result = "OK")) {
           persistAdaptedLevelIfNeeded(articleID);
           setStateChanged(false);
+          clearAdaptationTracking(); // the adaptation is now the saved original
         } else {
           console.log(result);
         }
@@ -392,6 +432,8 @@ export default function EditText() {
           content={articleState.article_content}
           language={articleState.language_code}
           onAdjusted={handleContentAdjusted}
+          adaptedLevel={adaptedLevel}
+          onReset={handleResetAdjustment}
         />
 
         <EditTextInputFields

--- a/src/teacher/myTextsPage/EditText.js
+++ b/src/teacher/myTextsPage/EditText.js
@@ -423,6 +423,7 @@ export default function EditText() {
           onOverrideChange={handleTeacherOverride}
           onEffectiveLevelChange={setDisplayLevel}
           initialAssessments={cefrAssessments}
+          adaptedLevel={adaptedLevel}
         />
 
         {/* Adjust to level: rewrite the teacher's text to an easier CEFR level on demand */}


### PR DESCRIPTION
Follow-up to the "Adjust to level" bar (#1192).

## Problem

After adapting a text to an easier level (e.g. click **A1**), the CEFR panel and the bar kept showing the old, harder level:

- **Display Level** stayed **B1**, and the bar still offered **A1 / A2** — even though the text was now A1.
- Reported from real use: "I simplified to A1 but still see A2, and the assessments still say B1."

**Root cause:** the LLM assessment is only recomputed via the manual **Recompute LLM** button, so on adapt it stays stale (B1). Display Level is the conservative `max(LLM, ML)`, so the stale LLM dominates even after ML correctly drops to A1 — and the bar derives its targets from Display Level, so it keeps offering levels the text is already at.

## Changes

- **Reflect the adapted level immediately.** On adapt, the target level is pushed into the CEFR panel as a teacher override, so Display Level (and the bar's targets) match the teacher's choice right away. Display-only — persistence on Save is unchanged (still the `resolveCEFR` path).
- **"Reset to original" button.** The pre-adapt state (text, title, assessments, dirty flag) is snapshotted on the *first* adapt; Reset restores it — keeping any edits made *before* adapting. This is distinct from **Cancel**, which re-fetches the last-saved server copy and discards all edits.
- Keep the bar visible while adapted (even at A1, where nothing is easier to offer) so it can host Reset; relabel it **"Adapted to X"**.
- Clear the adapt/reset tracking after a successful Save.

## Files

- `AdjustLevelBar.js` — `adaptedLevel` + `onReset` props, Reset button, visible-while-adapted, relabel.
- `EditText.js` — snapshot/restore, push override into the panel on adapt, clear tracking on save.

## Testing

- `vite build` passes.
- Not yet exercised in the running app — worth a manual pass: adapt B1→A1 (Display Level should show A1, bar shows only Reset), Reset (back to B1, A1/A2 offered again), then Save an adapted text and confirm students see the adapted level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)