### PR TITLE
Shared inbox: top spacing above the first row

### DIFF
--- a/src/articles/SharedArticleRow.sc.js
+++ b/src/articles/SharedArticleRow.sc.js
@@ -2,6 +2,11 @@ import styled from "styled-components";
 import { orange500 } from "../components/colors";
 import { Row as SavedRow, Title as SavedTitle } from "./SavedArticleRow.sc";
 
+// Top breathing room so the first shared row isn't jammed right under the tab bar.
+export const InboxList = styled.div`
+  padding-top: 1rem;
+`;
+
 // Unread is signalled by the bold title + trailing dot alone — read rows stay
 // at full strength (no dimming), so the list doesn't look half-disabled.
 export const Row = styled(SavedRow)`

--- a/src/articles/SharedInbox.js
+++ b/src/articles/SharedInbox.js
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 import { SharedArticlesContext } from "../contexts/SharedArticlesContext";
 import SharedArticleRow from "./SharedArticleRow";
+import { InboxList } from "./SharedArticleRow.sc";
 import * as s from "../components/TopMessage.sc";
 
 // "Shared with you" inbox — articles friends have sent, rendered with the
@@ -24,10 +25,10 @@ export default function SharedInbox() {
   }
 
   return (
-    <>
+    <InboxList>
       {sharedArticles.map((share) => (
         <SharedArticleRow key={share.id} share={share} />
       ))}
-    </>
+    </InboxList>
   );
 }


### PR DESCRIPTION
One commit off latest master: a little top padding so the first shared-article row isn't jammed under the tab bar. (Replaces #1204, which re-carried the already-squash-merged #1203 commits.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)