### PR TITLE
Friend-share: shared-by header + open the recipient's derivative

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,16 @@
                     android:pathPrefix="/shared-lesson" />
             </intent-filter>
 
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="zeeguu.org"
+                    android:pathPrefix="/articles/shared" />
+            </intent-filter>
+
             <!-- Share Sheet: receive shared URLs/text from other apps -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -7,7 +7,8 @@
         "paths": [
           "/read/article*",
           "/exercise/*",
-          "/shared-lesson/*"
+          "/shared-lesson/*",
+          "/articles/shared*"
         ]
       }
     ]

--- a/src/articles/SharedArticleRow.js
+++ b/src/articles/SharedArticleRow.js
@@ -31,13 +31,19 @@ export default function SharedArticleRow({ share }) {
 
   function handleOpen() {
     api.markSharedArticleRead(share.id);
-    // Carry who shared it (and whether it was translated) into the reader so
-    // the header can say "Simplified by <name> to your level". Router state, so
-    // it stays off the URL; a refresh falls back to the plain simplified header.
+    // Carry who shared it (and whether it was translated) into the reader so the
+    // header can say "Simplified by <name> to your level". Only when the
+    // personalized derivative actually exists (delivery_ready) — otherwise the
+    // row opens the un-adapted canonical article, and claiming "simplified to
+    // your level" would be a lie. Router state, so it stays off the URL; a
+    // refresh falls back to the article's own header.
+    const shareState = share.delivery_ready
+      ? { sharedByName: share.from_user_name, sharedTranslated: !!share.translated }
+      : undefined;
     history.push({
       pathname: "/read/article",
       search: `?id=${article.id}`,
-      state: { sharedByName: share.from_user_name, sharedTranslated: !!share.translated },
+      state: shareState,
     });
   }
 

--- a/src/articles/SharedArticleRow.js
+++ b/src/articles/SharedArticleRow.js
@@ -78,7 +78,6 @@ export default function SharedArticleRow({ share }) {
 
   return (
     <Row $read={share.read} onClick={handleOpen} onKeyDown={handleKeyDown} role="button" tabIndex={0}>
-      {unread && <UnreadDot aria-label="Unread" />}
       <s.ThumbnailWrap>
         {article.img_url ? (
           <s.Thumbnail src={article.img_url} alt="" loading="lazy" decoding="async" />
@@ -89,7 +88,10 @@ export default function SharedArticleRow({ share }) {
         )}
       </s.ThumbnailWrap>
       <s.Content>
-        <Title $unread={unread}>{article.title || "Untitled article"}</Title>
+        <Title $unread={unread}>
+          {article.title || "Untitled article"}
+          {unread && <UnreadDot aria-label="Unread" />}
+        </Title>
         <MetaStrip>
           <MetaTag>
             Shared by{" "}

--- a/src/articles/SharedArticleRow.js
+++ b/src/articles/SharedArticleRow.js
@@ -31,7 +31,14 @@ export default function SharedArticleRow({ share }) {
 
   function handleOpen() {
     api.markSharedArticleRead(share.id);
-    history.push(`/read/article?id=${article.id}`);
+    // Carry who shared it (and whether it was translated) into the reader so
+    // the header can say "Simplified by <name> to your level". Router state, so
+    // it stays off the URL; a refresh falls back to the plain simplified header.
+    history.push({
+      pathname: "/read/article",
+      search: `?id=${article.id}`,
+      state: { sharedByName: share.from_user_name, sharedTranslated: !!share.translated },
+    });
   }
 
   function handleKeyDown(e) {

--- a/src/articles/SharedArticleRow.js
+++ b/src/articles/SharedArticleRow.js
@@ -77,7 +77,7 @@ export default function SharedArticleRow({ share }) {
   }
 
   return (
-    <Row $read={share.read} onClick={handleOpen} onKeyDown={handleKeyDown} role="button" tabIndex={0}>
+    <Row onClick={handleOpen} onKeyDown={handleKeyDown} role="button" tabIndex={0}>
       <s.ThumbnailWrap>
         {article.img_url ? (
           <s.Thumbnail src={article.img_url} alt="" loading="lazy" decoding="async" />

--- a/src/articles/SharedArticleRow.js
+++ b/src/articles/SharedArticleRow.js
@@ -31,14 +31,15 @@ export default function SharedArticleRow({ share }) {
 
   function handleOpen() {
     api.markSharedArticleRead(share.id);
-    // Carry who shared it (and whether it was translated) into the reader so the
-    // header can say "Simplified by <name> to your level". Only when the
-    // personalized derivative actually exists (delivery_ready) — otherwise the
-    // row opens the un-adapted canonical article, and claiming "simplified to
-    // your level" would be a lie. Router state, so it stays off the URL; a
-    // refresh falls back to the article's own header.
+    // Carry who shared it into the reader so the header can attribute it
+    // ("… by <name> to your level"). The verb (Simplified vs Translated &
+    // simplified) comes from the article's own is_translated/is_simplified, not
+    // from here. Only when the personalized derivative actually exists
+    // (delivery_ready) — otherwise the row opens the un-adapted canonical
+    // article and attributing it would mislead. Router state, so it stays off
+    // the URL; a refresh falls back to the article's own header.
     const shareState = share.delivery_ready
-      ? { sharedByName: share.from_user_name, sharedTranslated: !!share.translated }
+      ? { sharedByName: share.from_user_name }
       : undefined;
     history.push({
       pathname: "/read/article",

--- a/src/articles/SharedArticleRow.sc.js
+++ b/src/articles/SharedArticleRow.sc.js
@@ -2,10 +2,10 @@ import styled from "styled-components";
 import { orange500 } from "../components/colors";
 import { Row as SavedRow, Title as SavedTitle } from "./SavedArticleRow.sc";
 
-// Read rows recede so the unread ones pop — the email-inbox convention.
+// Unread is signalled by the bold title + trailing dot alone — read rows stay
+// at full strength (no dimming), so the list doesn't look half-disabled.
 export const Row = styled(SavedRow)`
   cursor: pointer;
-  opacity: ${(p) => (p.$read ? 0.6 : 1)};
 `;
 
 // Bold title = unread. The strongest, most familiar read/unread cue.
@@ -13,16 +13,18 @@ export const Title = styled(SavedTitle)`
   ${(p) => p.$unread && "font-weight: 700;"}
 `;
 
-// Unread marker: a dot pinned to the top-right, in the same column as the ×
-// (which is itself absolutely positioned). Keeping it out of the flex flow means
-// it doesn't shift the row, so thumbnails stay aligned with the Saves list.
-// Same orange as the tab badge, so "orange = unread" reads as one language.
+// Unread marker: a small dot trailing the title, inline on the title's
+// baseline. Reads as "this one's new" right where the eye already is, instead
+// of floating in the top-right corner. Same orange as the tab badge, so
+// "orange = unread" is one visual language. flex-shrink:0 keeps it round if the
+// title is long; the leading margin gives it a little breathing room.
 export const UnreadDot = styled.span`
-  position: absolute;
-  top: 0.9em;
-  right: 0.8em;
-  width: 9px;
-  height: 9px;
+  display: inline-block;
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  margin-left: 0.45em;
   border-radius: 50%;
   background: ${orange500};
+  vertical-align: middle;
 `;

--- a/src/articles/SharedInbox.js
+++ b/src/articles/SharedInbox.js
@@ -7,7 +7,12 @@ import * as s from "../components/TopMessage.sc";
 // saved-article row styling. Lives as its own tab in the reading area; the list
 // comes from SharedArticlesContext (refetched on navigation).
 export default function SharedInbox() {
-  const { sharedArticles } = useContext(SharedArticlesContext);
+  const { sharedArticles, sharedArticlesLoading } = useContext(SharedArticlesContext);
+
+  // Render nothing until we're actually loaded — otherwise the empty-state
+  // message flashes for a beat before the shares (or the real empty state)
+  // resolve.
+  if (sharedArticlesLoading) return null;
 
   if (!sharedArticles || sharedArticles.length === 0) {
     return (

--- a/src/components/ArticleStatInfo.js
+++ b/src/components/ArticleStatInfo.js
@@ -17,24 +17,28 @@ export default function ArticleStatInfo({ articleInfo, shareContext }) {
   const assessments = articleInfo.cefr_assessments;
   const hasAssessments = assessments && (assessments.llm?.level || assessments.ml?.level);
 
+  // Cross-language derivatives are translated AND adapted to a level; same-
+  // language ones are just simplified. The verb comes from the article's own
+  // flags — correct for the user's own translated copies, not only shares.
+  const isTranslated = articleInfo.is_translated;
+  const adaptVerb = isTranslated ? "Translated & simplified" : "Simplified";
+
   // Opened from a friend's share (SharedArticleRow → router state): credit the
-  // *share*, not authorship, and drop the CEFR letter ("to your level"). Verb
-  // flexes same- vs cross-language.
+  // *share*, not authorship, and drop the CEFR letter ("to your level").
   const sharedByName = shareContext?.sharedByName;
-  const sharedVerb = shareContext?.sharedTranslated ? "Translated & simplified" : "Simplified";
 
   let levelTag = null;
   if (sharedByName) {
-    levelTag = <MetaTag>{`${sharedVerb} by ${sharedByName} to your level`}</MetaTag>;
-  } else if (isSimplified) {
-    levelTag = <MetaTag>{targetLevel ? `Simplified to ${targetLevel}` : "Simplified"}</MetaTag>;
+    levelTag = <MetaTag>{`${adaptVerb} by ${sharedByName} to your level`}</MetaTag>;
+  } else if (isSimplified || isTranslated) {
+    levelTag = <MetaTag>{targetLevel ? `${adaptVerb} to ${targetLevel}` : adaptVerb}</MetaTag>;
   }
 
-  // Source-link label: "See original at" for a share, "Original:" for the
-  // user's own simplified copy, "Source:" for a plain article.
+  // Source-link label: "See original at" for a share, "Original:" for an
+  // adapted copy (simplified or translated), "Source:" for a plain article.
   let sourcePrefix = <>Source:&nbsp;</>;
   if (sharedByName) sourcePrefix = <>See original at&nbsp;</>;
-  else if (isSimplified) sourcePrefix = <>Original:&nbsp;</>;
+  else if (isSimplified || isTranslated) sourcePrefix = <>Original:&nbsp;</>;
 
   return (
     <MetaStrip>

--- a/src/components/ArticleStatInfo.js
+++ b/src/components/ArticleStatInfo.js
@@ -2,7 +2,7 @@ import { MetaStrip, MetaItem, MetaLink, MetaTag } from "./MetaStrip.sc";
 import getDomainName from "../utils/misc/getDomainName";
 import { isSimplifiedArticle } from "../utils/misc/articleHelpers";
 
-export default function ArticleStatInfo({ articleInfo }) {
+export default function ArticleStatInfo({ articleInfo, shareContext }) {
   const isSimplified = isSimplifiedArticle(articleInfo);
   const sourceUrl = articleInfo.parent_url || articleInfo.url;
   const sourceDomain = sourceUrl ? getDomainName(sourceUrl) : null;
@@ -17,18 +17,31 @@ export default function ArticleStatInfo({ articleInfo }) {
   const assessments = articleInfo.cefr_assessments;
   const hasAssessments = assessments && (assessments.llm?.level || assessments.ml?.level);
 
+  // Opened from a friend's share (SharedArticleRow → router state): credit the
+  // *share*, not authorship, and drop the CEFR letter ("to your level"). Verb
+  // flexes same- vs cross-language.
+  const sharedByName = shareContext?.sharedByName;
+  const sharedVerb = shareContext?.sharedTranslated ? "Translated & simplified" : "Simplified";
+
+  let levelTag = null;
+  if (sharedByName) {
+    levelTag = <MetaTag>{`${sharedVerb} by ${sharedByName} to your level`}</MetaTag>;
+  } else if (isSimplified) {
+    levelTag = <MetaTag>{targetLevel ? `Simplified to ${targetLevel}` : "Simplified"}</MetaTag>;
+  }
+
+  // Source-link label: "See original at" for a share, "Original:" for the
+  // user's own simplified copy, "Source:" for a plain article.
+  let sourcePrefix = <>Source:&nbsp;</>;
+  if (sharedByName) sourcePrefix = <>See original at&nbsp;</>;
+  else if (isSimplified) sourcePrefix = <>Original:&nbsp;</>;
+
   return (
     <MetaStrip>
-      {isSimplified && (
-        <MetaTag>{targetLevel ? `Simplified to ${targetLevel}` : "Simplified"}</MetaTag>
-      )}
+      {levelTag}
       {sourceDomain && (
         <MetaItem>
-          {/* Label the source link so the bare domain reads as metadata rather
-              than a stray link. "Original:" for simplified articles (the text on
-              screen is adapted; the real thing is here); "Source:" otherwise
-              (the domain IS what they're reading, so "Original" would misread). */}
-          {isSimplified ? <>Original:&nbsp;</> : <>Source:&nbsp;</>}
+          {sourcePrefix}
           <MetaLink href={sourceUrl} target="_blank" rel="noopener noreferrer">
             {sourceDomain}
             <span aria-hidden="true" style={{ marginLeft: '0.2em' }}>↗</span>

--- a/src/contexts/SharedArticlesContext.js
+++ b/src/contexts/SharedArticlesContext.js
@@ -4,5 +4,6 @@ export const SharedArticlesContext = createContext({
   sharedArticles: [],
   sharedUnreadCount: 0,
   hasSharedNotification: false,
+  sharedArticlesLoading: true,
   refreshSharedArticles: () => {},
 });

--- a/src/hooks/useSharedArticlesNotification.js
+++ b/src/hooks/useSharedArticlesNotification.js
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom/cjs/react-router-dom";
 import { APIContext } from "../contexts/APIContext";
+import { UserContext } from "../contexts/UserContext";
 import Feature from "../features/Feature";
 
 // Drives the "Shared with you" inbox + its unread badge. Mirrors
@@ -8,8 +9,21 @@ import Feature from "../features/Feature";
 export default function useSharedArticlesNotification() {
   const path = useLocation().pathname;
   const api = useContext(APIContext);
+  const { userDetails } = useContext(UserContext);
+  const activeLanguage = userDetails?.learned_language;
 
-  const [sharedArticles, setSharedArticles] = useState([]);
+  const [allShares, setAllShares] = useState([]);
+
+  // A share is a per-language item: the API stamps every share with a
+  // delivery_language (the recipient's study language for it), so a Danish
+  // share doesn't surface while you're studying German. Show only shares for
+  // the language currently being studied; the badge counts the same filtered
+  // set, so it never disagrees with the list. (Legacy rows created before
+  // routing have no delivery_language and simply don't appear — re-share to
+  // route them.)
+  const sharedArticles = allShares.filter(
+    (s) => s.delivery_language === activeLanguage,
+  );
   const sharedUnreadCount = sharedArticles.filter((s) => !s.read).length;
   const hasSharedNotification = sharedUnreadCount > 0;
 
@@ -21,7 +35,7 @@ export default function useSharedArticlesNotification() {
 
   function refreshSharedArticles() {
     api.getArticlesSharedWithMe((data) => {
-      setSharedArticles(data || []);
+      setAllShares(data || []);
     });
   }
 

--- a/src/hooks/useSharedArticlesNotification.js
+++ b/src/hooks/useSharedArticlesNotification.js
@@ -13,6 +13,7 @@ export default function useSharedArticlesNotification() {
   const activeLanguage = userDetails?.learned_language;
 
   const [allShares, setAllShares] = useState([]);
+  const [loaded, setLoaded] = useState(false);
 
   // A share is a per-language item: the API stamps every share with a
   // delivery_language (the recipient's study language for it), so a Danish
@@ -27,8 +28,16 @@ export default function useSharedArticlesNotification() {
   const sharedUnreadCount = sharedArticles.filter((s) => !s.read).length;
   const hasSharedNotification = sharedUnreadCount > 0;
 
+  // Loading until the first fetch is back AND the active language is known, so
+  // the inbox never flashes its "nothing shared yet" empty state before it can
+  // actually filter.
+  const sharedArticlesLoading = !loaded || activeLanguage === undefined;
+
   useEffect(() => {
-    if (!Feature.has_gamification()) return;
+    if (!Feature.has_gamification()) {
+      setLoaded(true);
+      return;
+    }
     refreshSharedArticles();
     // eslint-disable-next-line
   }, [path]);
@@ -36,6 +45,7 @@ export default function useSharedArticlesNotification() {
   function refreshSharedArticles() {
     api.getArticlesSharedWithMe((data) => {
       setAllShares(data || []);
+      setLoaded(true);
     });
   }
 
@@ -43,6 +53,7 @@ export default function useSharedArticlesNotification() {
     sharedArticles,
     sharedUnreadCount,
     hasSharedNotification,
+    sharedArticlesLoading,
     refreshSharedArticles,
   };
 }

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -52,6 +52,9 @@ export function onBlur(api, articleID, source) {
 
 export default function ArticleReader({ teacherArticleID }) {
   const api = useContext(APIContext);
+  // Share context, when the reader was opened from the "Shared with you" inbox
+  // (SharedArticleRow passes it via router state). Absent on any other entry.
+  const shareContext = useLocation().state;
   let articleID = "";
   let query = useQuery();
   teacherArticleID ? (articleID = teacherArticleID) : (articleID = query.get("id"));
@@ -450,7 +453,7 @@ export default function ArticleReader({ teacherArticleID }) {
 
           <ArticleAuthors articleInfo={articleInfo} />
           <s.ArticleInfoContainer>
-            <ArticleStatInfo articleInfo={articleInfo}></ArticleStatInfo>
+            <ArticleStatInfo articleInfo={articleInfo} shareContext={shareContext}></ArticleStatInfo>
           </s.ArticleInfoContainer>
 
           {articleInfo.img_url && (

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -61,6 +61,16 @@ export default function ArticleReader({ teacherArticleID }) {
   let last_reading_percentage = query.get("percentage");
   last_reading_percentage = last_reading_percentage === "undefined" ? null : Number(last_reading_percentage);
 
+  // Opened from a share-email deep-link (…?id=X&shared=<id>): mark that share
+  // read so the inbox row + badge stay in sync — the in-app row does this on
+  // click, and the email link must too, or the "first unread" email debounce
+  // never resets and later shares stop notifying.
+  const sharedArticleIdFromEmail = query.get("shared");
+  useEffect(() => {
+    if (sharedArticleIdFromEmail) api.markSharedArticleRead(sharedArticleIdFromEmail);
+    // eslint-disable-next-line
+  }, [sharedArticleIdFromEmail]);
+
   const [articleInfo, setArticleInfo] = useState();
 
   // Simplified articles live in the user's saves — back-gesture them to


### PR DESCRIPTION
## What

Recipient-facing polish for the friend-share multiplexer. Pairs with **zeeguu/api#690** — deploy api first.

- The "Shared with you" inbox row opens the recipient's **personalized derivative** (the API now returns it as the row's article, titled in the recipient's language) and carries share context — the sharer's name and whether it was translated — into the reader.
- New reader header state in `ArticleStatInfo`:

  > **Simplified by Mircea to your level** · See original at illvid.dk ↗

  The verb flexes to **"Translated & simplified"** for cross-language shares, and there's deliberately no CEFR letter ("to your level" — see the unreliable-classifier suppression). It sits alongside the existing header family (Plain → `Source:`, own-simplified → `Simplified to A1 · Original:`).

## Behavior / degradation

- Share context is passed via router state, so a hard refresh (or any non-share open) falls back to the normal simplified header — no data lost.
- No change to any other reader entry point.

## Depends on

zeeguu/api#690 (the inbox payload fields + the derivative). Deploy api before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
