### PR TITLE
Profile: unify Friend & Classroom leaderboards into one tab with a scope selector

### DIFF
--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -665,6 +665,7 @@ let strings = new LocalizedStrings(
       leaderboardRank: "Rank",
       leaderboardUser: "User",
       selectClassroom: "Select a classroom",
+      leaderboardScopeFriends: "Friends",
 
       //Settings
       //Settings categories
@@ -1789,6 +1790,7 @@ let strings = new LocalizedStrings(
       leaderboardRank: "Placering",
       leaderboardUser: "Bruger",
       selectClassroom: "Vælg en klasse",
+      leaderboardScopeFriends: "Venner",
     },
   },
   {

--- a/src/leaderboards/Leaderboards.js
+++ b/src/leaderboards/Leaderboards.js
@@ -51,7 +51,7 @@ function computeWeeklyPeriod(weekShift = 0) {
 export default function Leaderboards({
   emptyMessage = strings.noLeaderboardData,
   errorMessage = strings.couldNotLoadLeaderboard,
-  scope,
+  isStudent = false,
   leaderboardTypes = LEADERBOARD_TYPES,
   navigationHandler,
 }) {
@@ -64,7 +64,8 @@ export default function Leaderboards({
   const [selectedLeaderboardKey, setSelectedLeaderboardKey] = useState(() => leaderboardTypes[0]?.key || "default");
   const setTabRef = useScrollActiveIntoView(selectedLeaderboardKey);
   const [cohorts, setCohorts] = useState([]);
-  const [selectedCohort, setSelectedCohort] = useState(null);
+  // "friends" (LEADERBOARD_SCOPES.FRIENDS) or a cohort id (as a string, since it comes from a <select>)
+  const [selectedScope, setSelectedScope] = useState(LEADERBOARD_SCOPES.FRIENDS);
   const [leaderboardData, setLeaderboardData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -73,6 +74,12 @@ export default function Leaderboards({
     () => leaderboardTypes.find((item) => item.key === selectedLeaderboardKey) || leaderboardTypes[0],
     [leaderboardTypes, selectedLeaderboardKey],
   );
+
+  const scopeOptions = useMemo(() => {
+    const options = [{ value: LEADERBOARD_SCOPES.FRIENDS, label: strings.leaderboardScopeFriends }];
+    cohorts.forEach((cohort) => options.push({ value: String(cohort.id), label: cohort.name }));
+    return options;
+  }, [cohorts]);
 
   function handleData(data) {
     if (!Array.isArray(data)) {
@@ -103,28 +110,21 @@ export default function Leaderboards({
       setLeaderboardData([]);
       setIsLoading(false);
     };
-    if (scope === LEADERBOARD_SCOPES.FRIENDS) {
+    if (selectedScope === LEADERBOARD_SCOPES.FRIENDS) {
       api.getFriendsLeaderboard(selectedLeaderboardKey, period.fromStr, period.toStr, handleData, handleLoadError);
-    } else if (scope === LEADERBOARD_SCOPES.COHORT) {
-      if (!selectedCohort) {
-        setLeaderboardData([]);
-        setIsLoading(false);
-        return;
-      }
-      api.getCohortLeaderboard(selectedCohort, selectedLeaderboardKey, period.fromStr, period.toStr, handleData, handleLoadError);
+    } else {
+      api.getCohortLeaderboard(Number(selectedScope), selectedLeaderboardKey, period.fromStr, period.toStr, handleData, handleLoadError);
     }
-  }, [api, selectedLeaderboardKey, period.fromStr, period.toStr, scope, selectedCohort]);
+  }, [api, selectedLeaderboardKey, period.fromStr, period.toStr, selectedScope]);
 
   useEffect(() => {
-    if (scope === LEADERBOARD_SCOPES.COHORT) {
-      api.getStudent((data) => {
-        if (data?.cohorts?.length) {
-          setCohorts(data.cohorts);
-          setSelectedCohort(data.cohorts[0].id);
-        }
-      });
-    }
-  }, [api, scope]);
+    if (!isStudent) return;
+    api.getStudent((data) => {
+      if (data?.cohorts?.length) {
+        setCohorts(data.cohorts);
+      }
+    });
+  }, [api, isStudent]);
 
   function assignRanks(data) {
     if (!Array.isArray(data)) return [];
@@ -169,6 +169,20 @@ export default function Leaderboards({
 
   return (
     <s.Container>
+      {cohorts.length > 0 && (
+        <s.ScopeSelectorWrapper>
+          <Selector
+            id="leaderboard-scope-select"
+            options={scopeOptions}
+            selectedValue={selectedScope}
+            onChange={(e) => setSelectedScope(e.target.value)}
+            optionLabel={(option) => option.label}
+            optionValue={(option) => option.value}
+            showPlaceholder={false}
+          />
+        </s.ScopeSelectorWrapper>
+      )}
+
       <div
         style={{
           display: "flex",
@@ -223,20 +237,6 @@ export default function Leaderboards({
             );
           })}
         </s.TabsWrapper>
-      )}
-
-      {scope === LEADERBOARD_SCOPES.COHORT && cohorts.length > 1 && (
-        <div style={{ marginBottom: "1rem", width: "fit-content" }}>
-          <Selector
-            id="cohort-select"
-            options={cohorts.map((c) => ({ value: c.id, label: c.name }))}
-            selectedValue={selectedCohort}
-            onChange={(e) => setSelectedCohort(Number(e.target.value))}
-            optionLabel={(option) => option.label}
-            optionValue={(option) => option.value}
-            placeholder={strings.selectClassroom}
-          />
-        </div>
       )}
 
       {isLoading && <p>{strings.loadingLeaderboard}</p>}

--- a/src/leaderboards/Leaderboards.sc.js
+++ b/src/leaderboards/Leaderboards.sc.js
@@ -27,6 +27,12 @@ export const Container = styled.section`
   max-width: 760px;
 `;
 
+export const ScopeSelectorWrapper = styled.div`
+  width: fit-content;
+  min-width: 200px;
+  margin-bottom: 1.25em;
+`;
+
 export const PeriodContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/profile/UserProfile.js
+++ b/src/profile/UserProfile.js
@@ -13,7 +13,6 @@ import { BadgeCounterContext } from "../contexts/BadgeCounterContext";
 import LoadingAnimation from "../components/LoadingAnimation";
 import Button from "../pages/_pages_shared/Button.sc";
 import Leaderboards from "../leaderboards/Leaderboards";
-import { LEADERBOARD_SCOPES } from "../leaderboards/leaderboardTypes";
 import useFriendActions from "../hooks/useFriendActions";
 import { ProfileHeaderCard } from "./ProfileHeaderCard";
 import { ProfileTabs } from "./ProfileTabs";
@@ -166,12 +165,7 @@ export default function UserProfile() {
       key: "friends",
       label: `Friends${isOwnProfile && hasFriendRequestNotification ? ` (${friendRequestCount})` : ""}`,
     },
-    ...(isOwnProfile
-      ? [
-          { key: "friendLeaderboards", label: "Friend Leaderboards" },
-          ...(profileData?.is_student ? [{ key: "cohortLeaderboards", label: "Classroom Leaderboards" }] : []),
-        ]
-      : []),
+    ...(isOwnProfile ? [{ key: "leaderboards", label: "Leaderboards" }] : []),
   ];
 
   const renderTabContent = () => {
@@ -183,12 +177,8 @@ export default function UserProfile() {
       return <Friends friendUsername={friendUsername} navigationHandler={handleUserProfileNavigation} />;
     }
 
-    if (activeTab === "friendLeaderboards") {
-      return <Leaderboards navigationHandler={handleUserProfileNavigation} scope={LEADERBOARD_SCOPES.FRIENDS} />;
-    }
-
-    if (activeTab === "cohortLeaderboards") {
-      return <Leaderboards navigationHandler={handleUserProfileNavigation} scope={LEADERBOARD_SCOPES.COHORT} />;
+    if (activeTab === "leaderboards") {
+      return <Leaderboards navigationHandler={handleUserProfileNavigation} isStudent={profileData?.is_student} />;
     }
 
     return null;


### PR DESCRIPTION
## What

The **Friend Leaderboards** and **Classroom Leaderboards** profile tabs rendered an *identical* table — same metric sub-tabs (Reading Time / Read Articles / Correct Exercises / Listening Time), same week navigation, same ranking — differing only in whose numbers were listed. They were already one shared `Leaderboards` component parameterized by a `scope` prop.

This collapses the two tabs into a single **Leaderboards** tab and moves the choice into a **scope dropdown** at the top of the view:

- **Not a student / no classroom** → no dropdown, just the Friends leaderboard.
- **Student** → dropdown with **Friends** (default) + one entry per classroom they belong to.

Switching scope swaps the list while keeping the selected metric and week. Also declutters the profile tab bar, which was wrapping onto two lines.

## How

- `UserProfile.js`: two leaderboard tabs → one `leaderboards` tab; passes `isStudent` down instead of a fixed `scope`.
- `Leaderboards.js`: internal `selectedScope` state (`"friends"` or a cohort id); fetches the student's cohorts when `isStudent`; the previously multi-cohort-only picker becomes the top-level Friends+classrooms scope selector.
- `Leaderboards.sc.js`: `ScopeSelectorWrapper` style.
- `i18n/definitions.js`: `leaderboardScopeFriends` label (EN "Friends" / DA "Venner").

Pure front-end change — the two endpoints (`friends_leaderboard` / `cohort_leaderboard/{id}`) are just selected by the chosen scope. `vite build` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)