### PR TITLE
Settings: Email notifications page (share-email opt-out)

### DIFF
--- a/src/pages/Settings/Pages/NotificationSettings.js
+++ b/src/pages/Settings/Pages/NotificationSettings.js
@@ -1,0 +1,64 @@
+import { useContext, useEffect, useState } from "react";
+import CardPage from "../../_pages_shared/CardPage";
+import Main from "../../_pages_shared/Main.sc";
+import SettingsPageHeader from "../SharedComponents/SettingsPageHeader";
+import { setTitle } from "../../../assorted/setTitle";
+import { APIContext } from "../../../contexts/APIContext";
+import { SectionContainer, SectionHeading } from "./FeedPreferences.sc";
+import { FormControlLabel, Checkbox } from "@mui/material";
+
+export default function NotificationSettings() {
+  const api = useContext(APIContext);
+  const [emailOnArticleShared, setEmailOnArticleShared] = useState(true);
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
+
+  useEffect(() => {
+    setTitle("Email Notifications");
+  }, []);
+
+  useEffect(() => {
+    api.getUserPreferences().then((preferences) => {
+      // Default ON (opt-out): only an explicit "false" turns it off.
+      setEmailOnArticleShared(preferences.email_on_article_shared !== "false");
+      setPreferencesLoaded(true);
+    });
+  }, [api]);
+
+  function handleToggleEmailOnArticleShared(e) {
+    const newValue = e.target.checked;
+    setEmailOnArticleShared(newValue);
+    api.saveUserPreferences(
+      { email_on_article_shared: newValue ? "true" : "false" },
+      () => {},
+      () => setEmailOnArticleShared(!newValue), // revert on error
+    );
+  }
+
+  return (
+    <CardPage layoutVariant={"card-under-menu"} isTransparent reducedPadding>
+      <SettingsPageHeader title="Email Notifications" />
+      <Main>
+        <SectionContainer>
+          <SectionHeading>Email notifications</SectionHeading>
+          <div style={{ marginTop: "0", marginBottom: "0" }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={emailOnArticleShared}
+                  onChange={handleToggleEmailOnArticleShared}
+                  disabled={!preferencesLoaded}
+                />
+              }
+              label="Email me when a friend shares an article with me"
+              sx={{ "& .MuiTypography-root": { fontFamily: "inherit" } }}
+            />
+            <div style={{ fontSize: "0.9em", color: "var(--text-secondary)", marginLeft: "32px", marginTop: "0.25em" }}>
+              You'll get at most one email while you have unread shares — further shares wait in your inbox until you
+              open it.
+            </div>
+          </div>
+        </SectionContainer>
+      </Main>
+    </CardPage>
+  );
+}

--- a/src/pages/Settings/Pages/Settings.js
+++ b/src/pages/Settings/Pages/Settings.js
@@ -62,6 +62,12 @@ export default function Settings() {
         <SettingsItem path={"/account_settings/interests"}>{strings.feedPreferences}</SettingsItem>
       </ListOfSettingsItems>
 
+      {!isAnonymous && (
+        <ListOfSettingsItems header={"Notifications"}>
+          <SettingsItem path={"/account_settings/notifications"}>Email notifications</SettingsItem>
+        </ListOfSettingsItems>
+      )}
+
       <ListOfSettingsItems header={strings.exercises}>
         <SettingsItem path={"/account_settings/exercise_types"}>Audio & Pronunciation</SettingsItem>
         <SettingsItem path={"/account_settings/exercise_scheduling"}>Scheduling</SettingsItem>

--- a/src/pages/Settings/_SettingsRouter.js
+++ b/src/pages/Settings/_SettingsRouter.js
@@ -9,6 +9,7 @@ import MyClassrooms from "./Pages/MyClassrooms/MyClassrooms";
 import DeleteAccount from "./Pages/DeleteAccount";
 import ExerciseSchedulingPreferences from "./Pages/ExerciseSchedulingPreferences";
 import ActivityTimer from "./Pages/ActivityTimer";
+import NotificationSettings from "./Pages/NotificationSettings";
 import Developer from "./Pages/Developer";
 
 export default function SettingsRouter({ setUser }) {
@@ -29,6 +30,8 @@ export default function SettingsRouter({ setUser }) {
       <PrivateRoute path="/account_settings/my_classrooms" component={MyClassrooms} />
 
       <PrivateRoute path="/account_settings/interests" component={FeedPreferences} />
+
+      <PrivateRoute path="/account_settings/notifications" component={NotificationSettings} />
 
       <PrivateRoute path="/account_settings/delete_account" component={DeleteAccount} />
 


### PR DESCRIPTION
Adds **Settings → Notifications → Email notifications** with a toggle: *"Email me when a friend shares an article with me"* (default on).

Round-trips through the existing `getUserPreferences` / `saveUserPreferences` (key `email_on_article_shared`), optimistic with revert-on-error — mirrors `FeedPreferences`. New page + route + a "Notifications" menu section (hidden for anonymous accounts).

Pairs with **api #685**, which sends the share email and reads this preference (and is itself gated by `SEND_NOTIFICATION_EMAILS`).

`vite build` passes. Not click-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)