### PR TITLE
Reader: show "Simplified to <level>" on simplified articles

### DIFF
--- a/src/components/ArticleStatInfo.js
+++ b/src/components/ArticleStatInfo.js
@@ -7,6 +7,11 @@ export default function ArticleStatInfo({ articleInfo }) {
   const sourceUrl = articleInfo.parent_url || articleInfo.url;
   const sourceDomain = sourceUrl ? getDomainName(sourceUrl) : null;
 
+  // The *target* level the article was simplified to (reliable, unlike the
+  // suppressed effective CEFR level). Only sent by the API for simplified
+  // articles; may be absent for older ones, so the tag degrades to "Simplified".
+  const targetLevel = articleInfo.target_cefr_level;
+
   // User-facing CEFR level is suppressed (see feedback_cefr_data_unreliable);
   // teacher-only assessments still surface for classifier debugging.
   const assessments = articleInfo.cefr_assessments;
@@ -14,7 +19,9 @@ export default function ArticleStatInfo({ articleInfo }) {
 
   return (
     <MetaStrip>
-      {isSimplified && <MetaTag>Simplified</MetaTag>}
+      {isSimplified && (
+        <MetaTag>{targetLevel ? `Simplified to ${targetLevel}` : "Simplified"}</MetaTag>
+      )}
       {sourceDomain && (
         <MetaItem>
           {/* "Original:" prefix only when the user is reading a simplified


### PR DESCRIPTION
## What

The `Simplified` badge on simplified articles now shows the target level — `Simplified to B1` — using the new `target_cefr_level` field. Degrades to plain `Simplified` when the level is absent (older articles / not yet sent).

## Depends on

zeeguu/api#686 (sends `target_cefr_level`). **Deploy that first** — until then the badge just shows `Simplified`, no breakage.

## Why the *target* level (not the measured one)

The measured/effective level is deliberately hidden from users because the classifier is unreliable (`feedback_cefr_data_unreliable`). The target is what the article was intentionally simplified to — reliable, so safe to show.

## Test plan

- [ ] Simplified article → `Simplified to <level>`
- [ ] Simplified article with no level → plain `Simplified`
- [ ] Non-simplified article → no badge, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)