### PR TITLE
Activity sessions: only re-render when the timer is actually shown

### DIFF
--- a/src/hooks/useDomActivitySession.js
+++ b/src/hooks/useDomActivitySession.js
@@ -1,12 +1,20 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useIdleTimer } from "react-idle-timer";
 import useSession from "./useSession";
+import useShadowRef from "./useShadowRef";
 
 // DOM activity strategy on top of useSession: 1Hz tick counter, idle
 // detection via useIdleTimer, focus/blur pause/resume. Used by reading,
 // browsing, exercise, and watching sessions. Listening uses
 // useListeningSession instead because audio playing is its own activity
 // model.
+//
+// exposeLiveDuration: mirror the elapsed seconds into React state so a
+// consumer can render a live-ticking timer. OFF by default: the duration
+// lives in a ref (read via getCurrentDuration, uploaded periodically), so
+// sessions that never display it — browsing, watching — don't re-render
+// their whole subtree once a second. Only reading and exercise (which show
+// a DigitalTimer) opt in.
 export default function useDomActivitySession({
   label,
   apiCreate,
@@ -18,12 +26,12 @@ export default function useDomActivitySession({
   uploadInterval = 10,
   autoStart = false,
   startOnActivity = false,
+  exposeLiveDuration = false,
 } = {}) {
-  const [sessionDuration, setSessionDuration] = useState(0);
+  // The ref is the source of truth for elapsed seconds; the reactive state
+  // is only kept in sync when exposeLiveDuration is set (see the 1Hz tick).
   const sessionDurationRef = useRef(0);
-  useEffect(() => {
-    sessionDurationRef.current = sessionDuration;
-  }, [sessionDuration]);
+  const [sessionDuration, setSessionDuration] = useState(0);
 
   const [hasStarted, setHasStarted] = useState(false);
   const hasStartedRef = useRef(false);
@@ -44,6 +52,11 @@ export default function useDomActivitySession({
     apiEnd,
     getCurrentDuration,
   });
+
+  // Shadow-ref so the 1Hz interval can fire uploads without listing `session`
+  // (a fresh object each render) in its deps, which would tear down and rebuild
+  // the interval every render.
+  const uploadRef = useShadowRef(session.upload);
 
   // Wrap the primitive's start with our local "has started" tracking.
   const start = useCallback(() => {
@@ -96,21 +109,20 @@ export default function useDomActivitySession({
     ],
   });
 
-  // 1Hz tick that increments duration while active.
+  // 1Hz tick: advance the ref while active, and fire the periodic upload off
+  // the ref every uploadInterval seconds. The reactive state is updated only
+  // when a consumer needs a live-ticking display (exposeLiveDuration) — so
+  // browsing/watching sessions advance and upload without re-rendering.
   useEffect(() => {
     if (!hasStarted) return;
     const interval = setInterval(() => {
-      if (isTimerActive) setSessionDuration((prev) => prev + 1);
+      if (!isTimerActive) return;
+      sessionDurationRef.current += 1;
+      if (exposeLiveDuration) setSessionDuration(sessionDurationRef.current);
+      if (sessionDurationRef.current % uploadInterval === 0) uploadRef.current?.();
     }, 1000);
     return () => clearInterval(interval);
-  }, [hasStarted, isTimerActive]);
-
-  // Periodic upload at uploadInterval seconds.
-  useEffect(() => {
-    if (hasStarted && isTimerActive && sessionDuration > 0 && sessionDuration % uploadInterval === 0) {
-      session.upload();
-    }
-  }, [sessionDuration, hasStarted, isTimerActive, session, uploadInterval]);
+  }, [hasStarted, isTimerActive, exposeLiveDuration, uploadInterval, uploadRef]);
 
   // Pause on blur, resume on focus.
   useEffect(() => {

--- a/src/hooks/useExerciseSession.js
+++ b/src/hooks/useExerciseSession.js
@@ -24,6 +24,7 @@ export default function useExerciseSession(enabled = true) {
     enabled,
     autoStart: true,
     idleTimeout: 30_000,
+    exposeLiveDuration: true, // ExerciseSession shows a DigitalTimer when the reading-timer pref is on
     apiCreate: (cb) => api.exerciseSessionCreate(cb),
     apiUpdate: (id, dur) => api.exerciseSessionUpdate(id, dur),
     apiEnd: (id, dur) => api.exerciseSessionEnd(id, dur),

--- a/src/hooks/useReadingSession.js
+++ b/src/hooks/useReadingSession.js
@@ -23,6 +23,7 @@ export default function useReadingSession(articleId, readingSource = "web", enab
     enabled: enabled && !!articleId,
     autoStart: true,
     idleTimeout: 30_000,
+    exposeLiveDuration: true, // ArticleReader shows a live DigitalTimer
     apiCreate: (cb) => api.readingSessionCreate(articleId, readingSource, cb),
     apiUpdate: (id, dur) => api.readingSessionUpdate(id, dur),
     apiEnd: (id, dur) => api.readingSessionEnd(id, dur),


### PR DESCRIPTION
## Problem

`useDomActivitySession` ran a **1 Hz `useState` tick** for *every* session type, re-rendering the whole subtree once a second — even for sessions that never display the elapsed time. Browsing sessions wrap the article feed / **"Shared with you" inbox** (`_ArticlesRouter`), and video watching wraps `VideoPlayer`; both repainted the top tabs every second for nothing. Surfaced while diagnosing a load spike on the API box.

## Fix

Make the reactive mirror **opt-in** via a new `exposeLiveDuration` flag:

- The elapsed-seconds counter now lives in a **ref** — already the source of truth for `getCurrentDuration`, periodic uploads, and session end.
- React state is updated **only** when a consumer renders a live `DigitalTimer`. **Reading** and **exercise** opt in (`exposeLiveDuration: true`); **browsing** and **watching** advance and upload with **zero re-renders**.
- Uploads are driven off the ref inside the tick, so the **cadence (every `uploadInterval`s) and the 5 s upload floor are unchanged**. `getCurrentDuration` is actually slightly more accurate now (no one-tick mirror lag).

## Verification

- `vite build` passes clean.
- Manually tested: inbox/feed top tabs no longer re-render every second (React DevTools highlight-updates); `browsing_session_update` still POSTs ~every 10 s; reading and exercise timers still tick; watching still records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)