### PR TITLE
Reader: skip junk "Publiceret D." author fragments in byline

### DIFF
--- a/src/reader/ArticleAuthors.js
+++ b/src/reader/ArticleAuthors.js
@@ -1,9 +1,19 @@
 import * as s from "./ArticleReader.sc";
 
-export default function ArticleAuthors({ articleInfo }) {
-  const firstAuthor = articleInfo.authors.split(",")[0].trim();
+// Scrapers sometimes store a "published on <date>" fragment as the first
+// author (e.g. "Publiceret D.", "Publié Le Mai À"). The backend now strips
+// these at ingestion, but older articles still carry them, so we also skip
+// them here. Matches a publish/update verb at the start of a byline part.
+const JUNK_AUTHOR_PREFIX =
+  /^(publiceret|publicerad|publisert|publié|publie|published|veröffentlicht|pubblicato|publicado|gepubliceerd|julkaistu|opdateret|uppdaterad|oppdatert|updated|aktualisiert)\b/i;
 
-  if (!firstAuthor || firstAuthor === "") return <></>;
+export default function ArticleAuthors({ articleInfo }) {
+  const firstAuthor = (articleInfo.authors || "")
+    .split(",")
+    .map((a) => a.replace(/\s+/g, " ").trim())
+    .find((a) => a && !JUNK_AUTHOR_PREFIX.test(a));
+
+  if (!firstAuthor) return <></>;
   return (
     <s.AuthorLinksContainer>
       <div>{firstAuthor}</div>


### PR DESCRIPTION
## What

`ArticleAuthors` picked the first comma-split token blindly, so scraped *"published on <date>"* fragments (`Publiceret D.`, `Publié Le Mai À`, …) rendered as the article's author. It now picks the first **non-junk** author, matching a publish/update verb at the start of a byline part.

## Why here too

The backend (zeeguu/api#687) now strips these at ingestion and ships a backfill for the ~30k existing rows — but this is the safety-net that fixes the display immediately for every already-stored article, and covers any edge cases the backfill misses.

## Test plan

- [ ] Danish illvid article (`Publiceret D., Søren…`) → shows `Søren…`, not the date
- [ ] French article (`Publié Le …`) with no real author → shows no byline
- [ ] Normal article → author unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)