### PR TITLE
Reader: label plain-article source as "Source:"

### DIFF
--- a/src/components/ArticleStatInfo.js
+++ b/src/components/ArticleStatInfo.js
@@ -24,11 +24,11 @@ export default function ArticleStatInfo({ articleInfo }) {
       )}
       {sourceDomain && (
         <MetaItem>
-          {/* "Original:" prefix only when the user is reading a simplified
-              version — without it the link reads as the source of the text
-              on screen, which would mislead. For non-simplified articles
-              the domain IS what they're reading. */}
-          {isSimplified && <>Original:&nbsp;</>}
+          {/* Label the source link so the bare domain reads as metadata rather
+              than a stray link. "Original:" for simplified articles (the text on
+              screen is adapted; the real thing is here); "Source:" otherwise
+              (the domain IS what they're reading, so "Original" would misread). */}
+          {isSimplified ? <>Original:&nbsp;</> : <>Source:&nbsp;</>}
           <MetaLink href={sourceUrl} target="_blank" rel="noopener noreferrer">
             {sourceDomain}
             <span aria-hidden="true" style={{ marginLeft: '0.2em' }}>↗</span>


### PR DESCRIPTION
On a non-simplified article the source line was a bare, unlabeled `illvid.dk ↗` that reads as a stray link. This adds a muted `Source:` prefix so it reads as metadata — mirroring the `Original:` prefix already shown on simplified articles.

| Article | Line |
|---|---|
| Simplified | `Simplified to A1 · Original: politiken.dk ↗` |
| Plain | `Source: illvid.dk ↗` |

`Original:` stays for simplified articles (the on-screen text is adapted; the link is the real source); plain articles get `Source:` (the domain *is* what you're reading, so "Original" would misread).

One-line change in `ArticleStatInfo.js`; the prefix renders in the same muted style as `Original:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)